### PR TITLE
feat: 공통 디자인 시스템 컴포넌트 (shared/ui) — UI/UX §7

### DIFF
--- a/__tests__/ui/components.test.tsx
+++ b/__tests__/ui/components.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import {
+  Button,
+  EmptyState,
+  FormField,
+  Stepper,
+  StatusBadge,
+  TextInput,
+} from "@/shared/ui";
+
+describe("Button", () => {
+  it("defaults to type=button and applies variant", () => {
+    render(<Button variant="danger">삭제</Button>);
+    const btn = screen.getByRole("button", { name: "삭제" });
+    expect(btn).toHaveAttribute("type", "button");
+    expect(btn).toHaveClass("bg-red-600");
+  });
+
+  it("is disabled and busy while loading", () => {
+    render(<Button loading>저장</Button>);
+    const btn = screen.getByRole("button", { name: "저장" });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute("aria-busy", "true");
+  });
+});
+
+describe("StatusBadge", () => {
+  it("renders the Korean label for a status", () => {
+    render(<StatusBadge status="succeeded" />);
+    expect(screen.getByText("성공")).toBeInTheDocument();
+  });
+
+  it("maps running to its live label", () => {
+    render(<StatusBadge status="running" />);
+    expect(screen.getByText("실행 중")).toBeInTheDocument();
+  });
+});
+
+describe("Stepper", () => {
+  const steps = [
+    { id: "a", label: "템플릿" },
+    { id: "b", label: "소스" },
+    { id: "c", label: "검증" },
+  ];
+
+  it("marks the current step with aria-current=step", () => {
+    render(<Stepper steps={steps} current={1} />);
+    const current = screen.getByText("소스").closest("li");
+    expect(current).toHaveAttribute("aria-current", "step");
+  });
+
+  it("does not mark non-current steps", () => {
+    render(<Stepper steps={steps} current={1} />);
+    expect(screen.getByText("템플릿").closest("li")).not.toHaveAttribute("aria-current");
+  });
+});
+
+describe("FormField", () => {
+  it("wires label, help and error via aria-describedby and role=alert", () => {
+    render(
+      <FormField
+        id="datasetId"
+        label="데이터셋 ID"
+        help="예: kma-daily-observations"
+        error="데이터셋 ID를 입력해주세요."
+      >
+        {(field) => <TextInput {...field} />}
+      </FormField>,
+    );
+
+    const input = screen.getByLabelText("데이터셋 ID");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-describedby", "datasetId-help datasetId-error");
+    expect(screen.getByRole("alert")).toHaveTextContent("데이터셋 ID를 입력해주세요.");
+  });
+
+  it("omits error id from aria-describedby when valid", () => {
+    render(
+      <FormField id="title" label="제목" help="빌드 제목">
+        {(field) => <TextInput {...field} />}
+      </FormField>,
+    );
+    const input = screen.getByLabelText("제목");
+    expect(input).toHaveAttribute("aria-describedby", "title-help");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});
+
+describe("EmptyState", () => {
+  it("renders a CTA link to the action href", () => {
+    render(
+      <MemoryRouter>
+        <EmptyState
+          title="아직 빌드가 없습니다"
+          description="첫 빌드를 만들어보세요."
+          actionLabel="새 빌드 만들기"
+          actionHref="/builds/new"
+        />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole("link", { name: "새 빌드 만들기" });
+    expect(link).toHaveAttribute("href", "/builds/new");
+  });
+});

--- a/__tests__/ui/components.test.tsx
+++ b/__tests__/ui/components.test.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   EmptyState,
   FormField,
+  LinkButton,
   Stepper,
   StatusBadge,
   TextInput,
@@ -89,7 +90,7 @@ describe("FormField", () => {
 });
 
 describe("EmptyState", () => {
-  it("renders a CTA link to the action href", () => {
+  it("renders a single anchor CTA (no nested button) to the action href", () => {
     render(
       <MemoryRouter>
         <EmptyState
@@ -102,5 +103,26 @@ describe("EmptyState", () => {
     );
     const link = screen.getByRole("link", { name: "새 빌드 만들기" });
     expect(link).toHaveAttribute("href", "/builds/new");
+    // 링크가 버튼으로 감싸지지 않는다(상호작용 요소 중첩 회피).
+    expect(link.closest("button")).toBeNull();
+  });
+
+  it("renders no CTA when there is no action", () => {
+    render(<EmptyState title="결과가 없습니다" />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});
+
+describe("LinkButton", () => {
+  it("renders an anchor styled as a button", () => {
+    render(
+      <MemoryRouter>
+        <LinkButton to="/builds">목록</LinkButton>
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole("link", { name: "목록" });
+    expect(link).toHaveAttribute("href", "/builds");
+    expect(link).toHaveClass("rounded-full");
   });
 });

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -1,0 +1,86 @@
+/**
+ * 공통 Button 컴포넌트.
+ *
+ * 페이지마다 반복되던 Tailwind 버튼 스타일을 variant/size/loading 상태로 통일한다.
+ * 접근성을 위해 focus-visible 링과 disabled/loading 시 상호작용 차단을 기본 제공한다.
+ */
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { cn } from "./cn";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger" | "success";
+export type ButtonSize = "sm" | "md" | "lg";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** 시각적 강조 수준을 결정하는 변형 */
+  variant?: ButtonVariant;
+  /** 버튼 크기 */
+  size?: ButtonSize;
+  /** 로딩 상태. true이면 스피너를 표시하고 클릭을 막는다. */
+  loading?: boolean;
+  /** 라벨 앞에 표시할 아이콘 등 */
+  leadingIcon?: ReactNode;
+}
+
+const VARIANT_CLASS: Record<ButtonVariant, string> = {
+  primary:
+    "bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200",
+  secondary:
+    "border border-zinc-300 text-zinc-700 hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900",
+  ghost:
+    "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900",
+  danger: "bg-red-600 text-white hover:bg-red-500",
+  success: "bg-emerald-600 text-white hover:bg-emerald-500",
+};
+
+const SIZE_CLASS: Record<ButtonSize, string> = {
+  sm: "px-3 py-1.5 text-xs",
+  md: "px-4 py-2 text-sm",
+  lg: "px-5 py-2.5 text-base",
+};
+
+/**
+ * 일관된 스타일과 상태를 가진 버튼을 렌더링한다.
+ *
+ * @param props - 표준 button 속성에 variant/size/loading/leadingIcon을 더한 값.
+ * @returns 버튼 엘리먼트.
+ */
+export function Button({
+  variant = "primary",
+  size = "md",
+  loading = false,
+  leadingIcon,
+  disabled,
+  className,
+  children,
+  type = "button",
+  ...rest
+}: ButtonProps) {
+  const isDisabled = disabled || loading;
+
+  return (
+    <button
+      type={type}
+      disabled={isDisabled}
+      aria-busy={loading || undefined}
+      className={cn(
+        "inline-flex items-center justify-center gap-2 rounded-full font-medium transition",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-950",
+        "disabled:cursor-not-allowed disabled:opacity-60",
+        VARIANT_CLASS[variant],
+        SIZE_CLASS[size],
+        className,
+      )}
+      {...rest}
+    >
+      {loading ? (
+        <span
+          aria-hidden="true"
+          className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+        />
+      ) : (
+        leadingIcon
+      )}
+      {children}
+    </button>
+  );
+}

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -5,10 +5,9 @@
  * 접근성을 위해 focus-visible 링과 disabled/loading 시 상호작용 차단을 기본 제공한다.
  */
 import type { ButtonHTMLAttributes, ReactNode } from "react";
-import { cn } from "./cn";
+import { buttonClassName, type ButtonSize, type ButtonVariant } from "./buttonStyles";
 
-export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger" | "success";
-export type ButtonSize = "sm" | "md" | "lg";
+export type { ButtonSize, ButtonVariant };
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** 시각적 강조 수준을 결정하는 변형 */
@@ -20,23 +19,6 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** 라벨 앞에 표시할 아이콘 등 */
   leadingIcon?: ReactNode;
 }
-
-const VARIANT_CLASS: Record<ButtonVariant, string> = {
-  primary:
-    "bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200",
-  secondary:
-    "border border-zinc-300 text-zinc-700 hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900",
-  ghost:
-    "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900",
-  danger: "bg-red-600 text-white hover:bg-red-500",
-  success: "bg-emerald-600 text-white hover:bg-emerald-500",
-};
-
-const SIZE_CLASS: Record<ButtonSize, string> = {
-  sm: "px-3 py-1.5 text-xs",
-  md: "px-4 py-2 text-sm",
-  lg: "px-5 py-2.5 text-base",
-};
 
 /**
  * 일관된 스타일과 상태를 가진 버튼을 렌더링한다.
@@ -62,12 +44,10 @@ export function Button({
       type={type}
       disabled={isDisabled}
       aria-busy={loading || undefined}
-      className={cn(
-        "inline-flex items-center justify-center gap-2 rounded-full font-medium transition",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-950",
+      className={buttonClassName(
+        variant,
+        size,
         "disabled:cursor-not-allowed disabled:opacity-60",
-        VARIANT_CLASS[variant],
-        SIZE_CLASS[size],
         className,
       )}
       {...rest}

--- a/src/shared/ui/Card.tsx
+++ b/src/shared/ui/Card.tsx
@@ -1,0 +1,42 @@
+/**
+ * 공통 Card 컴포넌트.
+ *
+ * 페이지마다 반복되던 `rounded-[2rem] border ... bg-white/80 shadow-lg` 패턴을
+ * variant로 통일한다.
+ */
+import type { HTMLAttributes } from "react";
+import { cn } from "./cn";
+
+export type CardVariant = "default" | "elevated" | "dashed" | "error" | "success";
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  /** 카드의 시각적 변형 */
+  variant?: CardVariant;
+}
+
+const VARIANT_CLASS: Record<CardVariant, string> = {
+  default:
+    "border border-zinc-200/80 bg-white/80 shadow-lg shadow-zinc-950/5 dark:border-zinc-800 dark:bg-zinc-950/70",
+  elevated:
+    "border border-zinc-200/80 bg-white shadow-xl shadow-zinc-950/10 dark:border-zinc-800 dark:bg-zinc-950",
+  dashed:
+    "border-2 border-dashed border-zinc-300 bg-transparent dark:border-zinc-700",
+  error:
+    "border border-red-300 bg-red-50/80 dark:border-red-900/60 dark:bg-red-950/30",
+  success:
+    "border border-emerald-300 bg-emerald-50/80 dark:border-emerald-900/60 dark:bg-emerald-950/30",
+};
+
+/**
+ * 표준 패딩과 모서리를 가진 카드 컨테이너를 렌더링한다.
+ *
+ * @param props - 표준 div 속성에 variant를 더한 값.
+ * @returns 카드 엘리먼트.
+ */
+export function Card({ variant = "default", className, children, ...rest }: CardProps) {
+  return (
+    <div className={cn("rounded-[2rem] p-6", VARIANT_CLASS[variant], className)} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/shared/ui/EmptyState.tsx
+++ b/src/shared/ui/EmptyState.tsx
@@ -2,33 +2,35 @@
  * 공통 EmptyState 컴포넌트.
  *
  * "무엇이 없는지 + 다음 행동 제안 + CTA" 구조로 빈 상태를 일관되게 표현한다(제안 §11).
+ * CTA는 실제 동작(actionHref 또는 onAction)이 있을 때만 노출되며, 타입 차원에서도
+ * actionLabel은 둘 중 하나와 함께만 지정할 수 있도록 제한한다.
  */
 import type { ReactNode } from "react";
-import { Link } from "react-router-dom";
 import { Button } from "./Button";
+import { LinkButton } from "./LinkButton";
 import { cn } from "./cn";
 
-export interface EmptyStateProps {
+// actionLabel은 반드시 actionHref(라우팅) 또는 onAction(핸들러)과 함께만 허용한다.
+type EmptyStateAction =
+  | { actionLabel: string; actionHref: string; onAction?: never }
+  | { actionLabel: string; actionHref?: never; onAction: () => void }
+  | { actionLabel?: never; actionHref?: never; onAction?: never };
+
+export type EmptyStateProps = {
   /** 비어 있는 이유를 요약한 제목 */
   title: string;
   /** 사용자가 할 수 있는 다음 행동 설명 */
   description?: ReactNode;
-  /** CTA 버튼 라벨 */
-  actionLabel?: string;
-  /** CTA 이동 경로(내부 라우트). actionLabel과 함께 사용. */
-  actionHref?: string;
-  /** 경로 대신 클릭 핸들러로 동작시킬 때 사용 */
-  onAction?: () => void;
   /** 상단 아이콘/일러스트 */
   icon?: ReactNode;
   /** 추가 className */
   className?: string;
-}
+} & EmptyStateAction;
 
 /**
- * 데이터가 없을 때 안내 문구와 다음 행동 CTA를 보여준다.
+ * 데이터가 없을 때 안내 문구와 (선택적) 다음 행동 CTA를 보여준다.
  *
- * @param props - title/description/action 관련 속성.
+ * @param props - title/description/icon과 actionLabel+actionHref|onAction.
  * @returns 빈 상태 엘리먼트.
  */
 export function EmptyState({
@@ -40,6 +42,8 @@ export function EmptyState({
   icon,
   className,
 }: EmptyStateProps) {
+  const hasAction = Boolean(actionLabel) && (Boolean(actionHref) || Boolean(onAction));
+
   return (
     <div className={cn("flex flex-col items-center px-6 py-14 text-center", className)}>
       {icon ? <div className="mb-4 text-zinc-400 dark:text-zinc-500">{icon}</div> : null}
@@ -49,19 +53,12 @@ export function EmptyState({
           {description}
         </p>
       ) : null}
-      {actionLabel ? (
+      {hasAction ? (
         <div className="mt-6">
           {actionHref ? (
-            <Link
-              to={actionHref}
-              className={cn(
-                "inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-medium transition",
-                "bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-950",
-              )}
-            >
+            <LinkButton to={actionHref} size="lg">
               {actionLabel}
-            </Link>
+            </LinkButton>
           ) : (
             <Button onClick={onAction}>{actionLabel}</Button>
           )}

--- a/src/shared/ui/EmptyState.tsx
+++ b/src/shared/ui/EmptyState.tsx
@@ -1,0 +1,72 @@
+/**
+ * 공통 EmptyState 컴포넌트.
+ *
+ * "무엇이 없는지 + 다음 행동 제안 + CTA" 구조로 빈 상태를 일관되게 표현한다(제안 §11).
+ */
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { Button } from "./Button";
+import { cn } from "./cn";
+
+export interface EmptyStateProps {
+  /** 비어 있는 이유를 요약한 제목 */
+  title: string;
+  /** 사용자가 할 수 있는 다음 행동 설명 */
+  description?: ReactNode;
+  /** CTA 버튼 라벨 */
+  actionLabel?: string;
+  /** CTA 이동 경로(내부 라우트). actionLabel과 함께 사용. */
+  actionHref?: string;
+  /** 경로 대신 클릭 핸들러로 동작시킬 때 사용 */
+  onAction?: () => void;
+  /** 상단 아이콘/일러스트 */
+  icon?: ReactNode;
+  /** 추가 className */
+  className?: string;
+}
+
+/**
+ * 데이터가 없을 때 안내 문구와 다음 행동 CTA를 보여준다.
+ *
+ * @param props - title/description/action 관련 속성.
+ * @returns 빈 상태 엘리먼트.
+ */
+export function EmptyState({
+  title,
+  description,
+  actionLabel,
+  actionHref,
+  onAction,
+  icon,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div className={cn("flex flex-col items-center px-6 py-14 text-center", className)}>
+      {icon ? <div className="mb-4 text-zinc-400 dark:text-zinc-500">{icon}</div> : null}
+      <p className="text-lg font-medium tracking-tight">{title}</p>
+      {description ? (
+        <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-300">
+          {description}
+        </p>
+      ) : null}
+      {actionLabel ? (
+        <div className="mt-6">
+          {actionHref ? (
+            <Link
+              to={actionHref}
+              className={cn(
+                "inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-medium transition",
+                "bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-950",
+              )}
+            >
+              {actionLabel}
+            </Link>
+          ) : (
+            <Button onClick={onAction}>{actionLabel}</Button>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/shared/ui/ErrorMessage.tsx
+++ b/src/shared/ui/ErrorMessage.tsx
@@ -4,13 +4,14 @@
  * 폼 필드 오류나 요약 오류를 role="alert"로 노출해 보조기기가 즉시 안내하도록 한다
  * (접근성, 제안 §12).
  */
+import type { ReactNode } from "react";
 import { cn } from "./cn";
 
 export interface ErrorMessageProps {
   /** aria-describedby로 연결하기 위한 id */
   id?: string;
   /** 오류 메시지 본문 */
-  children?: React.ReactNode;
+  children?: ReactNode;
   /** 추가 className */
   className?: string;
 }

--- a/src/shared/ui/ErrorMessage.tsx
+++ b/src/shared/ui/ErrorMessage.tsx
@@ -1,0 +1,35 @@
+/**
+ * 공통 ErrorMessage 컴포넌트.
+ *
+ * 폼 필드 오류나 요약 오류를 role="alert"로 노출해 보조기기가 즉시 안내하도록 한다
+ * (접근성, 제안 §12).
+ */
+import { cn } from "./cn";
+
+export interface ErrorMessageProps {
+  /** aria-describedby로 연결하기 위한 id */
+  id?: string;
+  /** 오류 메시지 본문 */
+  children?: React.ReactNode;
+  /** 추가 className */
+  className?: string;
+}
+
+/**
+ * 오류 메시지를 role="alert"로 렌더링한다. children이 없으면 아무것도 렌더링하지 않는다.
+ *
+ * @param props - id/children/className.
+ * @returns 오류 메시지 엘리먼트 또는 null.
+ */
+export function ErrorMessage({ id, children, className }: ErrorMessageProps) {
+  if (!children) return null;
+  return (
+    <p
+      id={id}
+      role="alert"
+      className={cn("text-sm text-red-600 dark:text-red-400", className)}
+    >
+      {children}
+    </p>
+  );
+}

--- a/src/shared/ui/FormField.tsx
+++ b/src/shared/ui/FormField.tsx
@@ -63,7 +63,15 @@ export function FormField({
     <div className={cn("flex flex-col gap-1.5", className)}>
       <label htmlFor={id} className="text-sm font-medium text-zinc-800 dark:text-zinc-100">
         {label}
-        {required ? <span className="ml-0.5 text-red-600">*</span> : null}
+        {required ? (
+          <>
+            {/* 시각적 별표는 보조기기에서 숨기고, 스크린리더에는 '(필수)'를 읽어준다. */}
+            <span aria-hidden="true" className="ml-0.5 text-red-600">
+              *
+            </span>
+            <span className="sr-only">(필수)</span>
+          </>
+        ) : null}
       </label>
       {children({ id, "aria-describedby": describedBy, invalid: Boolean(error) })}
       {help ? (

--- a/src/shared/ui/FormField.tsx
+++ b/src/shared/ui/FormField.tsx
@@ -1,0 +1,77 @@
+/**
+ * 공통 FormField 컴포넌트.
+ *
+ * label + help 텍스트 + error 메시지를 일관되게 배치하고, 접근성을 위해 control에
+ * 연결할 id와 aria-describedby를 계산해 render-prop으로 넘긴다(제안 §8/§12.3).
+ *
+ * 사용 예:
+ *   <FormField id="datasetId" label="데이터셋 ID" help="예: kma-daily-observations"
+ *              error={errors.datasetId?.message}>
+ *     {(field) => <TextInput {...register("datasetId")} {...field} />}
+ *   </FormField>
+ */
+import type { ReactNode } from "react";
+import { cn } from "./cn";
+import { ErrorMessage } from "./ErrorMessage";
+
+export interface FormFieldRenderProps {
+  /** control의 id (label htmlFor와 연결됨) */
+  id: string;
+  /** help/error id를 합친 aria-describedby 값(없으면 undefined) */
+  "aria-describedby": string | undefined;
+  /** 오류 여부 */
+  invalid: boolean;
+}
+
+export interface FormFieldProps {
+  /** control과 label을 연결할 기본 id */
+  id: string;
+  /** 필드 라벨(한국어) */
+  label: string;
+  /** 입력 형식 등 보조 설명 */
+  help?: ReactNode;
+  /** 검증 오류 메시지 */
+  error?: ReactNode;
+  /** 필수 표시(*) 여부 */
+  required?: boolean;
+  /** 계산된 접근성 속성을 받아 control을 렌더링하는 함수 */
+  children: (field: FormFieldRenderProps) => ReactNode;
+  /** 추가 className */
+  className?: string;
+}
+
+/**
+ * 라벨/도움말/오류와 접근성 속성이 연결된 폼 필드 래퍼를 렌더링한다.
+ *
+ * @param props - id/label/help/error/required/children.
+ * @returns 폼 필드 엘리먼트.
+ */
+export function FormField({
+  id,
+  label,
+  help,
+  error,
+  required,
+  children,
+  className,
+}: FormFieldProps) {
+  const helpId = help ? `${id}-help` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+  const describedBy = [helpId, errorId].filter(Boolean).join(" ") || undefined;
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <label htmlFor={id} className="text-sm font-medium text-zinc-800 dark:text-zinc-100">
+        {label}
+        {required ? <span className="ml-0.5 text-red-600">*</span> : null}
+      </label>
+      {children({ id, "aria-describedby": describedBy, invalid: Boolean(error) })}
+      {help ? (
+        <p id={helpId} className="text-xs text-zinc-500 dark:text-zinc-400">
+          {help}
+        </p>
+      ) : null}
+      <ErrorMessage id={errorId}>{error}</ErrorMessage>
+    </div>
+  );
+}

--- a/src/shared/ui/LinkButton.tsx
+++ b/src/shared/ui/LinkButton.tsx
@@ -1,0 +1,26 @@
+/**
+ * 공통 LinkButton 컴포넌트.
+ *
+ * React Router `Link`를 버튼 스타일로 렌더링한다. `<Button>` 안에 `<Link>`를 중첩하면
+ * 상호작용 요소(button>a)가 중첩되어 HTML 유효성·접근성·키보드 동작에 문제가 생기므로,
+ * 라우팅이 필요한 "버튼처럼 보이는" 요소는 이 단일 anchor 컴포넌트를 사용한다.
+ */
+import { Link, type LinkProps } from "react-router-dom";
+import { buttonClassName, type ButtonSize, type ButtonVariant } from "./buttonStyles";
+
+export interface LinkButtonProps extends LinkProps {
+  /** 시각적 강조 수준을 결정하는 변형 */
+  variant?: ButtonVariant;
+  /** 버튼 크기 */
+  size?: ButtonSize;
+}
+
+/**
+ * 버튼 스타일을 입힌 라우터 링크를 렌더링한다(상호작용 요소 중첩 없이).
+ *
+ * @param props - Link 속성에 variant/size를 더한 값.
+ * @returns 버튼처럼 보이는 anchor(Link) 엘리먼트.
+ */
+export function LinkButton({ variant = "primary", size = "md", className, ...rest }: LinkButtonProps) {
+  return <Link className={buttonClassName(variant, size, className)} {...rest} />;
+}

--- a/src/shared/ui/PageHeader.tsx
+++ b/src/shared/ui/PageHeader.tsx
@@ -1,0 +1,56 @@
+/**
+ * 공통 PageHeader 컴포넌트.
+ *
+ * 각 페이지 상단에서 반복되던 "eyebrow 라벨 + 제목 + 설명 + 우측 액션" 패턴을 통일한다.
+ */
+import type { ReactNode } from "react";
+import { cn } from "./cn";
+
+export interface PageHeaderProps {
+  /** 제목 위에 표시할 작은 대문자 라벨(예: "Runs") */
+  eyebrow?: string;
+  /** 페이지 제목 */
+  title: string;
+  /** 제목 아래 보조 설명 */
+  description?: ReactNode;
+  /** 우측 정렬 액션 영역(버튼 등) */
+  actions?: ReactNode;
+  /** 추가 className */
+  className?: string;
+}
+
+/**
+ * 페이지 머리말(라벨/제목/설명/액션)을 일관된 레이아웃으로 렌더링한다.
+ *
+ * @param props - eyebrow/title/description/actions.
+ * @returns 페이지 헤더 엘리먼트.
+ */
+export function PageHeader({
+  eyebrow,
+  title,
+  description,
+  actions,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 md:flex-row md:items-end md:justify-between",
+        className,
+      )}
+    >
+      <div>
+        {eyebrow ? (
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+            {eyebrow}
+          </p>
+        ) : null}
+        <h2 className="mt-2 text-3xl font-semibold tracking-tight">{title}</h2>
+        {description ? (
+          <p className="mt-2 max-w-2xl text-zinc-600 dark:text-zinc-300">{description}</p>
+        ) : null}
+      </div>
+      {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+    </div>
+  );
+}

--- a/src/shared/ui/Select.tsx
+++ b/src/shared/ui/Select.tsx
@@ -1,0 +1,40 @@
+/**
+ * 공통 Select 컴포넌트.
+ *
+ * Provider/Dataset/데이터 단위 등 선택 입력을 통일한다. react-hook-form ref 주입을
+ * 위해 forwardRef로 구현한다. 옵션은 children(<option>)으로 전달한다.
+ */
+import { forwardRef, type SelectHTMLAttributes } from "react";
+import { cn } from "./cn";
+
+export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  /** 검증 오류 상태. true이면 빨간 테두리와 aria-invalid를 적용한다. */
+  invalid?: boolean;
+}
+
+/**
+ * 스타일과 오류 상태를 갖춘 select 컨트롤.
+ */
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
+  { invalid, className, children, ...rest },
+  ref,
+) {
+  return (
+    <select
+      ref={ref}
+      aria-invalid={invalid || undefined}
+      className={cn(
+        "w-full rounded-xl border bg-white px-3 py-2 text-sm text-zinc-900 transition",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0",
+        "dark:bg-zinc-950 dark:text-zinc-100",
+        invalid
+          ? "border-red-400 focus-visible:ring-red-500 dark:border-red-700"
+          : "border-zinc-300 focus-visible:ring-zinc-500 dark:border-zinc-700",
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </select>
+  );
+});

--- a/src/shared/ui/StatusBadge.tsx
+++ b/src/shared/ui/StatusBadge.tsx
@@ -1,0 +1,77 @@
+/**
+ * 공통 StatusBadge 컴포넌트.
+ *
+ * draft/run/publish 흐름의 모든 상태값을 한국어 라벨 + 일관된 색상으로 표시한다.
+ * 색상만으로 의미를 전달하지 않도록 항상 텍스트 라벨을 함께 노출한다(접근성).
+ */
+import { cn } from "./cn";
+
+/** Studio 전반에서 배지로 표시 가능한 모든 상태값의 합집합 */
+export type StatusValue =
+  | "new"
+  | "draft"
+  | "dirty"
+  | "validated"
+  | "invalid"
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "publishing"
+  | "published";
+
+interface StatusMeta {
+  /** 화면에 노출할 한국어 라벨 */
+  label: string;
+  /** Tailwind 색상 클래스 */
+  className: string;
+}
+
+const STATUS_META: Record<StatusValue, StatusMeta> = {
+  new: { label: "새 초안", className: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200" },
+  draft: { label: "초안", className: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200" },
+  dirty: { label: "수정됨", className: "bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300" },
+  validated: { label: "검증됨", className: "bg-blue-100 text-blue-800 dark:bg-blue-950/50 dark:text-blue-300" },
+  invalid: { label: "오류 있음", className: "bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300" },
+  queued: { label: "대기 중", className: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200" },
+  running: { label: "실행 중", className: "bg-blue-100 text-blue-800 dark:bg-blue-950/50 dark:text-blue-300" },
+  succeeded: { label: "성공", className: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300" },
+  failed: { label: "실패", className: "bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300" },
+  cancelled: { label: "취소됨", className: "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400" },
+  publishing: { label: "게시 중", className: "bg-blue-100 text-blue-800 dark:bg-blue-950/50 dark:text-blue-300" },
+  published: { label: "게시됨", className: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300" },
+};
+
+export interface StatusBadgeProps {
+  /** 표시할 상태값 */
+  status: StatusValue;
+  /** 추가 className */
+  className?: string;
+}
+
+/**
+ * 상태값에 대응하는 한국어 라벨과 색상을 가진 배지를 렌더링한다.
+ *
+ * @param props - status와 추가 className.
+ * @returns 상태 배지 엘리먼트.
+ */
+export function StatusBadge({ status, className }: StatusBadgeProps) {
+  const meta = STATUS_META[status];
+  const isLive = status === "running" || status === "publishing";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium",
+        meta.className,
+        className,
+      )}
+    >
+      {isLive ? (
+        <span aria-hidden="true" className="h-1.5 w-1.5 animate-pulse rounded-full bg-current" />
+      ) : null}
+      {meta.label}
+    </span>
+  );
+}

--- a/src/shared/ui/Stepper.tsx
+++ b/src/shared/ui/Stepper.tsx
@@ -1,0 +1,116 @@
+/**
+ * 공통 Stepper 컴포넌트.
+ *
+ * New Build Wizard처럼 다단계 흐름의 진행 상태를 표시한다. 각 단계는
+ * upcoming/current/complete/error 상태를 가지며, 현재 단계에 aria-current="step"을
+ * 부여해 보조기기에서 위치를 알 수 있게 한다(접근성, 제안 §12).
+ */
+import { cn } from "./cn";
+
+export type StepState = "upcoming" | "current" | "complete" | "error";
+
+export interface StepItem {
+  /** 단계 식별자 */
+  id: string;
+  /** 단계 라벨(한국어) */
+  label: string;
+}
+
+export interface StepperProps {
+  /** 표시할 단계 목록(순서대로) */
+  steps: StepItem[];
+  /** 현재 활성 단계의 0-기반 인덱스 */
+  current: number;
+  /** 오류가 발생한 단계 인덱스 집합(선택) */
+  errorSteps?: number[];
+  /** 단계 클릭으로 이동 허용 시 핸들러(완료된 단계만 이동 가능) */
+  onStepClick?: (index: number) => void;
+  /** 추가 className */
+  className?: string;
+}
+
+function resolveState(index: number, current: number, errorSteps: number[]): StepState {
+  if (errorSteps.includes(index)) return "error";
+  if (index < current) return "complete";
+  if (index === current) return "current";
+  return "upcoming";
+}
+
+const STATE_CIRCLE: Record<StepState, string> = {
+  upcoming: "border-zinc-300 text-zinc-400 dark:border-zinc-700 dark:text-zinc-500",
+  current: "border-zinc-900 bg-zinc-900 text-white dark:border-white dark:bg-white dark:text-zinc-900",
+  complete: "border-emerald-600 bg-emerald-600 text-white",
+  error: "border-red-600 bg-red-600 text-white",
+};
+
+/**
+ * 다단계 흐름의 진행 상태를 가로 스텝 표시기로 렌더링한다.
+ *
+ * @param props - steps/current/errorSteps/onStepClick.
+ * @returns 스텝퍼 엘리먼트.
+ */
+export function Stepper({
+  steps,
+  current,
+  errorSteps = [],
+  onStepClick,
+  className,
+}: StepperProps) {
+  return (
+    <ol className={cn("flex w-full items-center gap-2 overflow-x-auto", className)}>
+      {steps.map((step, index) => {
+        const state = resolveState(index, current, errorSteps);
+        const clickable = Boolean(onStepClick) && index < current;
+        const circle = (
+          <span
+            className={cn(
+              "flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-xs font-semibold",
+              STATE_CIRCLE[state],
+            )}
+            aria-hidden="true"
+          >
+            {state === "complete" ? "✓" : state === "error" ? "!" : index + 1}
+          </span>
+        );
+
+        return (
+          <li
+            key={step.id}
+            aria-current={state === "current" ? "step" : undefined}
+            className="flex min-w-fit items-center gap-2"
+          >
+            {clickable ? (
+              <button
+                type="button"
+                onClick={() => onStepClick?.(index)}
+                className="flex items-center gap-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500"
+              >
+                {circle}
+                <span className="whitespace-nowrap text-sm font-medium text-zinc-700 dark:text-zinc-200">
+                  {step.label}
+                </span>
+              </button>
+            ) : (
+              <div className="flex items-center gap-2">
+                {circle}
+                <span
+                  className={cn(
+                    "whitespace-nowrap text-sm font-medium",
+                    state === "upcoming"
+                      ? "text-zinc-400 dark:text-zinc-500"
+                      : "text-zinc-700 dark:text-zinc-200",
+                  )}
+                >
+                  {step.label}
+                </span>
+              </div>
+            )}
+            {index < steps.length - 1 ? (
+              <span aria-hidden="true" className="h-px w-6 bg-zinc-300 dark:bg-zinc-700" />
+            ) : null}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/src/shared/ui/TextInput.tsx
+++ b/src/shared/ui/TextInput.tsx
@@ -1,0 +1,38 @@
+/**
+ * 공통 TextInput 컴포넌트.
+ *
+ * react-hook-form의 register가 ref를 주입할 수 있도록 forwardRef로 구현한다.
+ * 오류 상태(invalid)에 따라 테두리 색과 focus 링을 바꾼다.
+ */
+import { forwardRef, type InputHTMLAttributes } from "react";
+import { cn } from "./cn";
+
+export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  /** 검증 오류 상태. true이면 빨간 테두리와 aria-invalid를 적용한다. */
+  invalid?: boolean;
+}
+
+/**
+ * 스타일과 오류 상태를 갖춘 텍스트 입력 컨트롤.
+ */
+export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(function TextInput(
+  { invalid, className, ...rest },
+  ref,
+) {
+  return (
+    <input
+      ref={ref}
+      aria-invalid={invalid || undefined}
+      className={cn(
+        "w-full rounded-xl border bg-white px-3 py-2 text-sm text-zinc-900 transition placeholder:text-zinc-400",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0",
+        "dark:bg-zinc-950 dark:text-zinc-100",
+        invalid
+          ? "border-red-400 focus-visible:ring-red-500 dark:border-red-700"
+          : "border-zinc-300 focus-visible:ring-zinc-500 dark:border-zinc-700",
+        className,
+      )}
+      {...rest}
+    />
+  );
+});

--- a/src/shared/ui/Textarea.tsx
+++ b/src/shared/ui/Textarea.tsx
@@ -1,0 +1,38 @@
+/**
+ * 공통 Textarea 컴포넌트.
+ *
+ * TextInput과 동일한 스타일 체계를 따르며 react-hook-form ref 주입을 위해 forwardRef로 구현한다.
+ */
+import { forwardRef, type TextareaHTMLAttributes } from "react";
+import { cn } from "./cn";
+
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  /** 검증 오류 상태. true이면 빨간 테두리와 aria-invalid를 적용한다. */
+  invalid?: boolean;
+}
+
+/**
+ * 스타일과 오류 상태를 갖춘 멀티라인 입력 컨트롤.
+ */
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { invalid, className, rows = 4, ...rest },
+  ref,
+) {
+  return (
+    <textarea
+      ref={ref}
+      rows={rows}
+      aria-invalid={invalid || undefined}
+      className={cn(
+        "w-full rounded-xl border bg-white px-3 py-2 font-mono text-sm text-zinc-900 transition placeholder:text-zinc-400",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0",
+        "dark:bg-zinc-950 dark:text-zinc-100",
+        invalid
+          ? "border-red-400 focus-visible:ring-red-500 dark:border-red-700"
+          : "border-zinc-300 focus-visible:ring-zinc-500 dark:border-zinc-700",
+        className,
+      )}
+      {...rest}
+    />
+  );
+});

--- a/src/shared/ui/buttonStyles.ts
+++ b/src/shared/ui/buttonStyles.ts
@@ -1,0 +1,49 @@
+/**
+ * Button과 LinkButton이 공유하는 시각 스타일 정의.
+ *
+ * 버튼과 "버튼처럼 보이는 링크"가 동일한 variant/size 룩을 갖도록 클래스 합성 로직을
+ * 한곳에 모은다. 이렇게 분리하면 `<button>` 안에 `<a>`를 중첩하지 않고도(상호작용 요소
+ * 중첩 회피) 링크를 버튼 스타일로 렌더링할 수 있다.
+ */
+import { cn, type ClassValue } from "./cn";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger" | "success";
+export type ButtonSize = "sm" | "md" | "lg";
+
+const VARIANT_CLASS: Record<ButtonVariant, string> = {
+  primary:
+    "bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200",
+  secondary:
+    "border border-zinc-300 text-zinc-700 hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900",
+  ghost: "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900",
+  danger: "bg-red-600 text-white hover:bg-red-500",
+  success: "bg-emerald-600 text-white hover:bg-emerald-500",
+};
+
+const SIZE_CLASS: Record<ButtonSize, string> = {
+  sm: "px-3 py-1.5 text-xs",
+  md: "px-4 py-2 text-sm",
+  lg: "px-5 py-2.5 text-base",
+};
+
+/**
+ * variant/size에 맞는 버튼 스타일 className을 만든다.
+ *
+ * @param variant - 강조 수준.
+ * @param size - 크기.
+ * @param extra - 추가로 합성할 클래스 값들.
+ * @returns 합쳐진 className 문자열.
+ */
+export function buttonClassName(
+  variant: ButtonVariant = "primary",
+  size: ButtonSize = "md",
+  ...extra: ClassValue[]
+): string {
+  return cn(
+    "inline-flex items-center justify-center gap-2 rounded-full font-medium transition",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-950",
+    VARIANT_CLASS[variant],
+    SIZE_CLASS[size],
+    ...extra,
+  );
+}

--- a/src/shared/ui/cn.ts
+++ b/src/shared/ui/cn.ts
@@ -1,0 +1,17 @@
+/**
+ * Tailwind 클래스 문자열을 조건부로 합성하는 경량 헬퍼.
+ *
+ * clsx 같은 외부 의존성 없이, falsy 값(`undefined`/`false`/`""`)을 걸러내고 공백으로
+ * 이어 붙인다. 공통 컴포넌트에서 variant별 클래스를 조립할 때 사용한다.
+ */
+export type ClassValue = string | false | null | undefined;
+
+/**
+ * 전달된 클래스 값들 중 truthy인 것만 공백으로 이어 붙여 반환한다.
+ *
+ * @param values - 합성할 클래스 값 목록(거짓값은 무시).
+ * @returns 합쳐진 className 문자열.
+ */
+export function cn(...values: ClassValue[]): string {
+  return values.filter(Boolean).join(" ");
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -4,6 +4,8 @@
  * 페이지/기능 모듈은 `@/shared/ui`에서 디자인 시스템 컴포넌트를 가져온다.
  */
 export { Button, type ButtonProps, type ButtonVariant, type ButtonSize } from "./Button";
+export { LinkButton, type LinkButtonProps } from "./LinkButton";
+export { buttonClassName } from "./buttonStyles";
 export { Card, type CardProps, type CardVariant } from "./Card";
 export { PageHeader, type PageHeaderProps } from "./PageHeader";
 export { EmptyState, type EmptyStateProps } from "./EmptyState";

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,0 +1,17 @@
+/**
+ * 공통 UI 컴포넌트 배럴(barrel) 모듈.
+ *
+ * 페이지/기능 모듈은 `@/shared/ui`에서 디자인 시스템 컴포넌트를 가져온다.
+ */
+export { Button, type ButtonProps, type ButtonVariant, type ButtonSize } from "./Button";
+export { Card, type CardProps, type CardVariant } from "./Card";
+export { PageHeader, type PageHeaderProps } from "./PageHeader";
+export { EmptyState, type EmptyStateProps } from "./EmptyState";
+export { StatusBadge, type StatusBadgeProps, type StatusValue } from "./StatusBadge";
+export { Stepper, type StepperProps, type StepItem, type StepState } from "./Stepper";
+export { FormField, type FormFieldProps, type FormFieldRenderProps } from "./FormField";
+export { TextInput, type TextInputProps } from "./TextInput";
+export { Textarea, type TextareaProps } from "./Textarea";
+export { Select, type SelectProps } from "./Select";
+export { ErrorMessage, type ErrorMessageProps } from "./ErrorMessage";
+export { cn, type ClassValue } from "./cn";


### PR DESCRIPTION
페이지마다 반복되던 인라인 Tailwind 패턴을 재사용 가능한 접근성 컴포넌트로 통일합니다 (UI/UX 개선안 §7).

## 포함
- Button(variant/size/loading, focus ring, type=button 기본), Card, PageHeader, EmptyState
- StatusBadge(draft/run/publish 전 상태, 한국어 라벨, 색상 단독 표현 금지)
- Stepper(upcoming/current/complete/error, `aria-current="step"`)
- FormField + TextInput/Textarea/Select + ErrorMessage (`aria-describedby`/`role="alert"` 연결, §8/§12)
- `cn()` 헬퍼 (신규 의존성 없음)

## 검증
tsc/eslint/vitest/build 통과, 테스트 추가.

## 스택 안내
이 PR이 기반이며, `route-restructure → new-build-wizard → page-polish` 순서로 쌓여 있습니다. 이 PR을 먼저 머지하면 후속 PR diff가 해당 레이어만 남습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)