### PR TITLE
feat: 나머지 페이지 한국어화 + 디자인시스템 적용 — UI/UX §5.6·§5.7·§14

### DIFF
--- a/__tests__/remainingPages.test.tsx
+++ b/__tests__/remainingPages.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import { ArtifactsPage } from "@/pages/ArtifactsPage";
@@ -7,7 +8,7 @@ import { PreviewPage } from "@/pages/PreviewPage";
 import { SettingsPage } from "@/pages/SettingsPage";
 import { ValidatePage } from "@/pages/ValidatePage";
 
-function renderPage(element: React.ReactNode) {
+function renderPage(element: ReactNode) {
   return render(<MemoryRouter>{element}</MemoryRouter>);
 }
 

--- a/__tests__/remainingPages.test.tsx
+++ b/__tests__/remainingPages.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { ArtifactsPage } from "@/pages/ArtifactsPage";
+import { BuildsPage } from "@/pages/BuildsPage";
+import { PreviewPage } from "@/pages/PreviewPage";
+import { SettingsPage } from "@/pages/SettingsPage";
+import { ValidatePage } from "@/pages/ValidatePage";
+
+function renderPage(element: React.ReactNode) {
+  return render(<MemoryRouter>{element}</MemoryRouter>);
+}
+
+describe("remaining pages", () => {
+  it("BuildsPage shows the Korean heading and an empty-state CTA", () => {
+    renderPage(<BuildsPage />);
+    expect(screen.getByRole("heading", { name: "빌드 목록" })).toBeInTheDocument();
+    expect(screen.getByText("아직 생성된 빌드가 없습니다")).toBeInTheDocument();
+  });
+
+  it("SettingsPage shows the API base URL section", () => {
+    renderPage(<SettingsPage />);
+    expect(screen.getByRole("heading", { name: "환경 설정" })).toBeInTheDocument();
+    expect(screen.getByText("Builder API 엔드포인트")).toBeInTheDocument();
+  });
+
+  it("ArtifactsPage guides to the build list", () => {
+    renderPage(<ArtifactsPage />);
+    expect(screen.getByRole("link", { name: "빌드 목록으로" })).toHaveAttribute("href", "/builds");
+  });
+
+  it("legacy Validate/Preview pages route into the wizard", () => {
+    renderPage(<ValidatePage />);
+    expect(screen.getByRole("link", { name: "새 빌드 만들기" })).toHaveAttribute(
+      "href",
+      "/builds/new",
+    );
+    renderPage(<PreviewPage />);
+    expect(screen.getAllByRole("link", { name: "새 빌드 만들기" }).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/pages/ArtifactsPage.tsx
+++ b/src/pages/ArtifactsPage.tsx
@@ -1,45 +1,33 @@
 /**
- * 빌드 결과 아티팩트 확인 화면의 기본 골격을 제공하는 페이지.
+ * 결과물 랜딩 페이지 (/artifacts).
  *
- * 생성 파일, manifest 요약, 다운로드 액션처럼 후속 기능이 들어갈 영역을 카드로 구분한다.
+ * 결과물은 빌드 단위로 관리되므로(제안 §5.7), 이 전역 화면은 빌드 선택으로 안내한다.
+ * 빌드별 상세 결과물은 /builds/:buildId/artifacts 에서 확인한다.
  */
-const artifactCards = [
-  "Generated files",
-  "Manifest summary",
-  "Download actions",
-] as const;
+import { Card, EmptyState, PageHeader } from "@/shared/ui";
 
 /**
- * 아티팩트 카드 목록을 렌더링하는 페이지 컴포넌트.
+ * 빌드별 결과물 화면으로 안내하는 전역 결과물 랜딩 페이지.
  *
- * @returns 아티팩트 뷰어 스캐폴드 화면.
+ * @returns 결과물 랜딩 화면.
  */
 export function ArtifactsPage() {
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-          Artifacts
-        </p>
-        <h2 className="mt-2 text-3xl font-semibold tracking-tight">Artifact viewer scaffold</h2>
-        <p className="mt-3 max-w-2xl text-zinc-600 dark:text-zinc-300">
-          Reserve space for manifests, generated file paths, and output-specific actions.
-        </p>
-      </div>
+      <PageHeader
+        eyebrow="결과물"
+        title="생성된 결과물"
+        description="결과물은 빌드 단위로 관리됩니다. 빌드를 선택하면 파일·manifest·다운로드를 볼 수 있습니다."
+      />
 
-      <div className="grid gap-4 xl:grid-cols-3">
-        {artifactCards.map((card) => (
-          <section
-            className="rounded-[1.75rem] border border-zinc-200/80 bg-white/80 p-5 dark:border-zinc-800 dark:bg-zinc-950/70"
-            key={card}
-          >
-            <h3 className="text-lg font-medium tracking-tight">{card}</h3>
-            <p className="mt-3 text-sm leading-6 text-zinc-600 dark:text-zinc-300">
-              Placeholder content for future artifact API integration.
-            </p>
-          </section>
-        ))}
-      </div>
+      <Card className="p-0">
+        <EmptyState
+          title="빌드를 선택하세요"
+          description="빌드 목록에서 빌드를 연 뒤 ‘결과물’ 탭에서 파일과 manifest를 확인할 수 있습니다."
+          actionLabel="빌드 목록으로"
+          actionHref="/builds"
+        />
+      </Card>
     </main>
   );
 }

--- a/src/pages/BuildsPage.tsx
+++ b/src/pages/BuildsPage.tsx
@@ -1,56 +1,47 @@
 /**
- * 빌드 실행 이력 목록을 위한 스캐폴드 페이지.
+ * 빌드 목록 페이지 (/builds).
  *
- * 향후 runs API와 polling 훅이 연결되면 대기/실행/완료 상태를 표 형태로 보여줄 예정이다.
+ * 전체 빌드와 실행 이력을 표로 보여준다(제안 §5.6). 실제 목록/상태는 #29 Builder API
+ * 연동 시 useBuilds()로 채운다.
  */
-import { Link } from "react-router-dom";
 import type { BuildRun } from "@/shared/lib/types";
+import { Card, EmptyState, LinkButton, PageHeader } from "@/shared/ui";
+
+const COLUMNS = ["빌드", "상태", "마지막 실행", "액션"] as const;
 
 /**
- * 실행 이력 표와 새 빌드 진입 버튼을 보여주는 페이지 컴포넌트.
+ * 빌드 실행 목록 표와 새 빌드 진입점을 보여주는 페이지.
  *
- * @returns 빌드 실행 목록 화면.
+ * @returns 빌드 목록 화면.
  */
 export function BuildsPage() {
   const runs: BuildRun[] = [];
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
-      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-            Runs
-          </p>
-          <h2 className="mt-2 text-3xl font-semibold tracking-tight">Build run history</h2>
-          <p className="mt-2 max-w-2xl text-zinc-600 dark:text-zinc-300">
-            Scaffold table for queued, running, and completed build executions.
-          </p>
-        </div>
-        <Link
-          className="rounded-full border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 transition hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900"
-          to="/builds/new"
-        >
-          New build draft
-        </Link>
-      </div>
+      <PageHeader
+        eyebrow="빌드"
+        title="빌드 목록"
+        description="전체 빌드와 대기·실행·완료 상태의 실행 이력을 확인하세요."
+        actions={<LinkButton to="/builds/new">새 빌드 만들기</LinkButton>}
+      />
 
-      <section className="overflow-hidden rounded-[2rem] border border-zinc-200/80 bg-white/80 shadow-lg shadow-zinc-950/5 dark:border-zinc-800 dark:bg-zinc-950/70">
-        <div className="grid grid-cols-[1.2fr_0.8fr_0.8fr_0.8fr] gap-4 border-b border-zinc-200/80 px-6 py-4 text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
-          <span>Build</span>
-          <span>Status</span>
-          <span>Started</span>
-          <span>Action</span>
+      <Card className="overflow-hidden p-0">
+        <div className="grid grid-cols-[1.4fr_0.7fr_0.9fr_0.7fr] gap-4 border-b border-zinc-200/80 px-6 py-4 text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+          {COLUMNS.map((column) => (
+            <span key={column}>{column}</span>
+          ))}
         </div>
 
         {runs.length === 0 ? (
-          <div className="px-6 py-14 text-center">
-            <p className="text-lg font-medium tracking-tight">No build runs yet</p>
-            <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-300">
-              Students can connect `listBuilds` and polling hooks here to populate the table with live run status.
-            </p>
-          </div>
+          <EmptyState
+            title="아직 생성된 빌드가 없습니다"
+            description="첫 빌드를 만들면 여기에 상태와 실행 이력이 표시됩니다. (목록 API는 #29 연동 시 연결됩니다.)"
+            actionLabel="새 빌드 만들기"
+            actionHref="/builds/new"
+          />
         ) : null}
-      </section>
+      </Card>
     </main>
   );
 }

--- a/src/pages/PreviewPage.tsx
+++ b/src/pages/PreviewPage.tsx
@@ -1,41 +1,33 @@
 /**
- * 빌드 결과 미리보기 패널 스캐폴드 페이지.
+ * 미리보기 페이지 (/preview, 레거시 딥링크).
  *
- * 실제 preview API가 연결되면 컬럼 스키마와 샘플 행을 이 화면에 표시한다.
+ * 미리보기는 이제 New Build 마법사의 ‘미리보기’ 단계에 통합되어 있다(제안 §5.3).
+ * 이 화면은 딥링크 호환을 위해 유지하며, 마법사로 안내한다.
  */
-const previewColumns = ["column", "type", "sample"] as const;
+import { Card, EmptyState, PageHeader } from "@/shared/ui";
 
 /**
- * 스키마/샘플 행 자리표시자 테이블을 렌더링한다.
+ * 미리보기 흐름을 마법사로 안내하는 레거시 페이지.
  *
- * @returns 미리보기 워크스페이스 화면.
+ * @returns 미리보기 안내 화면.
  */
 export function PreviewPage() {
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-          Preview
-        </p>
-        <h2 className="mt-2 text-3xl font-semibold tracking-tight">Preview panel scaffold</h2>
-        <p className="mt-3 max-w-2xl text-zinc-600 dark:text-zinc-300">
-          Placeholder table for dataset rows returned by the preview API stub.
-        </p>
-      </div>
+      <PageHeader
+        eyebrow="미리보기"
+        title="데이터 미리보기"
+        description="현재 설정으로 가져올 수 있는 샘플 데이터를 확인하는 단계입니다."
+      />
 
-      <section className="overflow-hidden rounded-[2rem] border border-zinc-200/80 bg-white/80 dark:border-zinc-800 dark:bg-zinc-950/70">
-        <div className="grid grid-cols-3 gap-4 border-b border-zinc-200/80 px-6 py-4 text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
-          {previewColumns.map((column) => (
-            <span key={column}>{column}</span>
-          ))}
-        </div>
-        <div className="px-6 py-14 text-center">
-          <p className="text-lg font-medium tracking-tight">No preview rows loaded</p>
-          <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-300">
-            Hook `previewBuild` into this page to render column schemas and sample rows after spec validation.
-          </p>
-        </div>
-      </section>
+      <Card className="p-0">
+        <EmptyState
+          title="미리보기는 새 빌드 만들기 안에서 진행됩니다"
+          description="샘플 행과 컬럼 스키마는 New Build 마법사의 ‘미리보기’ 단계에서 바로 확인할 수 있습니다."
+          actionLabel="새 빌드 만들기"
+          actionHref="/builds/new"
+        />
+      </Card>
     </main>
   );
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,39 +1,36 @@
 /**
- * Studio 환경 설정 확인 화면.
+ * Studio 환경 설정 페이지 (/settings).
  *
- * 현재는 환경 변수로 주입된 Builder API 엔드포인트를 노출해 연결 상태를 점검할 수 있게 한다.
+ * 환경 변수로 주입된 Builder API 엔드포인트를 노출해 연결 상태를 점검할 수 있게 한다.
  */
 import { API_BASE } from "@/shared/config/env";
+import { Card, PageHeader } from "@/shared/ui";
 
 /**
- * 환경 기반 설정 값을 읽어 사용자에게 보여주는 페이지 컴포넌트.
+ * 환경 기반 설정 값을 보여주는 페이지 컴포넌트.
  *
- * @returns 설정 스캐폴드 화면.
+ * @returns 설정 화면.
  */
 export function SettingsPage() {
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-          Settings
-        </p>
-        <h2 className="mt-2 text-3xl font-semibold tracking-tight">Studio configuration scaffold</h2>
-        <p className="mt-3 max-w-2xl text-zinc-600 dark:text-zinc-300">
-          Keep environment-driven API endpoint settings visible while students wire actual persistence later.
-        </p>
-      </div>
+      <PageHeader
+        eyebrow="설정"
+        title="환경 설정"
+        description="Builder API 엔드포인트 등 환경값을 확인합니다. 실제 저장 기능은 이후 연동됩니다."
+      />
 
-      <section className="rounded-[2rem] border border-zinc-200/80 bg-white/80 p-6 dark:border-zinc-800 dark:bg-zinc-950/70">
+      <Card>
         <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-          Builder API endpoint
+          Builder API 엔드포인트
         </p>
         <div className="mt-4 rounded-[1.5rem] border border-dashed border-zinc-300/80 bg-zinc-50/80 p-4 dark:border-zinc-700 dark:bg-zinc-900/80">
-          <p className="text-sm font-medium">Current base URL</p>
+          <p className="text-sm font-medium">현재 base URL</p>
           <code className="mt-3 block break-all text-sm text-emerald-700 dark:text-emerald-400">
             {API_BASE}
           </code>
         </div>
-      </section>
+      </Card>
     </main>
   );
 }

--- a/src/pages/ValidatePage.tsx
+++ b/src/pages/ValidatePage.tsx
@@ -1,54 +1,33 @@
 /**
- * 빌드 스펙 검증 결과를 구조적으로 배치할 워크스페이스 페이지.
+ * 검증 결과 페이지 (/validate, 레거시 딥링크).
  *
- * 오류, 경고, 다음 액션을 구역별로 분리해 사용자가 수정 우선순위를 이해하도록 돕는다.
+ * 검증은 이제 New Build 마법사의 ‘검증·실행’ 단계에 통합되어 있다(제안 §5.4).
+ * 이 화면은 딥링크 호환을 위해 유지하며, 마법사로 안내한다.
  */
-const validationSections = [
-  {
-    title: "Errors",
-    description: "Blocking issues from `POST /validate` will be grouped here.",
-  },
-  {
-    title: "Warnings",
-    description: "Non-blocking feedback for metadata, export choices, and source parameters.",
-  },
-  {
-    title: "Next actions",
-    description: "Guide students toward fixing the draft or proceeding to preview and run stages.",
-  },
-];
+import { Card, EmptyState, PageHeader } from "@/shared/ui";
 
 /**
- * 검증 결과 카드 목록을 렌더링하는 페이지 컴포넌트.
+ * 검증 흐름을 마법사로 안내하는 레거시 페이지.
  *
- * @returns 검증 워크스페이스 화면.
+ * @returns 검증 안내 화면.
  */
 export function ValidatePage() {
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-          Validate
-        </p>
-        <h2 className="mt-2 text-3xl font-semibold tracking-tight">Validation result workspace</h2>
-        <p className="mt-3 max-w-2xl text-zinc-600 dark:text-zinc-300">
-          This route is reserved for structured validation output tied to the current build spec.
-        </p>
-      </div>
+      <PageHeader
+        eyebrow="검증"
+        title="검증 결과"
+        description="입력값과 빌드 설정에서 수정이 필요한 항목을 확인하는 단계입니다."
+      />
 
-      <div className="grid gap-4 xl:grid-cols-3">
-        {validationSections.map((section) => (
-          <section
-            className="rounded-[1.75rem] border border-zinc-200/80 bg-white/80 p-5 dark:border-zinc-800 dark:bg-zinc-950/70"
-            key={section.title}
-          >
-            <h3 className="text-lg font-medium tracking-tight">{section.title}</h3>
-            <p className="mt-3 text-sm leading-6 text-zinc-600 dark:text-zinc-300">
-              {section.description}
-            </p>
-          </section>
-        ))}
-      </div>
+      <Card className="p-0">
+        <EmptyState
+          title="검증은 새 빌드 만들기 안에서 진행됩니다"
+          description="필드별 오류와 수정 가이드는 New Build 마법사의 ‘검증·실행’ 단계에서 바로 확인할 수 있습니다."
+          actionLabel="새 빌드 만들기"
+          actionHref="/builds/new"
+        />
+      </Card>
     </main>
   );
 }


### PR DESCRIPTION
Foundation(#40~#43)에 이어, 남은 페이지를 한국어 + 공통 디자인 시스템으로 마저 정리합니다.

## 포함
- **BuildsPage**(§5.6): PageHeader + 표 헤더(빌드/상태/마지막 실행/액션) + EmptyState CTA
- **SettingsPage**: PageHeader + Card (API base URL)
- **ArtifactsPage**: 결과물은 빌드 단위이므로 전역 화면은 빌드 선택으로 안내(§5.7)
- **ValidatePage/PreviewPage**: 레거시 딥링크 — New Build 마법사의 검증/미리보기 단계로 안내(§5.3/§5.4)
- 전부 한국어 카피, EmptyState 패턴 적용(§11/§15), 렌더 테스트 추가

## 검증
tsc/eslint/vitest/build 통과 (29 tests).

## 스택 안내
`feat/page-polish`(#43) 위에 쌓여 있습니다. #40→#41→#42→#43→#45 순서로 머지해 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)