### PR TITLE
feat: 접근성 — ESC로 사이드바 닫기 + aria-label 한국어화 (UI/UX §12)

### DIFF
--- a/__tests__/layout.test.tsx
+++ b/__tests__/layout.test.tsx
@@ -1,0 +1,28 @@
+import { act, fireEvent, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+import { Layout } from "@/app/Layout";
+import { useUIStore } from "@/shared/hooks/useUIStore";
+
+describe("Layout sidebar accessibility", () => {
+  beforeEach(() => {
+    // jsdom에는 matchMedia가 없으므로 system 테마 분기를 피하도록 light로 고정한다.
+    act(() => useUIStore.setState({ theme: "light", isSidebarOpen: false }));
+  });
+
+  it("closes the open sidebar when Escape is pressed", () => {
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>,
+    );
+
+    // 마운트 시 closeSidebar가 호출되므로, ESC 동작을 검증하기 위해 다시 연다.
+    act(() => useUIStore.setState({ isSidebarOpen: true }));
+    expect(useUIStore.getState().isSidebarOpen).toBe(true);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(useUIStore.getState().isSidebarOpen).toBe(false);
+  });
+});

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -71,12 +71,22 @@ export function Layout() {
     closeSidebar();
   }, [closeSidebar]);
 
+  // 모바일 사이드바가 열려 있을 때 ESC로 닫을 수 있게 한다(접근성, 제안 §12.2).
+  useEffect(() => {
+    if (!isSidebarOpen) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeSidebar();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isSidebarOpen, closeSidebar]);
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="flex min-h-screen">
         {isSidebarOpen ? (
           <button
-            aria-label="Close navigation overlay"
+            aria-label="내비게이션 닫기"
             className="fixed inset-0 z-30 bg-zinc-950/45 lg:hidden"
             onClick={closeSidebar}
             type="button"
@@ -102,7 +112,7 @@ export function Layout() {
               </p>
             </div>
             <button
-              aria-label="Close sidebar"
+              aria-label="사이드바 닫기"
               className="rounded-full border border-zinc-200 p-2 text-zinc-500 lg:hidden dark:border-zinc-800 dark:text-zinc-300"
               onClick={closeSidebar}
               type="button"
@@ -160,7 +170,7 @@ export function Layout() {
             <div className="flex items-center justify-between gap-4 px-5 py-4 sm:px-8">
               <div className="flex items-center gap-3">
                 <button
-                  aria-label="Toggle sidebar"
+                  aria-label="사이드바 열기/닫기"
                   className="inline-flex rounded-full border border-zinc-200 bg-white p-2 text-zinc-700 shadow-sm lg:hidden dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100"
                   onClick={toggleSidebar}
                   type="button"


### PR DESCRIPTION
앱 셸의 접근성 격차를 보완합니다 (§12.2).

## 포함
- 모바일 사이드바가 열려 있을 때 **ESC로 닫기** (열려 있을 때만 keydown 리스너 활성)
- 남은 영어 aria-label(overlay/close/toggle)을 한국어로 통일
- ESC 동작 테스트 추가

## 검증
tsc/eslint/vitest/build 통과 (30 tests).

## 스택 안내
`feat/remaining-pages`(#45) 위에 쌓여 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)