### PR TITLE
fix: remove stray JS comment rendered as visible text in BuildsPage

### DIFF
--- a/src/pages/BuildsPage.tsx
+++ b/src/pages/BuildsPage.tsx
@@ -42,7 +42,6 @@ export function BuildsPage() {
           <span>Action</span>
         </div>
 
-        // 데이터가 없을 때는 연결 포인트를 설명하는 빈 상태 메시지를 보여준다.
         {runs.length === 0 ? (
           <div className="px-6 py-14 text-center">
             <p className="text-lg font-medium tracking-tight">No build runs yet</p>


### PR DESCRIPTION
## Summary

BuildsPage.tsx의 JSX 내부에 `//` 자바스크립트 주석이 있어 화면에 텍스트로 렌더링되는 버그를 수정했습니다.

## Changes
- `src/pages/BuildsPage.tsx`: JSX 영역 내 잘못된 `//` 주석 제거