### PR TITLE
ci: 프론트엔드 품질 게이트 (lint/tsc/test/build) — #38

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+# PR 머지 전 프론트엔드 코드 품질 게이트: lint(ESLint) + type check(tsc) + 테스트(Vitest)
+# + 프로덕션 빌드. 문서 배포 워크플로(docs.yml)와 분리된 코드 품질 전용 CI다 (#38).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Lint, type check, test, build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20", "22"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint (ESLint)
+        run: npm run lint
+
+      - name: Type check (tsc --noEmit)
+        run: npm run typecheck
+
+      - name: Test (Vitest)
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
   push:
     branches: [main]
 
+# 최소 권한 원칙: 이 워크플로는 코드를 읽고 검사만 하므로 GITHUB_TOKEN에 읽기 권한만 부여한다.
+# (의존성 설치 단계의 공급망 공격 시 피해 범위를 줄인다.)
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-.github/workflows/ci.yml

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest"


### PR DESCRIPTION
Studio에 PR 품질 게이트가 없어(docs.yml만 존재) 회귀를 늦게 발견합니다. (#38)

## 포함
- `.github/workflows/ci.yml`: PR/push 시 ESLint + `tsc --noEmit` + Vitest + 프로덕션 빌드 (Node 20/22 매트릭스)
- `typecheck` npm 스크립트 추가
- 이 CI 파일을 정확히 제외하던 stale `.gitignore` 항목 제거

## 비고
`main`에서 독립적으로 분기되어 다른 PR과 무관하게 머지 가능합니다.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)