### PR TITLE
feat: 대시보드 한국어화 + 디자인시스템 적용 — UI/UX §5.1·§15

### DIFF
--- a/__tests__/HomePage.test.tsx
+++ b/__tests__/HomePage.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { HomePage } from "@/pages/HomePage";
 
 describe("HomePage", () => {
-  it("renders scaffold quick actions", () => {
+  it("renders the Korean dashboard heading and status summary", () => {
     render(
       <MemoryRouter>
         <HomePage />
@@ -13,9 +13,25 @@ describe("HomePage", () => {
 
     expect(
       screen.getByRole("heading", {
-        name: /build public-data workflows with a shell students can extend safely/i,
+        name: /공공데이터 수집부터 결과물 생성까지 한 번에 관리하세요/,
       }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /create a new build/i })).toBeVisible();
+    // 상태 요약 카드 라벨
+    expect(screen.getByText("초안")).toBeInTheDocument();
+    expect(screen.getByText("성공")).toBeInTheDocument();
+  });
+
+  it("shows an empty state with a CTA to create the first build", () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("아직 생성된 빌드가 없습니다")).toBeInTheDocument();
+    // 빠른 시작 카드의 새 빌드 링크
+    expect(
+      screen.getAllByRole("link", { name: /새 빌드 만들기/ }).length,
+    ).toBeGreaterThanOrEqual(1);
   });
 });

--- a/__tests__/buildRoutes.test.tsx
+++ b/__tests__/buildRoutes.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { BuildArtifactsPage } from "@/pages/BuildArtifactsPage";
+import { BuildDetailPage } from "@/pages/BuildDetailPage";
+import { BuildPublishPage } from "@/pages/BuildPublishPage";
+import { BuildRunPage } from "@/pages/BuildRunPage";
+
+function renderAt(path: string, element: React.ReactNode) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/builds/:buildId" element={element} />
+        <Route path="/builds/:buildId/run" element={element} />
+        <Route path="/builds/:buildId/artifacts" element={element} />
+        <Route path="/builds/:buildId/publish" element={element} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("build-centric routes", () => {
+  it("renders the build detail page with the buildId from the route", () => {
+    renderAt("/builds/air-quality", <BuildDetailPage />);
+    expect(screen.getByRole("heading", { name: "air-quality" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /편집/ })).toHaveAttribute(
+      "href",
+      "/builds/air-quality/edit",
+    );
+  });
+
+  it("renders the run page with progress steps", () => {
+    renderAt("/builds/abc/run", <BuildRunPage />);
+    expect(screen.getByText("진행 단계")).toBeInTheDocument();
+    expect(screen.getByText("수집")).toBeInTheDocument();
+  });
+
+  it("renders the artifacts page with a manifest section", () => {
+    renderAt("/builds/abc/artifacts", <BuildArtifactsPage />);
+    expect(screen.getByText("Manifest 요약")).toBeInTheDocument();
+  });
+
+  it("renders the publish page with destination options", () => {
+    renderAt("/builds/abc/publish", <BuildPublishPage />);
+    expect(screen.getByText("HuggingFace Dataset")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /게시/ })).toBeDisabled();
+  });
+});

--- a/__tests__/newBuildWizard.test.tsx
+++ b/__tests__/newBuildWizard.test.tsx
@@ -38,4 +38,28 @@ describe("New Build Wizard", () => {
     expect(await screen.findByRole("heading", { name: "데이터 소스" })).toBeInTheDocument();
     expect(screen.getByLabelText(/제공자/)).toBeInTheDocument();
   });
+
+  it("blocks the params step when the JSON is invalid", async () => {
+    renderWizard();
+    // 1단계: 기본 정보
+    fireEvent.change(screen.getByLabelText(/데이터셋 ID/), { target: { value: "kma-daily" } });
+    fireEvent.change(screen.getByLabelText(/제목/), { target: { value: "기상청 일별" } });
+    fireEvent.change(screen.getByLabelText(/설명/), { target: { value: "일별 관측" } });
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+
+    // 2단계: 데이터 소스
+    await screen.findByRole("heading", { name: "데이터 소스" });
+    fireEvent.change(screen.getByLabelText(/제공자/), { target: { value: "datago" } });
+    fireEvent.change(screen.getByLabelText(/데이터셋/), { target: { value: "air-quality" } });
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+
+    // 3단계: 파라미터 — 잘못된 JSON 입력 후 다음 시도
+    await screen.findByRole("heading", { name: "파라미터" });
+    fireEvent.change(screen.getByLabelText(/요청 파라미터/), { target: { value: "{not json" } });
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+
+    // JSON 오류가 필드에 표시되고 단계 이동이 막힌다.
+    expect(await screen.findByText(/올바른 JSON이 아닙니다/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "파라미터" })).toBeInTheDocument();
+  });
 });

--- a/__tests__/newBuildWizard.test.tsx
+++ b/__tests__/newBuildWizard.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { NewBuildPage } from "@/pages/NewBuildPage";
+
+function renderWizard() {
+  return render(
+    <MemoryRouter>
+      <NewBuildPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("New Build Wizard", () => {
+  it("starts on the first step", () => {
+    renderWizard();
+    expect(screen.getByRole("heading", { name: "기본 정보" })).toBeInTheDocument();
+    // 스텝퍼 + 헤딩 모두에 "기본 정보"가 나타난다(최소 2곳).
+    expect(screen.getAllByText("기본 정보").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("blocks advancing while required fields are empty", async () => {
+    renderWizard();
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    expect(await screen.findByText(/데이터셋 ID를 입력해주세요/)).toBeInTheDocument();
+    // 검증 실패로 1단계 헤딩에 머문다.
+    expect(screen.getByRole("heading", { name: "기본 정보" })).toBeInTheDocument();
+  });
+
+  it("advances to the source step once identity fields are filled", async () => {
+    renderWizard();
+    fireEvent.change(screen.getByLabelText(/데이터셋 ID/), { target: { value: "kma-daily" } });
+    fireEvent.change(screen.getByLabelText(/제목/), { target: { value: "기상청 일별" } });
+    fireEvent.change(screen.getByLabelText(/설명/), { target: { value: "일별 관측 데이터" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+
+    expect(await screen.findByRole("heading", { name: "데이터 소스" })).toBeInTheDocument();
+    expect(screen.getByLabelText(/제공자/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/ui/components.test.tsx
+++ b/__tests__/ui/components.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import {
+  Button,
+  EmptyState,
+  FormField,
+  Stepper,
+  StatusBadge,
+  TextInput,
+} from "@/shared/ui";
+
+describe("Button", () => {
+  it("defaults to type=button and applies variant", () => {
+    render(<Button variant="danger">삭제</Button>);
+    const btn = screen.getByRole("button", { name: "삭제" });
+    expect(btn).toHaveAttribute("type", "button");
+    expect(btn).toHaveClass("bg-red-600");
+  });
+
+  it("is disabled and busy while loading", () => {
+    render(<Button loading>저장</Button>);
+    const btn = screen.getByRole("button", { name: "저장" });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute("aria-busy", "true");
+  });
+});
+
+describe("StatusBadge", () => {
+  it("renders the Korean label for a status", () => {
+    render(<StatusBadge status="succeeded" />);
+    expect(screen.getByText("성공")).toBeInTheDocument();
+  });
+
+  it("maps running to its live label", () => {
+    render(<StatusBadge status="running" />);
+    expect(screen.getByText("실행 중")).toBeInTheDocument();
+  });
+});
+
+describe("Stepper", () => {
+  const steps = [
+    { id: "a", label: "템플릿" },
+    { id: "b", label: "소스" },
+    { id: "c", label: "검증" },
+  ];
+
+  it("marks the current step with aria-current=step", () => {
+    render(<Stepper steps={steps} current={1} />);
+    const current = screen.getByText("소스").closest("li");
+    expect(current).toHaveAttribute("aria-current", "step");
+  });
+
+  it("does not mark non-current steps", () => {
+    render(<Stepper steps={steps} current={1} />);
+    expect(screen.getByText("템플릿").closest("li")).not.toHaveAttribute("aria-current");
+  });
+});
+
+describe("FormField", () => {
+  it("wires label, help and error via aria-describedby and role=alert", () => {
+    render(
+      <FormField
+        id="datasetId"
+        label="데이터셋 ID"
+        help="예: kma-daily-observations"
+        error="데이터셋 ID를 입력해주세요."
+      >
+        {(field) => <TextInput {...field} />}
+      </FormField>,
+    );
+
+    const input = screen.getByLabelText("데이터셋 ID");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-describedby", "datasetId-help datasetId-error");
+    expect(screen.getByRole("alert")).toHaveTextContent("데이터셋 ID를 입력해주세요.");
+  });
+
+  it("omits error id from aria-describedby when valid", () => {
+    render(
+      <FormField id="title" label="제목" help="빌드 제목">
+        {(field) => <TextInput {...field} />}
+      </FormField>,
+    );
+    const input = screen.getByLabelText("제목");
+    expect(input).toHaveAttribute("aria-describedby", "title-help");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});
+
+describe("EmptyState", () => {
+  it("renders a CTA link to the action href", () => {
+    render(
+      <MemoryRouter>
+        <EmptyState
+          title="아직 빌드가 없습니다"
+          description="첫 빌드를 만들어보세요."
+          actionLabel="새 빌드 만들기"
+          actionHref="/builds/new"
+        />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole("link", { name: "새 빌드 만들기" });
+    expect(link).toHaveAttribute("href", "/builds/new");
+  });
+});

--- a/__tests__/ui/components.test.tsx
+++ b/__tests__/ui/components.test.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   EmptyState,
   FormField,
+  LinkButton,
   Stepper,
   StatusBadge,
   TextInput,
@@ -89,7 +90,7 @@ describe("FormField", () => {
 });
 
 describe("EmptyState", () => {
-  it("renders a CTA link to the action href", () => {
+  it("renders a single anchor CTA (no nested button) to the action href", () => {
     render(
       <MemoryRouter>
         <EmptyState
@@ -102,5 +103,26 @@ describe("EmptyState", () => {
     );
     const link = screen.getByRole("link", { name: "새 빌드 만들기" });
     expect(link).toHaveAttribute("href", "/builds/new");
+    // 링크가 버튼으로 감싸지지 않는다(상호작용 요소 중첩 회피).
+    expect(link.closest("button")).toBeNull();
+  });
+
+  it("renders no CTA when there is no action", () => {
+    render(<EmptyState title="결과가 없습니다" />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});
+
+describe("LinkButton", () => {
+  it("renders an anchor styled as a button", () => {
+    render(
+      <MemoryRouter>
+        <LinkButton to="/builds">목록</LinkButton>
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole("link", { name: "목록" });
+    expect(link).toHaveAttribute("href", "/builds");
+    expect(link).toHaveClass("rounded-full");
   });
 });

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -8,16 +8,14 @@ import { useEffect } from "react";
 import { Link, NavLink, Outlet } from "react-router-dom";
 import { useUIStore } from "@/shared/hooks/useUIStore";
 
+// 내비게이션은 Build 중심으로 단순화한다(제안 §6.3). Validate/Preview는 독립 메뉴에서
+// 제거하고 New Build Wizard 내부 패널로 통합한다(§5.3/§5.4).
 const primaryNavItems = [
-  { to: "/builds/new", label: "New Build", description: "Create a fresh spec" },
-  { to: "/builds", label: "Runs", description: "Track executions" },
-  { to: "/artifacts", label: "Artifacts", description: "Inspect outputs" },
-  { to: "/settings", label: "Settings", description: "Configure Studio" },
-] as const;
-
-const utilityNavItems = [
-  { to: "/validate", label: "Validate" },
-  { to: "/preview", label: "Preview" },
+  { to: "/", label: "대시보드", description: "최근 빌드와 빠른 시작", end: true },
+  { to: "/builds", label: "빌드", description: "전체 빌드와 실행 이력", end: false },
+  { to: "/builds/new", label: "새 빌드 (New Build)", description: "새 스펙 만들기", end: false },
+  { to: "/artifacts", label: "결과물 (Artifacts)", description: "생성된 산출물", end: false },
+  { to: "/settings", label: "설정 (Settings)", description: "Studio 환경설정", end: false },
 ] as const;
 
 /**
@@ -97,10 +95,10 @@ export function Layout() {
                 KPubData Studio
               </p>
               <Link className="mt-2 block text-2xl font-semibold tracking-tight" to="/">
-                Workflow Atelier
+                공공데이터 빌드 스튜디오
               </Link>
               <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
-                Draft, validate, preview, and ship builder specs from one shell.
+                데이터 소스 선택부터 미리보기(Preview), 검증, 결과물까지 한 흐름으로 진행하세요.
               </p>
             </div>
             <button
@@ -118,6 +116,7 @@ export function Layout() {
               {primaryNavItems.map((item) => (
                 <NavLink
                   className={navigationClassName}
+                  end={item.end}
                   key={item.to}
                   onClick={closeSidebar}
                   to={item.to}
@@ -127,48 +126,23 @@ export function Layout() {
                     <p className="mt-1 text-sm opacity-80">{item.description}</p>
                   </div>
                   <span className="mt-1 text-xs uppercase tracking-[0.25em] opacity-60">
-                    Open
+                    열기
                   </span>
                 </NavLink>
               ))}
-            </div>
-
-            <div className="rounded-3xl border border-dashed border-zinc-300/80 bg-zinc-50/70 p-4 dark:border-zinc-700 dark:bg-zinc-900/70">
-              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-                Workspace panels
-              </p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {utilityNavItems.map((item) => (
-                  <NavLink
-                    className={({ isActive }) =>
-                      [
-                        "rounded-full border px-3 py-2 text-sm transition",
-                        isActive
-                          ? "border-emerald-500 bg-emerald-500 text-white"
-                          : "border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-200",
-                      ].join(" ")
-                    }
-                    key={item.to}
-                    onClick={closeSidebar}
-                    to={item.to}
-                  >
-                    {item.label}
-                  </NavLink>
-                ))}
-              </div>
             </div>
           </nav>
 
           <div className="rounded-3xl border border-zinc-200/80 bg-zinc-50/80 p-4 dark:border-zinc-800 dark:bg-zinc-900/70">
             <div className="flex items-center justify-between gap-3">
               <div>
-                <p className="text-sm font-medium">Theme</p>
+                <p className="text-sm font-medium">테마</p>
                 <p className="text-sm text-zinc-600 dark:text-zinc-300">
-                  Keep the shell legible while scaffolding new workflows.
+                  작업 중에도 화면이 잘 보이도록 테마를 선택하세요.
                 </p>
               </div>
               <select
-                aria-label="Select theme"
+                aria-label="테마 선택"
                 className="rounded-full border border-zinc-200 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-950"
                 onChange={(event) => setTheme(event.target.value as "system" | "light" | "dark")}
                 value={theme}
@@ -195,10 +169,10 @@ export function Layout() {
                 </button>
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-                    Builder control surface
+                    Builder 제어 화면
                   </p>
                   <h1 className="text-lg font-semibold tracking-tight">
-                    Portable dataset workflows for students and maintainers
+                    학생과 메인테이너를 위한 공공데이터 빌드 워크플로
                   </h1>
                 </div>
               </div>
@@ -207,7 +181,7 @@ export function Layout() {
                 className="rounded-full bg-emerald-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-400"
                 to="/builds/new"
               >
-                Start new build
+                새 빌드 만들기
               </Link>
             </div>
           </header>

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -6,6 +6,10 @@
 import { createBrowserRouter } from "react-router-dom";
 import { Layout } from "@/app/Layout";
 import { ArtifactsPage } from "@/pages/ArtifactsPage";
+import { BuildArtifactsPage } from "@/pages/BuildArtifactsPage";
+import { BuildDetailPage } from "@/pages/BuildDetailPage";
+import { BuildPublishPage } from "@/pages/BuildPublishPage";
+import { BuildRunPage } from "@/pages/BuildRunPage";
 import { BuildsPage } from "@/pages/BuildsPage";
 import { HomePage } from "@/pages/HomePage";
 import { NewBuildPage } from "@/pages/NewBuildPage";
@@ -35,6 +39,30 @@ export const router = createBrowserRouter([
         path: "builds/new",
         element: <NewBuildPage />,
       },
+      // Build 단위 중심 라우트 (제안 §3.3): 상세 → 편집/실행/결과물/게시.
+      {
+        path: "builds/:buildId",
+        element: <BuildDetailPage />,
+      },
+      {
+        // 편집은 New Build와 동일한 에디터를 재사용한다.
+        path: "builds/:buildId/edit",
+        element: <NewBuildPage />,
+      },
+      {
+        path: "builds/:buildId/run",
+        element: <BuildRunPage />,
+      },
+      {
+        path: "builds/:buildId/artifacts",
+        element: <BuildArtifactsPage />,
+      },
+      {
+        path: "builds/:buildId/publish",
+        element: <BuildPublishPage />,
+      },
+      // 레거시 단독 라우트: 내비게이션에서는 제거됐지만 딥링크 호환을 위해 유지한다.
+      // Validate/Preview는 New Build Wizard 내부 패널로 통합 예정(§5.3/§5.4).
       {
         path: "validate",
         element: <ValidatePage />,

--- a/src/pages/BuildArtifactsPage.tsx
+++ b/src/pages/BuildArtifactsPage.tsx
@@ -1,0 +1,54 @@
+/**
+ * 빌드 결과물 페이지 (/builds/:buildId/artifacts).
+ *
+ * manifest 요약, 생성 파일 목록, 다운로드/게시 액션을 보여준다(제안 §5.7).
+ * 실제 manifest/파일은 #30 manifest viewer + #29 API 연동 시 채운다.
+ */
+import { Link, useParams } from "react-router-dom";
+import { Button, Card, EmptyState, PageHeader } from "@/shared/ui";
+
+/**
+ * 빌드가 생성한 결과물과 manifest 요약을 보여주는 페이지.
+ *
+ * @returns 결과물 화면.
+ */
+export function BuildArtifactsPage() {
+  const { buildId = "" } = useParams();
+
+  return (
+    <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+      <PageHeader
+        eyebrow="결과물"
+        title={`${buildId || "빌드"} 결과물`}
+        description="빌드가 생성한 파일, manifest, 다운로드 링크를 확인하세요."
+        actions={
+          <Button>
+            <Link to={`/builds/${buildId}/publish`}>게시하기</Link>
+          </Button>
+        }
+      />
+
+      <Card>
+        <p className="text-sm font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+          Manifest 요약
+        </p>
+        <p className="mt-3 text-sm text-zinc-600 dark:text-zinc-300">
+          datasetId · 레코드 수 · 출력 형식 등 manifest 메타데이터가 여기에 표시됩니다 (#30).
+        </p>
+      </Card>
+
+      <Card className="p-0">
+        <div className="grid grid-cols-[1.4fr_0.6fr_0.6fr_0.8fr] gap-4 border-b border-zinc-200/80 px-6 py-4 text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+          <span>파일</span>
+          <span>형식</span>
+          <span>크기</span>
+          <span>액션</span>
+        </div>
+        <EmptyState
+          title="생성된 파일이 없습니다"
+          description="빌드가 성공하면 생성된 파일과 다운로드/미리보기 액션이 여기에 표시됩니다."
+        />
+      </Card>
+    </main>
+  );
+}

--- a/src/pages/BuildArtifactsPage.tsx
+++ b/src/pages/BuildArtifactsPage.tsx
@@ -4,8 +4,8 @@
  * manifest 요약, 생성 파일 목록, 다운로드/게시 액션을 보여준다(제안 §5.7).
  * 실제 manifest/파일은 #30 manifest viewer + #29 API 연동 시 채운다.
  */
-import { Link, useParams } from "react-router-dom";
-import { Button, Card, EmptyState, PageHeader } from "@/shared/ui";
+import { useParams } from "react-router-dom";
+import { Card, EmptyState, LinkButton, PageHeader } from "@/shared/ui";
 
 /**
  * 빌드가 생성한 결과물과 manifest 요약을 보여주는 페이지.
@@ -21,11 +21,7 @@ export function BuildArtifactsPage() {
         eyebrow="결과물"
         title={`${buildId || "빌드"} 결과물`}
         description="빌드가 생성한 파일, manifest, 다운로드 링크를 확인하세요."
-        actions={
-          <Button>
-            <Link to={`/builds/${buildId}/publish`}>게시하기</Link>
-          </Button>
-        }
+        actions={<LinkButton to={`/builds/${buildId}/publish`}>게시하기</LinkButton>}
       />
 
       <Card>

--- a/src/pages/BuildDetailPage.tsx
+++ b/src/pages/BuildDetailPage.tsx
@@ -5,7 +5,7 @@
  * 실제 데이터는 #29 Builder API 연동 시 useBuild(buildId)로 채운다.
  */
 import { Link, useParams } from "react-router-dom";
-import { Button, Card, PageHeader, StatusBadge } from "@/shared/ui";
+import { Card, LinkButton, PageHeader, StatusBadge } from "@/shared/ui";
 
 const SUBPAGES = [
   { segment: "edit", label: "편집", description: "스펙 수정" },
@@ -28,11 +28,7 @@ export function BuildDetailPage() {
         eyebrow="빌드 상세"
         title={buildId || "빌드"}
         description="이 빌드의 상태를 확인하고 편집·실행·결과물·게시 단계로 이동하세요."
-        actions={
-          <Button>
-            <Link to={`/builds/${buildId}/run`}>실행하기</Link>
-          </Button>
-        }
+        actions={<LinkButton to={`/builds/${buildId}/run`}>실행하기</LinkButton>}
       />
 
       <Card className="flex flex-wrap items-center gap-3">

--- a/src/pages/BuildDetailPage.tsx
+++ b/src/pages/BuildDetailPage.tsx
@@ -1,0 +1,60 @@
+/**
+ * 빌드 상세 요약 페이지 (/builds/:buildId).
+ *
+ * 빌드의 현재 상태와 편집/실행/결과물/게시로 이어지는 하위 흐름 진입점을 보여준다.
+ * 실제 데이터는 #29 Builder API 연동 시 useBuild(buildId)로 채운다.
+ */
+import { Link, useParams } from "react-router-dom";
+import { Button, Card, PageHeader, StatusBadge } from "@/shared/ui";
+
+const SUBPAGES = [
+  { segment: "edit", label: "편집", description: "스펙 수정" },
+  { segment: "run", label: "실행", description: "빌드 실행 및 추적" },
+  { segment: "artifacts", label: "결과물", description: "파일과 manifest 확인" },
+  { segment: "publish", label: "게시", description: "배포 전 검토 및 publish" },
+] as const;
+
+/**
+ * 빌드 상세 요약과 하위 흐름 진입 카드를 보여주는 페이지.
+ *
+ * @returns 빌드 상세 화면.
+ */
+export function BuildDetailPage() {
+  const { buildId = "" } = useParams();
+
+  return (
+    <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+      <PageHeader
+        eyebrow="빌드 상세"
+        title={buildId || "빌드"}
+        description="이 빌드의 상태를 확인하고 편집·실행·결과물·게시 단계로 이동하세요."
+        actions={
+          <Button>
+            <Link to={`/builds/${buildId}/run`}>실행하기</Link>
+          </Button>
+        }
+      />
+
+      <Card className="flex flex-wrap items-center gap-3">
+        <span className="text-sm text-zinc-600 dark:text-zinc-300">현재 상태</span>
+        <StatusBadge status="draft" />
+        <span className="text-sm text-zinc-500 dark:text-zinc-400">
+          Builder API 연동(#29) 후 실제 상태가 표시됩니다.
+        </span>
+      </Card>
+
+      <section className="grid gap-4 sm:grid-cols-2">
+        {SUBPAGES.map((sub) => (
+          <Link
+            key={sub.segment}
+            to={`/builds/${buildId}/${sub.segment}`}
+            className="rounded-[1.5rem] border border-zinc-200/80 bg-white/80 p-5 transition hover:border-zinc-300 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-800 dark:bg-zinc-950/70"
+          >
+            <p className="text-base font-semibold tracking-tight">{sub.label}</p>
+            <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-300">{sub.description}</p>
+          </Link>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/src/pages/BuildPublishPage.tsx
+++ b/src/pages/BuildPublishPage.tsx
@@ -1,0 +1,78 @@
+/**
+ * 빌드 게시 페이지 (/builds/:buildId/publish).
+ *
+ * 데이터셋 카드 검토, 배포 대상 선택, 게시 전 검증, 게시 실행을 보여준다(제안 §5.8).
+ * 실제 게시는 #9 Publish flow + Builder publish API 연동 시 채운다.
+ */
+import { useParams } from "react-router-dom";
+import { Button, Card, PageHeader } from "@/shared/ui";
+
+const DESTINATIONS = [
+  { id: "local", label: "로컬 다운로드 (Local only)" },
+  { id: "huggingface", label: "HuggingFace Dataset" },
+  { id: "github", label: "GitHub Release" },
+] as const;
+
+/**
+ * 배포 전 검토와 게시 대상 선택을 보여주는 페이지.
+ *
+ * @returns 게시 검토 화면.
+ */
+export function BuildPublishPage() {
+  const { buildId = "" } = useParams();
+
+  return (
+    <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+      <PageHeader
+        eyebrow="게시"
+        title={`${buildId || "빌드"} 게시`}
+        description="배포 전에 데이터셋 메타데이터와 라이선스를 확인하고 게시 대상을 선택하세요."
+      />
+
+      <Card>
+        <p className="text-sm font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+          검토 (Review)
+        </p>
+        <dl className="mt-3 grid gap-2 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-zinc-500 dark:text-zinc-400">제목</dt>
+            <dd className="text-zinc-800 dark:text-zinc-100">—</dd>
+          </div>
+          <div>
+            <dt className="text-zinc-500 dark:text-zinc-400">라이선스</dt>
+            <dd className="text-zinc-800 dark:text-zinc-100">—</dd>
+          </div>
+        </dl>
+        <p className="mt-3 text-sm text-zinc-500 dark:text-zinc-400">
+          데이터셋 카드 정보는 #9 Publish flow 연동 시 manifest에서 채워집니다.
+        </p>
+      </Card>
+
+      <Card>
+        <fieldset>
+          <legend className="text-sm font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+            배포 대상 (Destination)
+          </legend>
+          <div className="mt-4 flex flex-col gap-3">
+            {DESTINATIONS.map((dest, index) => (
+              <label key={dest.id} className="flex items-center gap-3 text-sm">
+                <input
+                  type="radio"
+                  name="publish-destination"
+                  value={dest.id}
+                  defaultChecked={index === 0}
+                  className="h-4 w-4 accent-zinc-900 dark:accent-white"
+                />
+                {dest.label}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+      </Card>
+
+      <div>
+        <Button disabled>게시 (연동 예정)</Button>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/BuildRunPage.tsx
+++ b/src/pages/BuildRunPage.tsx
@@ -1,0 +1,69 @@
+/**
+ * 빌드 실행 추적 페이지 (/builds/:buildId/run).
+ *
+ * 실행 상태 헤더, 단계별 진행률(Stepper), 로그 영역, 다음 행동을 보여준다(제안 §5.5).
+ * 실제 진행 상태/로그는 #39 비동기 job 연동과 #29 API 연동 시 채운다.
+ */
+import { Link, useParams } from "react-router-dom";
+import { Button, Card, EmptyState, PageHeader, StatusBadge, Stepper } from "@/shared/ui";
+
+const RUN_STEPS = [
+  { id: "queued", label: "대기" },
+  { id: "fetching", label: "수집" },
+  { id: "normalizing", label: "정규화" },
+  { id: "exporting", label: "내보내기" },
+  { id: "uploading", label: "업로드" },
+  { id: "completed", label: "완료" },
+];
+
+/**
+ * 빌드 실행 진행 상태와 로그를 추적하는 페이지.
+ *
+ * @returns 실행 추적 화면.
+ */
+export function BuildRunPage() {
+  const { buildId = "" } = useParams();
+
+  return (
+    <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+      <PageHeader
+        eyebrow="실행"
+        title={`${buildId || "빌드"} 실행`}
+        description="빌드 실행 단계와 진행 상태를 실시간으로 추적합니다."
+        actions={
+          <Button variant="secondary" disabled>
+            취소
+          </Button>
+        }
+      />
+
+      <Card className="flex flex-wrap items-center gap-3">
+        <span className="text-sm text-zinc-600 dark:text-zinc-300">상태</span>
+        <StatusBadge status="queued" />
+      </Card>
+
+      <Card>
+        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+          진행 단계
+        </p>
+        <Stepper steps={RUN_STEPS} current={0} />
+      </Card>
+
+      <Card variant="dashed" className="p-0">
+        <EmptyState
+          title="실행 로그가 아직 없습니다"
+          description="실행을 시작하면 수집·정규화·내보내기 로그가 여기에 표시됩니다. 비동기 실행 연동은 #39에서 진행됩니다."
+        />
+      </Card>
+
+      <div className="flex flex-wrap gap-3">
+        <Button variant="secondary">
+          <Link to={`/builds/${buildId}/artifacts`}>결과물 보기</Link>
+        </Button>
+        <Button variant="ghost">
+          <Link to={`/builds/${buildId}/edit`}>스펙 수정</Link>
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/BuildRunPage.tsx
+++ b/src/pages/BuildRunPage.tsx
@@ -4,8 +4,8 @@
  * 실행 상태 헤더, 단계별 진행률(Stepper), 로그 영역, 다음 행동을 보여준다(제안 §5.5).
  * 실제 진행 상태/로그는 #39 비동기 job 연동과 #29 API 연동 시 채운다.
  */
-import { Link, useParams } from "react-router-dom";
-import { Button, Card, EmptyState, PageHeader, StatusBadge, Stepper } from "@/shared/ui";
+import { useParams } from "react-router-dom";
+import { Button, Card, EmptyState, LinkButton, PageHeader, StatusBadge, Stepper } from "@/shared/ui";
 
 const RUN_STEPS = [
   { id: "queued", label: "대기" },
@@ -57,12 +57,12 @@ export function BuildRunPage() {
       </Card>
 
       <div className="flex flex-wrap gap-3">
-        <Button variant="secondary">
-          <Link to={`/builds/${buildId}/artifacts`}>결과물 보기</Link>
-        </Button>
-        <Button variant="ghost">
-          <Link to={`/builds/${buildId}/edit`}>스펙 수정</Link>
-        </Button>
+        <LinkButton variant="secondary" to={`/builds/${buildId}/artifacts`}>
+          결과물 보기
+        </LinkButton>
+        <LinkButton variant="ghost" to={`/builds/${buildId}/edit`}>
+          스펙 수정
+        </LinkButton>
       </div>
     </main>
   );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,31 +1,41 @@
 /**
  * Studio 홈 대시보드 화면.
  *
- * 사용자가 가장 먼저 보는 안내 화면으로, 최근 빌드 요약과 주요 워크플로 진입 버튼을 함께 보여준다.
+ * 사용자가 가장 먼저 보는 화면으로, 빌드 상태 요약, 최근 빌드, 빠른 시작 진입점을
+ * 보여준다(제안 §5.1). 실제 수치/목록은 #29 Builder API 연동 시 채운다.
  */
 import { Link } from "react-router-dom";
 import type { BuildRun } from "@/shared/lib/types";
+import { Button, Card, EmptyState, PageHeader, type StatusValue } from "@/shared/ui";
 
-const quickActions = [
+// 상태 요약 카드. 수치는 Builder API 연동 전까지 0으로 둔다.
+const STATUS_SUMMARY: { status: StatusValue; label: string; count: number }[] = [
+  { status: "draft", label: "초안", count: 0 },
+  { status: "running", label: "실행 중", count: 0 },
+  { status: "failed", label: "실패", count: 0 },
+  { status: "succeeded", label: "성공", count: 0 },
+];
+
+const QUICK_ACTIONS = [
   {
     href: "/builds/new",
-    label: "Create a new build",
-    description: "Start a draft spec with source, export, and output scaffolding.",
+    label: "새 빌드 만들기",
+    description: "데이터 소스·파라미터·출력 형식을 단계별로 설정합니다.",
   },
   {
-    href: "/validate",
-    label: "Review validation",
-    description: "Inspect schema and spec feedback before a run leaves draft state.",
+    href: "/builds",
+    label: "빌드 목록 보기",
+    description: "전체 빌드와 실행 이력을 확인합니다.",
   },
   {
     href: "/artifacts",
-    label: "Inspect artifacts",
-    description: "Reserve a space for generated files, manifests, and download links.",
+    label: "결과물 확인",
+    description: "생성된 파일과 manifest, 다운로드 링크를 봅니다.",
   },
 ];
 
 /**
- * 최근 실행 개요와 빠른 액션을 보여주는 랜딩 페이지 컴포넌트.
+ * 상태 요약·최근 빌드·빠른 시작을 보여주는 대시보드 페이지.
  *
  * @returns Studio 대시보드 메인 화면.
  */
@@ -34,68 +44,51 @@ export function HomePage() {
 
   return (
     <main className="flex flex-1 flex-col gap-8 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
-      <section className="grid gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.9fr)]">
-        <div className="overflow-hidden rounded-[2rem] border border-zinc-200/80 bg-[radial-gradient(circle_at_top_left,_rgba(16,185,129,0.22),_transparent_42%),linear-gradient(135deg,rgba(255,255,255,0.98),rgba(244,244,245,0.95))] p-7 shadow-xl shadow-zinc-950/5 dark:border-zinc-800 dark:bg-[radial-gradient(circle_at_top_left,_rgba(16,185,129,0.16),_transparent_38%),linear-gradient(135deg,rgba(9,9,11,0.98),rgba(24,24,27,0.96))]">
-          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-emerald-600 dark:text-emerald-400">
-            Studio dashboard
-          </p>
-          <h2 className="mt-4 max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">
-            Build public-data workflows with a shell students can extend safely.
-          </h2>
-          <p className="mt-4 max-w-2xl text-base leading-7 text-zinc-600 dark:text-zinc-300">
-            This scaffold keeps draft creation, validation, preview, and output review visible without hiding builder semantics behind heavy abstractions.
-          </p>
-          <div className="mt-8 flex flex-wrap gap-3">
-            <Link
-              className="rounded-full bg-zinc-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-950 dark:hover:bg-zinc-200"
-              to="/builds/new"
-            >
-              Open build editor
-            </Link>
-            <Link
-              className="rounded-full border border-zinc-300 px-5 py-3 text-sm font-medium text-zinc-700 transition hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900"
-              to="/builds"
-            >
-              Browse runs
-            </Link>
-          </div>
-        </div>
+      <PageHeader
+        eyebrow="대시보드"
+        title="공공데이터 수집부터 결과물 생성까지 한 번에 관리하세요"
+        description="템플릿을 선택하고, 미리보기와 검증을 거쳐 안전하게 빌드를 실행할 수 있습니다."
+        actions={
+          <Button>
+            <Link to="/builds/new">새 빌드 만들기</Link>
+          </Button>
+        }
+      />
 
-        <section className="rounded-[2rem] border border-zinc-200/80 bg-white/80 p-6 shadow-lg shadow-zinc-950/5 dark:border-zinc-800 dark:bg-zinc-950/80">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-                Recent builds
-              </p>
-              <h3 className="mt-2 text-2xl font-semibold tracking-tight">No runs yet</h3>
-            </div>
-            <span className="rounded-full border border-dashed border-zinc-300 px-3 py-1 text-xs uppercase tracking-[0.28em] text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
-              {recentBuilds.length} queued
-            </span>
-          </div>
-          <p className="mt-4 text-sm leading-6 text-zinc-600 dark:text-zinc-300">
-            Recent run history will appear here once students wire the runs API into the dashboard cards.
-          </p>
-        </section>
+      {/* 상태 요약 카드 (§5.1) */}
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {STATUS_SUMMARY.map((item) => (
+          <Card key={item.status} className="flex items-center justify-between">
+            <span className="text-sm text-zinc-600 dark:text-zinc-300">{item.label}</span>
+            <span className="text-2xl font-semibold tracking-tight">{item.count}</span>
+          </Card>
+        ))}
       </section>
 
+      {/* 최근 빌드 (§5.1) */}
       <section>
-        <div className="flex items-end justify-between gap-4">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-              Quick actions
-            </p>
-            <h3 className="mt-2 text-2xl font-semibold tracking-tight">
-              Start from the workflow step you need
-            </h3>
-          </div>
-        </div>
-        <div className="mt-5 grid gap-4 xl:grid-cols-3">
-          {quickActions.map((action) => (
+        <PageHeader eyebrow="최근 빌드" title="최근 실행" className="mb-4" />
+        <Card className="p-0">
+          {recentBuilds.length === 0 ? (
+            <EmptyState
+              title="아직 생성된 빌드가 없습니다"
+              description="공공데이터 템플릿으로 첫 빌드를 만들어보세요. 실행 이력은 Builder API 연동(#29) 후 여기에 표시됩니다."
+              actionLabel="새 빌드 만들기"
+              actionHref="/builds/new"
+            />
+          ) : null}
+        </Card>
+      </section>
+
+      {/* 빠른 시작 */}
+      <section>
+        <PageHeader eyebrow="빠른 시작" title="필요한 단계에서 바로 시작하세요" className="mb-4" />
+        <div className="grid gap-4 xl:grid-cols-3">
+          {QUICK_ACTIONS.map((action) => (
             <Link
-              className="rounded-[1.75rem] border border-zinc-200/80 bg-white/80 p-5 transition hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-lg hover:shadow-zinc-950/5 dark:border-zinc-800 dark:bg-zinc-950/80 dark:hover:border-zinc-700"
               key={action.href}
               to={action.href}
+              className="rounded-[1.75rem] border border-zinc-200/80 bg-white/80 p-5 transition hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-lg hover:shadow-zinc-950/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-800 dark:bg-zinc-950/80 dark:hover:border-zinc-700"
             >
               <p className="text-lg font-medium tracking-tight">{action.label}</p>
               <p className="mt-3 text-sm leading-6 text-zinc-600 dark:text-zinc-300">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -6,7 +6,7 @@
  */
 import { Link } from "react-router-dom";
 import type { BuildRun } from "@/shared/lib/types";
-import { Button, Card, EmptyState, PageHeader, type StatusValue } from "@/shared/ui";
+import { Card, EmptyState, LinkButton, PageHeader, type StatusValue } from "@/shared/ui";
 
 // 상태 요약 카드. 수치는 Builder API 연동 전까지 0으로 둔다.
 const STATUS_SUMMARY: { status: StatusValue; label: string; count: number }[] = [
@@ -48,11 +48,7 @@ export function HomePage() {
         eyebrow="대시보드"
         title="공공데이터 수집부터 결과물 생성까지 한 번에 관리하세요"
         description="템플릿을 선택하고, 미리보기와 검증을 거쳐 안전하게 빌드를 실행할 수 있습니다."
-        actions={
-          <Button>
-            <Link to="/builds/new">새 빌드 만들기</Link>
-          </Button>
-        }
+        actions={<LinkButton to="/builds/new">새 빌드 만들기</LinkButton>}
       />
 
       {/* 상태 요약 카드 (§5.1) */}

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -1,34 +1,50 @@
 /**
- * 새 빌드 스펙 초안을 작성하고 즉시 검증해보는 편집 화면.
+ * 새 빌드 작성 마법사(New Build Wizard) 화면.
  *
- * React Hook Form으로 입력 상태를 관리하고, zod 스키마와 검증 API 스텁을 이용해
- * 사용자가 만든 초안이 공유 도메인 모델과 맞는지 빠르게 확인할 수 있게 한다.
+ * 단일 폼 대신 단계별 Stepper로 안내한다(제안 §5.2): 기본 정보 → 데이터 소스 →
+ * 파라미터 → 미리보기 → 출력 형식 → 검증·실행. React Hook Form으로 입력을 관리하고
+ * 각 단계 진행 전에 해당 단계 필드만 검증한다. Preview/Validate는 독립 페이지가 아니라
+ * 마법사 내부 단계로 통합되어 있다(§5.3/§5.4).
  */
 import { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
 import { useForm } from "react-hook-form";
+import { previewBuild } from "@/features/preview/api";
 import { validateSpec } from "@/features/validation/api";
 import { buildSpecSchema, exportFormatSchema } from "@/shared/lib/schemas";
-import type { BuildDraft, BuildSpec } from "@/shared/lib/types";
+import type { BuildSpec } from "@/shared/lib/types";
+import {
+  Button,
+  Card,
+  EmptyState,
+  FormField,
+  PageHeader,
+  Select,
+  StatusBadge,
+  Stepper,
+  TextInput,
+  Textarea,
+  type StepItem,
+} from "@/shared/ui";
 
 const exportFormats = exportFormatSchema.options;
 
+// Provider는 직접 입력 대신 선택형으로 제공한다(제안 §5.2.2). dataset 자동 로딩은
+// #29 Builder API 연동 시 추가한다.
+const PROVIDER_OPTIONS = [
+  { value: "datago", label: "data.go.kr (공공데이터포털)" },
+  { value: "kma", label: "기상청 (KMA)" },
+  { value: "seoul", label: "서울 열린데이터광장" },
+  { value: "kosis", label: "통계청 (KOSIS)" },
+] as const;
+
 interface BuildFormValues {
-  /** 빌드를 식별하는 데이터셋 고유 ID */
   datasetId: string;
-  /** 사용자가 읽을 제목 */
   title: string;
-  /** 빌드 목적과 확장 가이드를 담는 설명 */
   description: string;
-  /** 데이터를 제공하는 provider 이름 */
   provider: string;
-  /** provider 내부의 원본 dataset 식별자 */
   sourceDataset: string;
-  /** 문자열 형태로 입력받는 JSON 파라미터 본문 */
   sourceParams: string;
-  /** 결과물을 저장하거나 게시할 출력 경로 */
   outputPath: string;
-  /** 사용자가 선택한 export 대상 형식 목록 */
   exportFormats: Array<(typeof exportFormats)[number]>;
 }
 
@@ -43,38 +59,53 @@ const initialValues: BuildFormValues = {
   exportFormats: ["jsonl"],
 };
 
+const STEPS: StepItem[] = [
+  { id: "identity", label: "기본 정보" },
+  { id: "source", label: "데이터 소스" },
+  { id: "params", label: "파라미터" },
+  { id: "preview", label: "미리보기" },
+  { id: "output", label: "출력 형식" },
+  { id: "review", label: "검증·실행" },
+];
+
+// 각 단계에서 Next 진입 전에 검증할 폼 필드. Preview/Review 단계는 입력 필드가 없다.
+const STEP_FIELDS: Array<Array<keyof BuildFormValues>> = [
+  ["datasetId", "title", "description"],
+  ["provider", "sourceDataset"],
+  ["sourceParams"],
+  [],
+  ["exportFormats", "outputPath"],
+  [],
+];
+
 /**
- * 폼에서 입력한 원본 JSON 문자열을 `Record<string, string>` 형태로 정규화한다.
+ * textarea의 JSON 파라미터 문자열을 `Record<string, string>`으로 정규화한다.
  *
- * @param sourceParams - 사용자가 textarea에 입력한 JSON 문자열.
- * @returns 파싱된 파라미터 객체 또는 오류 메시지.
+ * @param sourceParams - 사용자가 입력한 JSON 문자열.
+ * @returns 파싱된 객체 또는 한국어 오류 메시지.
  */
 function parseSourceParams(sourceParams: string) {
   try {
     const parsed = JSON.parse(sourceParams) as unknown;
-
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return { error: "Source params must be a JSON object." };
+      return { error: "파라미터는 JSON 객체여야 합니다. 예: {\"region\": \"seoul\"}" };
     }
-
     const entries = Object.entries(parsed);
     const values = Object.fromEntries(entries.map(([key, value]) => [key, String(value)]));
-
     return { data: values };
   } catch {
-    return { error: "Source params must be valid JSON." };
+    return { error: "파라미터가 올바른 JSON이 아닙니다. 형식을 확인하세요." };
   }
 }
 
 /**
- * 폼 입력값에 대한 `BuildSpec` 후보와 검증 결과.
+ * 폼 입력값으로 BuildSpec 후보를 만들고 zod로 검증한다.
  *
-  * @param values - 현재 폼에 입력된 원시 값 집합.
-  * @returns 검증을 통과한 스펙 또는 사용자에게 보여줄 오류 메시지.
+ * @param values - 현재 폼 입력값.
+ * @returns 검증을 통과한 스펙 또는 한국어 오류 메시지.
  */
 function toBuildSpec(values: BuildFormValues): { spec?: BuildSpec; error?: string } {
   const parsedParams = parseSourceParams(values.sourceParams);
-
   if (parsedParams.error) {
     return { error: parsedParams.error };
   }
@@ -84,357 +115,369 @@ function toBuildSpec(values: BuildFormValues): { spec?: BuildSpec; error?: strin
     title: values.title,
     description: values.description,
     sources: [
-      {
-        provider: values.provider,
-        dataset: values.sourceDataset,
-        params: parsedParams.data ?? {},
-      },
+      { provider: values.provider, dataset: values.sourceDataset, params: parsedParams.data ?? {} },
     ],
     exports: values.exportFormats.map((format) => ({
       format,
       options: format === "huggingface" ? { outputPath: values.outputPath } : undefined,
     })),
-    metadata: {
-      outputPath: values.outputPath,
-    },
+    metadata: { outputPath: values.outputPath },
   };
 
   const result = buildSpecSchema.safeParse(candidate);
-
   if (!result.success) {
-    return { error: result.error.issues[0]?.message ?? "Invalid build spec." };
+    return { error: result.error.issues[0]?.message ?? "빌드 스펙이 올바르지 않습니다." };
   }
-
   return { spec: result.data };
 }
 
+interface PreviewState {
+  status: "idle" | "loading" | "loaded" | "error";
+  rows: Record<string, unknown>[];
+  schema: Record<string, string>;
+  error?: string;
+}
+
+interface ValidationState {
+  status: "idle" | "validating" | "validated";
+  isValid: boolean;
+  errors: string[];
+}
+
 /**
- * 빌드 초안 편집, 로컬 검증, 제출 미리보기를 담당하는 페이지 컴포넌트.
+ * 단계별 New Build Wizard 페이지 컴포넌트.
  *
- * @returns 새 빌드 편집 폼과 우측 상태 패널 UI.
+ * @returns 마법사 UI.
  */
 export function NewBuildPage() {
-  const [validationState, setValidationState] = useState<{
-    /** 마지막 검증에서 수집된 오류 문자열 목록 */
-    errors: string[];
-    /** 현재 스펙이 검증을 통과했는지 여부 */
-    isValid: boolean;
-    /** 검증 요청의 진행 상태 */
-    status: "idle" | "validating" | "validated";
-  }>({
-    errors: [],
-    isValid: false,
+  const [step, setStep] = useState(0);
+  const [preview, setPreview] = useState<PreviewState>({ status: "idle", rows: [], schema: {} });
+  const [validation, setValidation] = useState<ValidationState>({
     status: "idle",
+    isValid: false,
+    errors: [],
   });
-  const [submittedSpec, setSubmittedSpec] = useState<BuildSpec | null>(null);
+
   const {
-    formState: { errors, isDirty, isSubmitting },
-    handleSubmit,
+    formState: { errors, isDirty },
     register,
-    setError,
-    clearErrors,
+    trigger,
     watch,
-  } = useForm<BuildFormValues>({
-    defaultValues: initialValues,
-    mode: "onChange",
-  });
+    getValues,
+  } = useForm<BuildFormValues>({ defaultValues: initialValues, mode: "onChange" });
 
   const values = watch();
   const specPreview = useMemo(() => toBuildSpec(values), [values]);
 
-  const initialSpec: BuildSpec = specPreview.spec ?? {
-    datasetId: "",
-    title: "",
-    description: "",
-    sources: [],
-    exports: [],
-    metadata: {},
-  };
+  const draftStatus = validation.isValid ? "validated" : isDirty ? "dirty" : "new";
 
-  const draft: BuildDraft = {
-    spec: initialSpec,
-    status: validationState.isValid ? "validated" : isDirty ? "dirty" : "new",
-    lastModified: new Date().toISOString(),
-  };
-
-  /**
-   * 현재 폼 상태를 기준으로 로컬 스펙을 구성하고 검증 API 스텁을 호출한다.
-   *
-   * @returns 검증 완료 후 상태 업데이트를 수행하는 비동기 작업.
-   */
-  async function validateCurrentSpec() {
-    clearErrors();
-    setValidationState({ errors: [], isValid: false, status: "validating" });
-
-    const nextSpec = toBuildSpec(watch());
-
-    if (nextSpec.error || !nextSpec.spec) {
-      setError("sourceParams", {
-        type: "manual",
-        message: nextSpec.error ?? "Unable to parse source parameters.",
-      });
-      setValidationState({
-        errors: [nextSpec.error ?? "Unable to parse source parameters."],
-        isValid: false,
-        status: "idle",
-      });
-      return;
-    }
-
-    const result = await validateSpec(nextSpec.spec);
-
-    if (!result.valid) {
-      setValidationState({ errors: result.errors, isValid: false, status: "validated" });
-      return;
-    }
-
-    setValidationState({ errors: [], isValid: true, status: "validated" });
-    setSubmittedSpec(nextSpec.spec);
+  async function goNext() {
+    const fields = STEP_FIELDS[step];
+    const ok = fields.length === 0 ? true : await trigger(fields);
+    if (!ok) return;
+    setStep((current) => Math.min(current + 1, STEPS.length - 1));
   }
 
-  const onSubmit = handleSubmit(async (formValues) => {
-    const nextSpec = toBuildSpec(formValues);
+  function goBack() {
+    setStep((current) => Math.max(current - 1, 0));
+  }
 
-    if (nextSpec.error || !nextSpec.spec) {
-      setError("sourceParams", {
-        type: "manual",
-        message: nextSpec.error ?? "Unable to parse source parameters.",
-      });
+  async function runPreview() {
+    const next = toBuildSpec(getValues());
+    if (next.error || !next.spec) {
+      setPreview({ status: "error", rows: [], schema: {}, error: next.error });
       return;
     }
+    setPreview({ status: "loading", rows: [], schema: {} });
+    try {
+      const result = await previewBuild(next.spec);
+      setPreview({ status: "loaded", rows: result.rows, schema: result.schema });
+    } catch (cause) {
+      setPreview({
+        status: "error",
+        rows: [],
+        schema: {},
+        error: cause instanceof Error ? cause.message : "미리보기에 실패했습니다.",
+      });
+    }
+  }
 
-    setSubmittedSpec(nextSpec.spec);
-  });
+  async function runValidate() {
+    const next = toBuildSpec(getValues());
+    if (next.error || !next.spec) {
+      setValidation({ status: "validated", isValid: false, errors: [next.error ?? "스펙 오류"] });
+      return;
+    }
+    setValidation({ status: "validating", isValid: false, errors: [] });
+    const result = await validateSpec(next.spec);
+    setValidation({ status: "validated", isValid: result.valid, errors: result.errors });
+  }
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-            New build
-          </p>
-          <h2 className="mt-2 text-3xl font-semibold tracking-tight">Build draft editor scaffold</h2>
-          <p className="mt-3 max-w-2xl text-zinc-600 dark:text-zinc-300">
-            React Hook Form manages draft input while zod keeps the generated spec aligned with the shared domain model.
-          </p>
-        </div>
+      <PageHeader
+        eyebrow="새 빌드"
+        title="새 공공데이터 빌드 만들기"
+        description="데이터 소스, 파라미터, 출력 형식을 단계별로 설정합니다."
+        actions={<StatusBadge status={draftStatus} />}
+      />
 
-        <div className="flex flex-wrap gap-3">
-          <Link
-            className="rounded-full border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 transition hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900"
-            to="/validate"
-          >
-            Open validation view
-          </Link>
-          <Link
-            className="rounded-full border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 transition hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900"
-            to="/preview"
-          >
-            Open preview view
-          </Link>
-        </div>
-      </div>
+      <Card>
+        <Stepper steps={STEPS} current={step} onStepClick={setStep} />
+      </Card>
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.3fr)_minmax(22rem,0.9fr)]">
-        <form
-          className="rounded-[2rem] border border-zinc-200/80 bg-white/80 p-6 shadow-lg shadow-zinc-950/5 dark:border-zinc-800 dark:bg-zinc-950/70"
-          onSubmit={onSubmit}
-        >
-          <div className="grid gap-6 lg:grid-cols-2">
-            <section className="space-y-4 lg:col-span-2">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-                  Build identity
-                </p>
-                <h3 className="mt-2 text-xl font-semibold tracking-tight">Dataset metadata</h3>
-              </div>
-
-              <div className="grid gap-4 md:grid-cols-2">
-                <label className="space-y-2">
-                  <span className="text-sm font-medium">Dataset ID</span>
-                  <input
-                    className="w-full rounded-2xl border border-zinc-200 bg-white px-4 py-3 outline-none transition focus:border-emerald-500 dark:border-zinc-800 dark:bg-zinc-950"
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.3fr)_minmax(20rem,0.8fr)]">
+        <Card>
+          {step === 0 ? (
+            <div className="space-y-4">
+              <h3 className="text-xl font-semibold tracking-tight">기본 정보</h3>
+              <FormField
+                id="datasetId"
+                label="데이터셋 ID"
+                required
+                help="공백 없이 영문 소문자·숫자·하이픈만. 예: kma-daily-observations"
+                error={errors.datasetId?.message}
+              >
+                {(field) => (
+                  <TextInput
                     placeholder="kma-daily-observations"
-                    {...register("datasetId", { required: "Dataset ID is required." })}
+                    {...field}
+                    {...register("datasetId", { required: "데이터셋 ID를 입력해주세요. 예: kma-daily-observations" })}
                   />
-                  {errors.datasetId ? (
-                    <span className="text-sm text-rose-500">{errors.datasetId.message}</span>
-                  ) : null}
-                </label>
-
-                <label className="space-y-2">
-                  <span className="text-sm font-medium">Title</span>
-                  <input
-                    className="w-full rounded-2xl border border-zinc-200 bg-white px-4 py-3 outline-none transition focus:border-emerald-500 dark:border-zinc-800 dark:bg-zinc-950"
-                    placeholder="KMA daily observations"
-                    {...register("title", { required: "Title is required." })}
+                )}
+              </FormField>
+              <FormField id="title" label="제목" required error={errors.title?.message}>
+                {(field) => (
+                  <TextInput
+                    placeholder="기상청 일별 관측"
+                    {...field}
+                    {...register("title", { required: "제목을 입력해주세요." })}
                   />
-                  {errors.title ? (
-                    <span className="text-sm text-rose-500">{errors.title.message}</span>
-                  ) : null}
-                </label>
-              </div>
-
-              <label className="space-y-2">
-                <span className="text-sm font-medium">Description</span>
-                <textarea
-                  className="min-h-32 w-full rounded-2xl border border-zinc-200 bg-white px-4 py-3 outline-none transition focus:border-emerald-500 dark:border-zinc-800 dark:bg-zinc-950"
-                  placeholder="Explain what this build collects and how students should extend it."
-                  {...register("description", { required: "Description is required." })}
-                />
-                {errors.description ? (
-                  <span className="text-sm text-rose-500">{errors.description.message}</span>
-                ) : null}
-              </label>
-            </section>
-
-            <section className="space-y-4 lg:col-span-2">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-                  Source selection
-                </p>
-                <h3 className="mt-2 text-xl font-semibold tracking-tight">Provider and dataset</h3>
-              </div>
-
-              <div className="grid gap-4 md:grid-cols-2">
-                <label className="space-y-2">
-                  <span className="text-sm font-medium">Provider</span>
-                  <input
-                    className="w-full rounded-2xl border border-zinc-200 bg-white px-4 py-3 outline-none transition focus:border-emerald-500 dark:border-zinc-800 dark:bg-zinc-950"
-                    placeholder="datago"
-                    {...register("provider", { required: "Provider is required." })}
+                )}
+              </FormField>
+              <FormField
+                id="description"
+                label="설명"
+                required
+                help="이 빌드가 무엇을 수집하고 어떻게 활용하는지 적어주세요."
+                error={errors.description?.message}
+              >
+                {(field) => (
+                  <Textarea
+                    className="font-sans"
+                    {...field}
+                    {...register("description", { required: "설명을 입력해주세요." })}
                   />
-                  {errors.provider ? (
-                    <span className="text-sm text-rose-500">{errors.provider.message}</span>
-                  ) : null}
-                </label>
+                )}
+              </FormField>
+            </div>
+          ) : null}
 
-                <label className="space-y-2">
-                  <span className="text-sm font-medium">Dataset</span>
-                  <input
-                    className="w-full rounded-2xl border border-zinc-200 bg-white px-4 py-3 outline-none transition focus:border-emerald-500 dark:border-zinc-800 dark:bg-zinc-950"
+          {step === 1 ? (
+            <div className="space-y-4">
+              <h3 className="text-xl font-semibold tracking-tight">데이터 소스</h3>
+              <FormField id="provider" label="제공자 (Provider)" required error={errors.provider?.message}>
+                {(field) => (
+                  <Select {...field} {...register("provider", { required: "제공자를 선택해주세요." })}>
+                    <option value="">제공자 선택…</option>
+                    {PROVIDER_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </Select>
+                )}
+              </FormField>
+              <FormField
+                id="sourceDataset"
+                label="데이터셋 (Dataset)"
+                required
+                help="제공자 내부의 데이터셋 코드. (자동 목록은 Builder API 연동 후 제공)"
+                error={errors.sourceDataset?.message}
+              >
+                {(field) => (
+                  <TextInput
                     placeholder="air-quality"
-                    {...register("sourceDataset", { required: "Dataset is required." })}
+                    {...field}
+                    {...register("sourceDataset", { required: "데이터셋을 입력해주세요." })}
                   />
-                  {errors.sourceDataset ? (
-                    <span className="text-sm text-rose-500">{errors.sourceDataset.message}</span>
-                  ) : null}
-                </label>
+                )}
+              </FormField>
+            </div>
+          ) : null}
+
+          {step === 2 ? (
+            <div className="space-y-4">
+              <h3 className="text-xl font-semibold tracking-tight">파라미터</h3>
+              <FormField
+                id="sourceParams"
+                label="요청 파라미터 (고급 / Advanced JSON)"
+                help='지역·기간 등 요청 파라미터를 JSON 객체로 입력하세요. 예: {"region": "gangnam"}'
+                error={errors.sourceParams?.message}
+              >
+                {(field) => (
+                  <Textarea
+                    rows={8}
+                    {...field}
+                    {...register("sourceParams", { required: "파라미터를 입력해주세요." })}
+                  />
+                )}
+              </FormField>
+            </div>
+          ) : null}
+
+          {step === 3 ? (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-xl font-semibold tracking-tight">미리보기</h3>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  loading={preview.status === "loading"}
+                  onClick={() => void runPreview()}
+                >
+                  미리보기 새로고침
+                </Button>
               </div>
-
-              <label className="space-y-2 lg:col-span-2">
-                <span className="text-sm font-medium">Params (JSON object)</span>
-                <textarea
-                  className="min-h-32 w-full rounded-2xl border border-zinc-200 bg-white px-4 py-3 font-mono text-sm outline-none transition focus:border-emerald-500 dark:border-zinc-800 dark:bg-zinc-950"
-                  {...register("sourceParams", { required: "Source params are required." })}
+              {preview.status === "idle" ? (
+                <EmptyState
+                  title="현재 설정으로 샘플 데이터를 확인하세요"
+                  description="‘미리보기 새로고침’을 누르면 Builder가 반환한 샘플 행과 스키마가 표시됩니다."
                 />
-                {errors.sourceParams ? (
-                  <span className="text-sm text-rose-500">{errors.sourceParams.message}</span>
-                ) : null}
-              </label>
-            </section>
-
-            <section className="space-y-4 lg:col-span-2">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-                  Export targets
+              ) : null}
+              {preview.status === "error" ? (
+                <EmptyState
+                  title="미리보기를 불러오지 못했습니다"
+                  description={preview.error ?? "파라미터를 확인한 뒤 다시 시도하세요."}
+                />
+              ) : null}
+              {preview.status === "loaded" && preview.rows.length === 0 ? (
+                <EmptyState
+                  title="조건에 맞는 데이터가 없습니다"
+                  description="날짜 범위나 지역 조건을 조정해보세요. (현재 Preview API는 스텁이라 빈 결과를 반환합니다.)"
+                />
+              ) : null}
+              {preview.status === "loaded" && preview.rows.length > 0 ? (
+                <p className="text-sm text-zinc-600 dark:text-zinc-300">
+                  {preview.rows.length}개 샘플 행 · {Object.keys(preview.schema).length}개 컬럼
                 </p>
-                <h3 className="mt-2 text-xl font-semibold tracking-tight">Output selection</h3>
-              </div>
+              ) : null}
+            </div>
+          ) : null}
 
-              <div className="grid gap-3 md:grid-cols-2">
-                {exportFormats.map((format) => (
-                  <label
-                    className="flex items-center gap-3 rounded-2xl border border-zinc-200/80 bg-zinc-50/80 px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900/70"
-                    key={format}
-                  >
-                    <input type="checkbox" value={format} {...register("exportFormats")} />
-                    <span className="text-sm font-medium capitalize">{format}</span>
-                  </label>
-                ))}
-              </div>
-
-              <label className="space-y-2 lg:col-span-2">
-                <span className="text-sm font-medium">Output path</span>
-                <input
-                  className="w-full rounded-2xl border border-zinc-200 bg-white px-4 py-3 outline-none transition focus:border-emerald-500 dark:border-zinc-800 dark:bg-zinc-950"
-                  placeholder="artifacts/builds/air-quality"
-                  {...register("outputPath", { required: "Output path is required." })}
-                />
-                {errors.outputPath ? (
-                  <span className="text-sm text-rose-500">{errors.outputPath.message}</span>
+          {step === 4 ? (
+            <div className="space-y-4">
+              <h3 className="text-xl font-semibold tracking-tight">출력 형식</h3>
+              <fieldset>
+                <legend className="text-sm font-medium text-zinc-800 dark:text-zinc-100">
+                  결과물 형식 (최소 1개)
+                </legend>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  {exportFormats.map((format) => (
+                    <label
+                      key={format}
+                      className="flex items-center gap-3 rounded-2xl border border-zinc-200/80 bg-zinc-50/80 px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900/70"
+                    >
+                      <input
+                        type="checkbox"
+                        value={format}
+                        className="h-4 w-4 accent-zinc-900 dark:accent-white"
+                        {...register("exportFormats", {
+                          validate: (selected) =>
+                            (selected?.length ?? 0) > 0 || "출력 형식을 최소 1개 선택해주세요.",
+                        })}
+                      />
+                      <span className="text-sm font-medium capitalize">{format}</span>
+                    </label>
+                  ))}
+                </div>
+                {errors.exportFormats ? (
+                  <p role="alert" className="mt-2 text-sm text-red-600 dark:text-red-400">
+                    {errors.exportFormats.message}
+                  </p>
                 ) : null}
-              </label>
-            </section>
-          </div>
+              </fieldset>
+              <FormField
+                id="outputPath"
+                label="출력 경로 (Output path)"
+                required
+                error={errors.outputPath?.message}
+              >
+                {(field) => (
+                  <TextInput
+                    placeholder="artifacts/builds/air-quality"
+                    {...field}
+                    {...register("outputPath", { required: "출력 경로를 입력해주세요." })}
+                  />
+                )}
+              </FormField>
+            </div>
+          ) : null}
 
-          <div className="mt-8 flex flex-wrap gap-3">
-            <button
-              className="rounded-full border border-zinc-300 px-5 py-3 text-sm font-medium text-zinc-700 transition hover:border-zinc-400 hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900"
-              disabled={isSubmitting || validationState.status === "validating"}
-              onClick={() => void validateCurrentSpec()}
-              type="button"
-            >
-              {validationState.status === "validating" ? "Validating…" : "Validate"}
-            </button>
-            <button
-              className="rounded-full bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-emerald-300"
-              disabled={!validationState.isValid || isSubmitting}
-              type="submit"
-            >
-              Save scaffold draft
-            </button>
+          {step === 5 ? (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-xl font-semibold tracking-tight">검증·실행</h3>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  loading={validation.status === "validating"}
+                  onClick={() => void runValidate()}
+                >
+                  다시 검증
+                </Button>
+              </div>
+              {validation.status === "idle" ? (
+                <p className="text-sm text-zinc-600 dark:text-zinc-300">
+                  ‘다시 검증’을 눌러 입력값과 빌드 설정을 확인하세요.
+                </p>
+              ) : null}
+              {validation.status === "validated" && validation.isValid ? (
+                <Card variant="success" className="p-4">
+                  <p className="text-sm font-medium text-emerald-800 dark:text-emerald-300">
+                    검증을 통과했습니다. 빌드를 실행할 수 있습니다.
+                  </p>
+                </Card>
+              ) : null}
+              {validation.errors.length > 0 ? (
+                <ul className="space-y-2">
+                  {validation.errors.map((error) => (
+                    <li
+                      key={error}
+                      role="alert"
+                      className="rounded-2xl bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-950/40 dark:text-red-200"
+                    >
+                      {error}
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+              <Button disabled={!validation.isValid}>빌드 실행 (연동 예정)</Button>
+            </div>
+          ) : null}
+
+          <div className="mt-8 flex items-center justify-between gap-3">
+            <Button variant="ghost" onClick={goBack} disabled={step === 0}>
+              이전
+            </Button>
+            <div className="flex gap-2">
+              <Button variant="secondary">초안 저장</Button>
+              {step < STEPS.length - 1 ? (
+                <Button onClick={() => void goNext()}>다음</Button>
+              ) : null}
+            </div>
           </div>
-        </form>
+        </Card>
 
         <aside className="space-y-5">
-          <section className="rounded-[2rem] border border-zinc-200/80 bg-white/80 p-5 dark:border-zinc-800 dark:bg-zinc-950/70">
+          <Card>
             <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-              Draft state
-            </p>
-            <p className="mt-3 text-lg font-medium tracking-tight">{draft.status}</p>
-            <p className="mt-2 text-sm leading-6 text-zinc-600 dark:text-zinc-300">
-              Draft validation stays separate from server state so students can evolve the draft model later.
-            </p>
-          </section>
-
-          <section className="rounded-[2rem] border border-zinc-200/80 bg-white/80 p-5 dark:border-zinc-800 dark:bg-zinc-950/70">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-                  Validation status
-                </p>
-                <p className="mt-2 text-lg font-medium tracking-tight">
-                  {validationState.isValid ? "Spec is ready" : "Validation pending"}
-                </p>
-              </div>
-              <span className="rounded-full border border-dashed border-zinc-300 px-3 py-1 text-xs uppercase tracking-[0.28em] text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
-                {validationState.errors.length} issues
-              </span>
-            </div>
-            <ul className="mt-4 space-y-2 text-sm text-zinc-600 dark:text-zinc-300">
-              {validationState.errors.length > 0 ? (
-                validationState.errors.map((error) => (
-                  <li className="rounded-2xl bg-rose-50 px-3 py-2 text-rose-700 dark:bg-rose-950/40 dark:text-rose-200" key={error}>
-                    {error}
-                  </li>
-                ))
-              ) : (
-                <li className="rounded-2xl bg-zinc-50 px-3 py-2 dark:bg-zinc-900">
-                  Use the validate button to exercise the stubbed validation API.
-                </li>
-              )}
-            </ul>
-          </section>
-
-          <section className="rounded-[2rem] border border-zinc-200/80 bg-white/80 p-5 dark:border-zinc-800 dark:bg-zinc-950/70">
-            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-              Generated spec preview
+              생성될 스펙 (Generated spec)
             </p>
             <pre className="mt-4 overflow-x-auto rounded-[1.5rem] bg-zinc-950 p-4 text-xs leading-6 text-zinc-100">
-              <code>{JSON.stringify(submittedSpec ?? specPreview.spec ?? draft.spec, null, 2)}</code>
+              <code>{JSON.stringify(specPreview.spec ?? values, null, 2)}</code>
             </pre>
-          </section>
+          </Card>
         </aside>
       </div>
     </main>

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -319,7 +319,11 @@ export function NewBuildPage() {
                   <Textarea
                     rows={8}
                     {...field}
-                    {...register("sourceParams", { required: "파라미터를 입력해주세요." })}
+                    {...register("sourceParams", {
+                      required: "파라미터를 입력해주세요.",
+                      // JSON 문법/객체 여부를 단계 이동(trigger) 시점에 바로 막고 필드에 표시한다.
+                      validate: (value) => parseSourceParams(value).error ?? true,
+                    })}
                   />
                 )}
               </FormField>

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -1,0 +1,86 @@
+/**
+ * 공통 Button 컴포넌트.
+ *
+ * 페이지마다 반복되던 Tailwind 버튼 스타일을 variant/size/loading 상태로 통일한다.
+ * 접근성을 위해 focus-visible 링과 disabled/loading 시 상호작용 차단을 기본 제공한다.
+ */
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { cn } from "./cn";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger" | "success";
+export type ButtonSize = "sm" | "md" | "lg";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** 시각적 강조 수준을 결정하는 변형 */
+  variant?: ButtonVariant;
+  /** 버튼 크기 */
+  size?: ButtonSize;
+  /** 로딩 상태. true이면 스피너를 표시하고 클릭을 막는다. */
+  loading?: boolean;
+  /** 라벨 앞에 표시할 아이콘 등 */
+  leadingIcon?: ReactNode;
+}
+
+const VARIANT_CLASS: Record<ButtonVariant, string> = {
+  primary:
+    "bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200",
+  secondary:
+    "border border-zinc-300 text-zinc-700 hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900",
+  ghost:
+    "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900",
+  danger: "bg-red-600 text-white hover:bg-red-500",
+  success: "bg-emerald-600 text-white hover:bg-emerald-500",
+};
+
+const SIZE_CLASS: Record<ButtonSize, string> = {
+  sm: "px-3 py-1.5 text-xs",
+  md: "px-4 py-2 text-sm",
+  lg: "px-5 py-2.5 text-base",
+};
+
+/**
+ * 일관된 스타일과 상태를 가진 버튼을 렌더링한다.
+ *
+ * @param props - 표준 button 속성에 variant/size/loading/leadingIcon을 더한 값.
+ * @returns 버튼 엘리먼트.
+ */
+export function Button({
+  variant = "primary",
+  size = "md",
+  loading = false,
+  leadingIcon,
+  disabled,
+  className,
+  children,
+  type = "button",
+  ...rest
+}: ButtonProps) {
+  const isDisabled = disabled || loading;
+
+  return (
+    <button
+      type={type}
+      disabled={isDisabled}
+      aria-busy={loading || undefined}
+      className={cn(
+        "inline-flex items-center justify-center gap-2 rounded-full font-medium transition",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-950",
+        "disabled:cursor-not-allowed disabled:opacity-60",
+        VARIANT_CLASS[variant],
+        SIZE_CLASS[size],
+        className,
+      )}
+      {...rest}
+    >
+      {loading ? (
+        <span
+          aria-hidden="true"
+          className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+        />
+      ) : (
+        leadingIcon
+      )}
+      {children}
+    </button>
+  );
+}

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -5,10 +5,9 @@
  * 접근성을 위해 focus-visible 링과 disabled/loading 시 상호작용 차단을 기본 제공한다.
  */
 import type { ButtonHTMLAttributes, ReactNode } from "react";
-import { cn } from "./cn";
+import { buttonClassName, type ButtonSize, type ButtonVariant } from "./buttonStyles";
 
-export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger" | "success";
-export type ButtonSize = "sm" | "md" | "lg";
+export type { ButtonSize, ButtonVariant };
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** 시각적 강조 수준을 결정하는 변형 */
@@ -20,23 +19,6 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** 라벨 앞에 표시할 아이콘 등 */
   leadingIcon?: ReactNode;
 }
-
-const VARIANT_CLASS: Record<ButtonVariant, string> = {
-  primary:
-    "bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200",
-  secondary:
-    "border border-zinc-300 text-zinc-700 hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900",
-  ghost:
-    "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900",
-  danger: "bg-red-600 text-white hover:bg-red-500",
-  success: "bg-emerald-600 text-white hover:bg-emerald-500",
-};
-
-const SIZE_CLASS: Record<ButtonSize, string> = {
-  sm: "px-3 py-1.5 text-xs",
-  md: "px-4 py-2 text-sm",
-  lg: "px-5 py-2.5 text-base",
-};
 
 /**
  * 일관된 스타일과 상태를 가진 버튼을 렌더링한다.
@@ -62,12 +44,10 @@ export function Button({
       type={type}
       disabled={isDisabled}
       aria-busy={loading || undefined}
-      className={cn(
-        "inline-flex items-center justify-center gap-2 rounded-full font-medium transition",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-950",
+      className={buttonClassName(
+        variant,
+        size,
         "disabled:cursor-not-allowed disabled:opacity-60",
-        VARIANT_CLASS[variant],
-        SIZE_CLASS[size],
         className,
       )}
       {...rest}

--- a/src/shared/ui/Card.tsx
+++ b/src/shared/ui/Card.tsx
@@ -1,0 +1,42 @@
+/**
+ * 공통 Card 컴포넌트.
+ *
+ * 페이지마다 반복되던 `rounded-[2rem] border ... bg-white/80 shadow-lg` 패턴을
+ * variant로 통일한다.
+ */
+import type { HTMLAttributes } from "react";
+import { cn } from "./cn";
+
+export type CardVariant = "default" | "elevated" | "dashed" | "error" | "success";
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  /** 카드의 시각적 변형 */
+  variant?: CardVariant;
+}
+
+const VARIANT_CLASS: Record<CardVariant, string> = {
+  default:
+    "border border-zinc-200/80 bg-white/80 shadow-lg shadow-zinc-950/5 dark:border-zinc-800 dark:bg-zinc-950/70",
+  elevated:
+    "border border-zinc-200/80 bg-white shadow-xl shadow-zinc-950/10 dark:border-zinc-800 dark:bg-zinc-950",
+  dashed:
+    "border-2 border-dashed border-zinc-300 bg-transparent dark:border-zinc-700",
+  error:
+    "border border-red-300 bg-red-50/80 dark:border-red-900/60 dark:bg-red-950/30",
+  success:
+    "border border-emerald-300 bg-emerald-50/80 dark:border-emerald-900/60 dark:bg-emerald-950/30",
+};
+
+/**
+ * 표준 패딩과 모서리를 가진 카드 컨테이너를 렌더링한다.
+ *
+ * @param props - 표준 div 속성에 variant를 더한 값.
+ * @returns 카드 엘리먼트.
+ */
+export function Card({ variant = "default", className, children, ...rest }: CardProps) {
+  return (
+    <div className={cn("rounded-[2rem] p-6", VARIANT_CLASS[variant], className)} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/shared/ui/EmptyState.tsx
+++ b/src/shared/ui/EmptyState.tsx
@@ -2,33 +2,35 @@
  * 공통 EmptyState 컴포넌트.
  *
  * "무엇이 없는지 + 다음 행동 제안 + CTA" 구조로 빈 상태를 일관되게 표현한다(제안 §11).
+ * CTA는 실제 동작(actionHref 또는 onAction)이 있을 때만 노출되며, 타입 차원에서도
+ * actionLabel은 둘 중 하나와 함께만 지정할 수 있도록 제한한다.
  */
 import type { ReactNode } from "react";
-import { Link } from "react-router-dom";
 import { Button } from "./Button";
+import { LinkButton } from "./LinkButton";
 import { cn } from "./cn";
 
-export interface EmptyStateProps {
+// actionLabel은 반드시 actionHref(라우팅) 또는 onAction(핸들러)과 함께만 허용한다.
+type EmptyStateAction =
+  | { actionLabel: string; actionHref: string; onAction?: never }
+  | { actionLabel: string; actionHref?: never; onAction: () => void }
+  | { actionLabel?: never; actionHref?: never; onAction?: never };
+
+export type EmptyStateProps = {
   /** 비어 있는 이유를 요약한 제목 */
   title: string;
   /** 사용자가 할 수 있는 다음 행동 설명 */
   description?: ReactNode;
-  /** CTA 버튼 라벨 */
-  actionLabel?: string;
-  /** CTA 이동 경로(내부 라우트). actionLabel과 함께 사용. */
-  actionHref?: string;
-  /** 경로 대신 클릭 핸들러로 동작시킬 때 사용 */
-  onAction?: () => void;
   /** 상단 아이콘/일러스트 */
   icon?: ReactNode;
   /** 추가 className */
   className?: string;
-}
+} & EmptyStateAction;
 
 /**
- * 데이터가 없을 때 안내 문구와 다음 행동 CTA를 보여준다.
+ * 데이터가 없을 때 안내 문구와 (선택적) 다음 행동 CTA를 보여준다.
  *
- * @param props - title/description/action 관련 속성.
+ * @param props - title/description/icon과 actionLabel+actionHref|onAction.
  * @returns 빈 상태 엘리먼트.
  */
 export function EmptyState({
@@ -40,6 +42,8 @@ export function EmptyState({
   icon,
   className,
 }: EmptyStateProps) {
+  const hasAction = Boolean(actionLabel) && (Boolean(actionHref) || Boolean(onAction));
+
   return (
     <div className={cn("flex flex-col items-center px-6 py-14 text-center", className)}>
       {icon ? <div className="mb-4 text-zinc-400 dark:text-zinc-500">{icon}</div> : null}
@@ -49,19 +53,12 @@ export function EmptyState({
           {description}
         </p>
       ) : null}
-      {actionLabel ? (
+      {hasAction ? (
         <div className="mt-6">
           {actionHref ? (
-            <Link
-              to={actionHref}
-              className={cn(
-                "inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-medium transition",
-                "bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-950",
-              )}
-            >
+            <LinkButton to={actionHref} size="lg">
               {actionLabel}
-            </Link>
+            </LinkButton>
           ) : (
             <Button onClick={onAction}>{actionLabel}</Button>
           )}

--- a/src/shared/ui/EmptyState.tsx
+++ b/src/shared/ui/EmptyState.tsx
@@ -1,0 +1,72 @@
+/**
+ * 공통 EmptyState 컴포넌트.
+ *
+ * "무엇이 없는지 + 다음 행동 제안 + CTA" 구조로 빈 상태를 일관되게 표현한다(제안 §11).
+ */
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { Button } from "./Button";
+import { cn } from "./cn";
+
+export interface EmptyStateProps {
+  /** 비어 있는 이유를 요약한 제목 */
+  title: string;
+  /** 사용자가 할 수 있는 다음 행동 설명 */
+  description?: ReactNode;
+  /** CTA 버튼 라벨 */
+  actionLabel?: string;
+  /** CTA 이동 경로(내부 라우트). actionLabel과 함께 사용. */
+  actionHref?: string;
+  /** 경로 대신 클릭 핸들러로 동작시킬 때 사용 */
+  onAction?: () => void;
+  /** 상단 아이콘/일러스트 */
+  icon?: ReactNode;
+  /** 추가 className */
+  className?: string;
+}
+
+/**
+ * 데이터가 없을 때 안내 문구와 다음 행동 CTA를 보여준다.
+ *
+ * @param props - title/description/action 관련 속성.
+ * @returns 빈 상태 엘리먼트.
+ */
+export function EmptyState({
+  title,
+  description,
+  actionLabel,
+  actionHref,
+  onAction,
+  icon,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div className={cn("flex flex-col items-center px-6 py-14 text-center", className)}>
+      {icon ? <div className="mb-4 text-zinc-400 dark:text-zinc-500">{icon}</div> : null}
+      <p className="text-lg font-medium tracking-tight">{title}</p>
+      {description ? (
+        <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-300">
+          {description}
+        </p>
+      ) : null}
+      {actionLabel ? (
+        <div className="mt-6">
+          {actionHref ? (
+            <Link
+              to={actionHref}
+              className={cn(
+                "inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-medium transition",
+                "bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-950",
+              )}
+            >
+              {actionLabel}
+            </Link>
+          ) : (
+            <Button onClick={onAction}>{actionLabel}</Button>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/shared/ui/ErrorMessage.tsx
+++ b/src/shared/ui/ErrorMessage.tsx
@@ -4,13 +4,14 @@
  * 폼 필드 오류나 요약 오류를 role="alert"로 노출해 보조기기가 즉시 안내하도록 한다
  * (접근성, 제안 §12).
  */
+import type { ReactNode } from "react";
 import { cn } from "./cn";
 
 export interface ErrorMessageProps {
   /** aria-describedby로 연결하기 위한 id */
   id?: string;
   /** 오류 메시지 본문 */
-  children?: React.ReactNode;
+  children?: ReactNode;
   /** 추가 className */
   className?: string;
 }

--- a/src/shared/ui/ErrorMessage.tsx
+++ b/src/shared/ui/ErrorMessage.tsx
@@ -1,0 +1,35 @@
+/**
+ * 공통 ErrorMessage 컴포넌트.
+ *
+ * 폼 필드 오류나 요약 오류를 role="alert"로 노출해 보조기기가 즉시 안내하도록 한다
+ * (접근성, 제안 §12).
+ */
+import { cn } from "./cn";
+
+export interface ErrorMessageProps {
+  /** aria-describedby로 연결하기 위한 id */
+  id?: string;
+  /** 오류 메시지 본문 */
+  children?: React.ReactNode;
+  /** 추가 className */
+  className?: string;
+}
+
+/**
+ * 오류 메시지를 role="alert"로 렌더링한다. children이 없으면 아무것도 렌더링하지 않는다.
+ *
+ * @param props - id/children/className.
+ * @returns 오류 메시지 엘리먼트 또는 null.
+ */
+export function ErrorMessage({ id, children, className }: ErrorMessageProps) {
+  if (!children) return null;
+  return (
+    <p
+      id={id}
+      role="alert"
+      className={cn("text-sm text-red-600 dark:text-red-400", className)}
+    >
+      {children}
+    </p>
+  );
+}

--- a/src/shared/ui/FormField.tsx
+++ b/src/shared/ui/FormField.tsx
@@ -63,7 +63,15 @@ export function FormField({
     <div className={cn("flex flex-col gap-1.5", className)}>
       <label htmlFor={id} className="text-sm font-medium text-zinc-800 dark:text-zinc-100">
         {label}
-        {required ? <span className="ml-0.5 text-red-600">*</span> : null}
+        {required ? (
+          <>
+            {/* 시각적 별표는 보조기기에서 숨기고, 스크린리더에는 '(필수)'를 읽어준다. */}
+            <span aria-hidden="true" className="ml-0.5 text-red-600">
+              *
+            </span>
+            <span className="sr-only">(필수)</span>
+          </>
+        ) : null}
       </label>
       {children({ id, "aria-describedby": describedBy, invalid: Boolean(error) })}
       {help ? (

--- a/src/shared/ui/FormField.tsx
+++ b/src/shared/ui/FormField.tsx
@@ -1,0 +1,77 @@
+/**
+ * 공통 FormField 컴포넌트.
+ *
+ * label + help 텍스트 + error 메시지를 일관되게 배치하고, 접근성을 위해 control에
+ * 연결할 id와 aria-describedby를 계산해 render-prop으로 넘긴다(제안 §8/§12.3).
+ *
+ * 사용 예:
+ *   <FormField id="datasetId" label="데이터셋 ID" help="예: kma-daily-observations"
+ *              error={errors.datasetId?.message}>
+ *     {(field) => <TextInput {...register("datasetId")} {...field} />}
+ *   </FormField>
+ */
+import type { ReactNode } from "react";
+import { cn } from "./cn";
+import { ErrorMessage } from "./ErrorMessage";
+
+export interface FormFieldRenderProps {
+  /** control의 id (label htmlFor와 연결됨) */
+  id: string;
+  /** help/error id를 합친 aria-describedby 값(없으면 undefined) */
+  "aria-describedby": string | undefined;
+  /** 오류 여부 */
+  invalid: boolean;
+}
+
+export interface FormFieldProps {
+  /** control과 label을 연결할 기본 id */
+  id: string;
+  /** 필드 라벨(한국어) */
+  label: string;
+  /** 입력 형식 등 보조 설명 */
+  help?: ReactNode;
+  /** 검증 오류 메시지 */
+  error?: ReactNode;
+  /** 필수 표시(*) 여부 */
+  required?: boolean;
+  /** 계산된 접근성 속성을 받아 control을 렌더링하는 함수 */
+  children: (field: FormFieldRenderProps) => ReactNode;
+  /** 추가 className */
+  className?: string;
+}
+
+/**
+ * 라벨/도움말/오류와 접근성 속성이 연결된 폼 필드 래퍼를 렌더링한다.
+ *
+ * @param props - id/label/help/error/required/children.
+ * @returns 폼 필드 엘리먼트.
+ */
+export function FormField({
+  id,
+  label,
+  help,
+  error,
+  required,
+  children,
+  className,
+}: FormFieldProps) {
+  const helpId = help ? `${id}-help` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+  const describedBy = [helpId, errorId].filter(Boolean).join(" ") || undefined;
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <label htmlFor={id} className="text-sm font-medium text-zinc-800 dark:text-zinc-100">
+        {label}
+        {required ? <span className="ml-0.5 text-red-600">*</span> : null}
+      </label>
+      {children({ id, "aria-describedby": describedBy, invalid: Boolean(error) })}
+      {help ? (
+        <p id={helpId} className="text-xs text-zinc-500 dark:text-zinc-400">
+          {help}
+        </p>
+      ) : null}
+      <ErrorMessage id={errorId}>{error}</ErrorMessage>
+    </div>
+  );
+}

--- a/src/shared/ui/LinkButton.tsx
+++ b/src/shared/ui/LinkButton.tsx
@@ -1,0 +1,26 @@
+/**
+ * 공통 LinkButton 컴포넌트.
+ *
+ * React Router `Link`를 버튼 스타일로 렌더링한다. `<Button>` 안에 `<Link>`를 중첩하면
+ * 상호작용 요소(button>a)가 중첩되어 HTML 유효성·접근성·키보드 동작에 문제가 생기므로,
+ * 라우팅이 필요한 "버튼처럼 보이는" 요소는 이 단일 anchor 컴포넌트를 사용한다.
+ */
+import { Link, type LinkProps } from "react-router-dom";
+import { buttonClassName, type ButtonSize, type ButtonVariant } from "./buttonStyles";
+
+export interface LinkButtonProps extends LinkProps {
+  /** 시각적 강조 수준을 결정하는 변형 */
+  variant?: ButtonVariant;
+  /** 버튼 크기 */
+  size?: ButtonSize;
+}
+
+/**
+ * 버튼 스타일을 입힌 라우터 링크를 렌더링한다(상호작용 요소 중첩 없이).
+ *
+ * @param props - Link 속성에 variant/size를 더한 값.
+ * @returns 버튼처럼 보이는 anchor(Link) 엘리먼트.
+ */
+export function LinkButton({ variant = "primary", size = "md", className, ...rest }: LinkButtonProps) {
+  return <Link className={buttonClassName(variant, size, className)} {...rest} />;
+}

--- a/src/shared/ui/PageHeader.tsx
+++ b/src/shared/ui/PageHeader.tsx
@@ -1,0 +1,56 @@
+/**
+ * 공통 PageHeader 컴포넌트.
+ *
+ * 각 페이지 상단에서 반복되던 "eyebrow 라벨 + 제목 + 설명 + 우측 액션" 패턴을 통일한다.
+ */
+import type { ReactNode } from "react";
+import { cn } from "./cn";
+
+export interface PageHeaderProps {
+  /** 제목 위에 표시할 작은 대문자 라벨(예: "Runs") */
+  eyebrow?: string;
+  /** 페이지 제목 */
+  title: string;
+  /** 제목 아래 보조 설명 */
+  description?: ReactNode;
+  /** 우측 정렬 액션 영역(버튼 등) */
+  actions?: ReactNode;
+  /** 추가 className */
+  className?: string;
+}
+
+/**
+ * 페이지 머리말(라벨/제목/설명/액션)을 일관된 레이아웃으로 렌더링한다.
+ *
+ * @param props - eyebrow/title/description/actions.
+ * @returns 페이지 헤더 엘리먼트.
+ */
+export function PageHeader({
+  eyebrow,
+  title,
+  description,
+  actions,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 md:flex-row md:items-end md:justify-between",
+        className,
+      )}
+    >
+      <div>
+        {eyebrow ? (
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+            {eyebrow}
+          </p>
+        ) : null}
+        <h2 className="mt-2 text-3xl font-semibold tracking-tight">{title}</h2>
+        {description ? (
+          <p className="mt-2 max-w-2xl text-zinc-600 dark:text-zinc-300">{description}</p>
+        ) : null}
+      </div>
+      {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+    </div>
+  );
+}

--- a/src/shared/ui/Select.tsx
+++ b/src/shared/ui/Select.tsx
@@ -1,0 +1,40 @@
+/**
+ * 공통 Select 컴포넌트.
+ *
+ * Provider/Dataset/데이터 단위 등 선택 입력을 통일한다. react-hook-form ref 주입을
+ * 위해 forwardRef로 구현한다. 옵션은 children(<option>)으로 전달한다.
+ */
+import { forwardRef, type SelectHTMLAttributes } from "react";
+import { cn } from "./cn";
+
+export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  /** 검증 오류 상태. true이면 빨간 테두리와 aria-invalid를 적용한다. */
+  invalid?: boolean;
+}
+
+/**
+ * 스타일과 오류 상태를 갖춘 select 컨트롤.
+ */
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
+  { invalid, className, children, ...rest },
+  ref,
+) {
+  return (
+    <select
+      ref={ref}
+      aria-invalid={invalid || undefined}
+      className={cn(
+        "w-full rounded-xl border bg-white px-3 py-2 text-sm text-zinc-900 transition",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0",
+        "dark:bg-zinc-950 dark:text-zinc-100",
+        invalid
+          ? "border-red-400 focus-visible:ring-red-500 dark:border-red-700"
+          : "border-zinc-300 focus-visible:ring-zinc-500 dark:border-zinc-700",
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </select>
+  );
+});

--- a/src/shared/ui/StatusBadge.tsx
+++ b/src/shared/ui/StatusBadge.tsx
@@ -1,0 +1,77 @@
+/**
+ * 공통 StatusBadge 컴포넌트.
+ *
+ * draft/run/publish 흐름의 모든 상태값을 한국어 라벨 + 일관된 색상으로 표시한다.
+ * 색상만으로 의미를 전달하지 않도록 항상 텍스트 라벨을 함께 노출한다(접근성).
+ */
+import { cn } from "./cn";
+
+/** Studio 전반에서 배지로 표시 가능한 모든 상태값의 합집합 */
+export type StatusValue =
+  | "new"
+  | "draft"
+  | "dirty"
+  | "validated"
+  | "invalid"
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "publishing"
+  | "published";
+
+interface StatusMeta {
+  /** 화면에 노출할 한국어 라벨 */
+  label: string;
+  /** Tailwind 색상 클래스 */
+  className: string;
+}
+
+const STATUS_META: Record<StatusValue, StatusMeta> = {
+  new: { label: "새 초안", className: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200" },
+  draft: { label: "초안", className: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200" },
+  dirty: { label: "수정됨", className: "bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300" },
+  validated: { label: "검증됨", className: "bg-blue-100 text-blue-800 dark:bg-blue-950/50 dark:text-blue-300" },
+  invalid: { label: "오류 있음", className: "bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300" },
+  queued: { label: "대기 중", className: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200" },
+  running: { label: "실행 중", className: "bg-blue-100 text-blue-800 dark:bg-blue-950/50 dark:text-blue-300" },
+  succeeded: { label: "성공", className: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300" },
+  failed: { label: "실패", className: "bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300" },
+  cancelled: { label: "취소됨", className: "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400" },
+  publishing: { label: "게시 중", className: "bg-blue-100 text-blue-800 dark:bg-blue-950/50 dark:text-blue-300" },
+  published: { label: "게시됨", className: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300" },
+};
+
+export interface StatusBadgeProps {
+  /** 표시할 상태값 */
+  status: StatusValue;
+  /** 추가 className */
+  className?: string;
+}
+
+/**
+ * 상태값에 대응하는 한국어 라벨과 색상을 가진 배지를 렌더링한다.
+ *
+ * @param props - status와 추가 className.
+ * @returns 상태 배지 엘리먼트.
+ */
+export function StatusBadge({ status, className }: StatusBadgeProps) {
+  const meta = STATUS_META[status];
+  const isLive = status === "running" || status === "publishing";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium",
+        meta.className,
+        className,
+      )}
+    >
+      {isLive ? (
+        <span aria-hidden="true" className="h-1.5 w-1.5 animate-pulse rounded-full bg-current" />
+      ) : null}
+      {meta.label}
+    </span>
+  );
+}

--- a/src/shared/ui/Stepper.tsx
+++ b/src/shared/ui/Stepper.tsx
@@ -1,0 +1,116 @@
+/**
+ * 공통 Stepper 컴포넌트.
+ *
+ * New Build Wizard처럼 다단계 흐름의 진행 상태를 표시한다. 각 단계는
+ * upcoming/current/complete/error 상태를 가지며, 현재 단계에 aria-current="step"을
+ * 부여해 보조기기에서 위치를 알 수 있게 한다(접근성, 제안 §12).
+ */
+import { cn } from "./cn";
+
+export type StepState = "upcoming" | "current" | "complete" | "error";
+
+export interface StepItem {
+  /** 단계 식별자 */
+  id: string;
+  /** 단계 라벨(한국어) */
+  label: string;
+}
+
+export interface StepperProps {
+  /** 표시할 단계 목록(순서대로) */
+  steps: StepItem[];
+  /** 현재 활성 단계의 0-기반 인덱스 */
+  current: number;
+  /** 오류가 발생한 단계 인덱스 집합(선택) */
+  errorSteps?: number[];
+  /** 단계 클릭으로 이동 허용 시 핸들러(완료된 단계만 이동 가능) */
+  onStepClick?: (index: number) => void;
+  /** 추가 className */
+  className?: string;
+}
+
+function resolveState(index: number, current: number, errorSteps: number[]): StepState {
+  if (errorSteps.includes(index)) return "error";
+  if (index < current) return "complete";
+  if (index === current) return "current";
+  return "upcoming";
+}
+
+const STATE_CIRCLE: Record<StepState, string> = {
+  upcoming: "border-zinc-300 text-zinc-400 dark:border-zinc-700 dark:text-zinc-500",
+  current: "border-zinc-900 bg-zinc-900 text-white dark:border-white dark:bg-white dark:text-zinc-900",
+  complete: "border-emerald-600 bg-emerald-600 text-white",
+  error: "border-red-600 bg-red-600 text-white",
+};
+
+/**
+ * 다단계 흐름의 진행 상태를 가로 스텝 표시기로 렌더링한다.
+ *
+ * @param props - steps/current/errorSteps/onStepClick.
+ * @returns 스텝퍼 엘리먼트.
+ */
+export function Stepper({
+  steps,
+  current,
+  errorSteps = [],
+  onStepClick,
+  className,
+}: StepperProps) {
+  return (
+    <ol className={cn("flex w-full items-center gap-2 overflow-x-auto", className)}>
+      {steps.map((step, index) => {
+        const state = resolveState(index, current, errorSteps);
+        const clickable = Boolean(onStepClick) && index < current;
+        const circle = (
+          <span
+            className={cn(
+              "flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-xs font-semibold",
+              STATE_CIRCLE[state],
+            )}
+            aria-hidden="true"
+          >
+            {state === "complete" ? "✓" : state === "error" ? "!" : index + 1}
+          </span>
+        );
+
+        return (
+          <li
+            key={step.id}
+            aria-current={state === "current" ? "step" : undefined}
+            className="flex min-w-fit items-center gap-2"
+          >
+            {clickable ? (
+              <button
+                type="button"
+                onClick={() => onStepClick?.(index)}
+                className="flex items-center gap-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500"
+              >
+                {circle}
+                <span className="whitespace-nowrap text-sm font-medium text-zinc-700 dark:text-zinc-200">
+                  {step.label}
+                </span>
+              </button>
+            ) : (
+              <div className="flex items-center gap-2">
+                {circle}
+                <span
+                  className={cn(
+                    "whitespace-nowrap text-sm font-medium",
+                    state === "upcoming"
+                      ? "text-zinc-400 dark:text-zinc-500"
+                      : "text-zinc-700 dark:text-zinc-200",
+                  )}
+                >
+                  {step.label}
+                </span>
+              </div>
+            )}
+            {index < steps.length - 1 ? (
+              <span aria-hidden="true" className="h-px w-6 bg-zinc-300 dark:bg-zinc-700" />
+            ) : null}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/src/shared/ui/TextInput.tsx
+++ b/src/shared/ui/TextInput.tsx
@@ -1,0 +1,38 @@
+/**
+ * 공통 TextInput 컴포넌트.
+ *
+ * react-hook-form의 register가 ref를 주입할 수 있도록 forwardRef로 구현한다.
+ * 오류 상태(invalid)에 따라 테두리 색과 focus 링을 바꾼다.
+ */
+import { forwardRef, type InputHTMLAttributes } from "react";
+import { cn } from "./cn";
+
+export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  /** 검증 오류 상태. true이면 빨간 테두리와 aria-invalid를 적용한다. */
+  invalid?: boolean;
+}
+
+/**
+ * 스타일과 오류 상태를 갖춘 텍스트 입력 컨트롤.
+ */
+export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(function TextInput(
+  { invalid, className, ...rest },
+  ref,
+) {
+  return (
+    <input
+      ref={ref}
+      aria-invalid={invalid || undefined}
+      className={cn(
+        "w-full rounded-xl border bg-white px-3 py-2 text-sm text-zinc-900 transition placeholder:text-zinc-400",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0",
+        "dark:bg-zinc-950 dark:text-zinc-100",
+        invalid
+          ? "border-red-400 focus-visible:ring-red-500 dark:border-red-700"
+          : "border-zinc-300 focus-visible:ring-zinc-500 dark:border-zinc-700",
+        className,
+      )}
+      {...rest}
+    />
+  );
+});

--- a/src/shared/ui/Textarea.tsx
+++ b/src/shared/ui/Textarea.tsx
@@ -1,0 +1,38 @@
+/**
+ * 공통 Textarea 컴포넌트.
+ *
+ * TextInput과 동일한 스타일 체계를 따르며 react-hook-form ref 주입을 위해 forwardRef로 구현한다.
+ */
+import { forwardRef, type TextareaHTMLAttributes } from "react";
+import { cn } from "./cn";
+
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  /** 검증 오류 상태. true이면 빨간 테두리와 aria-invalid를 적용한다. */
+  invalid?: boolean;
+}
+
+/**
+ * 스타일과 오류 상태를 갖춘 멀티라인 입력 컨트롤.
+ */
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { invalid, className, rows = 4, ...rest },
+  ref,
+) {
+  return (
+    <textarea
+      ref={ref}
+      rows={rows}
+      aria-invalid={invalid || undefined}
+      className={cn(
+        "w-full rounded-xl border bg-white px-3 py-2 font-mono text-sm text-zinc-900 transition placeholder:text-zinc-400",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0",
+        "dark:bg-zinc-950 dark:text-zinc-100",
+        invalid
+          ? "border-red-400 focus-visible:ring-red-500 dark:border-red-700"
+          : "border-zinc-300 focus-visible:ring-zinc-500 dark:border-zinc-700",
+        className,
+      )}
+      {...rest}
+    />
+  );
+});

--- a/src/shared/ui/buttonStyles.ts
+++ b/src/shared/ui/buttonStyles.ts
@@ -1,0 +1,49 @@
+/**
+ * Button과 LinkButton이 공유하는 시각 스타일 정의.
+ *
+ * 버튼과 "버튼처럼 보이는 링크"가 동일한 variant/size 룩을 갖도록 클래스 합성 로직을
+ * 한곳에 모은다. 이렇게 분리하면 `<button>` 안에 `<a>`를 중첩하지 않고도(상호작용 요소
+ * 중첩 회피) 링크를 버튼 스타일로 렌더링할 수 있다.
+ */
+import { cn, type ClassValue } from "./cn";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger" | "success";
+export type ButtonSize = "sm" | "md" | "lg";
+
+const VARIANT_CLASS: Record<ButtonVariant, string> = {
+  primary:
+    "bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200",
+  secondary:
+    "border border-zinc-300 text-zinc-700 hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900",
+  ghost: "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900",
+  danger: "bg-red-600 text-white hover:bg-red-500",
+  success: "bg-emerald-600 text-white hover:bg-emerald-500",
+};
+
+const SIZE_CLASS: Record<ButtonSize, string> = {
+  sm: "px-3 py-1.5 text-xs",
+  md: "px-4 py-2 text-sm",
+  lg: "px-5 py-2.5 text-base",
+};
+
+/**
+ * variant/size에 맞는 버튼 스타일 className을 만든다.
+ *
+ * @param variant - 강조 수준.
+ * @param size - 크기.
+ * @param extra - 추가로 합성할 클래스 값들.
+ * @returns 합쳐진 className 문자열.
+ */
+export function buttonClassName(
+  variant: ButtonVariant = "primary",
+  size: ButtonSize = "md",
+  ...extra: ClassValue[]
+): string {
+  return cn(
+    "inline-flex items-center justify-center gap-2 rounded-full font-medium transition",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-950",
+    VARIANT_CLASS[variant],
+    SIZE_CLASS[size],
+    ...extra,
+  );
+}

--- a/src/shared/ui/cn.ts
+++ b/src/shared/ui/cn.ts
@@ -1,0 +1,17 @@
+/**
+ * Tailwind 클래스 문자열을 조건부로 합성하는 경량 헬퍼.
+ *
+ * clsx 같은 외부 의존성 없이, falsy 값(`undefined`/`false`/`""`)을 걸러내고 공백으로
+ * 이어 붙인다. 공통 컴포넌트에서 variant별 클래스를 조립할 때 사용한다.
+ */
+export type ClassValue = string | false | null | undefined;
+
+/**
+ * 전달된 클래스 값들 중 truthy인 것만 공백으로 이어 붙여 반환한다.
+ *
+ * @param values - 합성할 클래스 값 목록(거짓값은 무시).
+ * @returns 합쳐진 className 문자열.
+ */
+export function cn(...values: ClassValue[]): string {
+  return values.filter(Boolean).join(" ");
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -4,6 +4,8 @@
  * 페이지/기능 모듈은 `@/shared/ui`에서 디자인 시스템 컴포넌트를 가져온다.
  */
 export { Button, type ButtonProps, type ButtonVariant, type ButtonSize } from "./Button";
+export { LinkButton, type LinkButtonProps } from "./LinkButton";
+export { buttonClassName } from "./buttonStyles";
 export { Card, type CardProps, type CardVariant } from "./Card";
 export { PageHeader, type PageHeaderProps } from "./PageHeader";
 export { EmptyState, type EmptyStateProps } from "./EmptyState";

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,0 +1,17 @@
+/**
+ * 공통 UI 컴포넌트 배럴(barrel) 모듈.
+ *
+ * 페이지/기능 모듈은 `@/shared/ui`에서 디자인 시스템 컴포넌트를 가져온다.
+ */
+export { Button, type ButtonProps, type ButtonVariant, type ButtonSize } from "./Button";
+export { Card, type CardProps, type CardVariant } from "./Card";
+export { PageHeader, type PageHeaderProps } from "./PageHeader";
+export { EmptyState, type EmptyStateProps } from "./EmptyState";
+export { StatusBadge, type StatusBadgeProps, type StatusValue } from "./StatusBadge";
+export { Stepper, type StepperProps, type StepItem, type StepState } from "./Stepper";
+export { FormField, type FormFieldProps, type FormFieldRenderProps } from "./FormField";
+export { TextInput, type TextInputProps } from "./TextInput";
+export { Textarea, type TextareaProps } from "./Textarea";
+export { Select, type SelectProps } from "./Select";
+export { ErrorMessage, type ErrorMessageProps } from "./ErrorMessage";
+export { cn, type ClassValue } from "./cn";


### PR DESCRIPTION
홈 대시보드를 개선합니다 (§5.1/§15).

## 포함
- 상태 요약 카드(초안/실행 중/실패/성공)
- 최근 빌드 EmptyState + CTA
- 빠른 시작 카드 — 전부 한국어, 디자인 시스템 기반
- 레거시 /validate 빠른 액션 제거(마법사 패널로 이동)

## 스택 안내
`feat/new-build-wizard` 위에 쌓여 있습니다. 순서대로 머지해 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)