### PR TITLE
feat: New Build 마법사 템플릿 갤러리 (#11)

### DIFF
--- a/__tests__/layout.test.tsx
+++ b/__tests__/layout.test.tsx
@@ -1,0 +1,28 @@
+import { act, fireEvent, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+import { Layout } from "@/app/Layout";
+import { useUIStore } from "@/shared/hooks/useUIStore";
+
+describe("Layout sidebar accessibility", () => {
+  beforeEach(() => {
+    // jsdom에는 matchMedia가 없으므로 system 테마 분기를 피하도록 light로 고정한다.
+    act(() => useUIStore.setState({ theme: "light", isSidebarOpen: false }));
+  });
+
+  it("closes the open sidebar when Escape is pressed", () => {
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>,
+    );
+
+    // 마운트 시 closeSidebar가 호출되므로, ESC 동작을 검증하기 위해 다시 연다.
+    act(() => useUIStore.setState({ isSidebarOpen: true }));
+    expect(useUIStore.getState().isSidebarOpen).toBe(true);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(useUIStore.getState().isSidebarOpen).toBe(false);
+  });
+});

--- a/__tests__/newBuildWizard.test.tsx
+++ b/__tests__/newBuildWizard.test.tsx
@@ -11,24 +11,37 @@ function renderWizard() {
   );
 }
 
+// 마법사는 템플릿 단계에서 시작한다(#11). 식별 단계로 넘어가는 헬퍼.
+function skipTemplateStep() {
+  fireEvent.click(screen.getByRole("button", { name: "다음" }));
+}
+
 describe("New Build Wizard", () => {
-  it("starts on the first step", () => {
+  it("starts on the template step", () => {
     renderWizard();
+    expect(screen.getByRole("heading", { name: "템플릿 선택" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /대기오염 정보/ })).toBeInTheDocument();
+  });
+
+  it("selecting a template prefills the form and advances to identity", () => {
+    renderWizard();
+    fireEvent.click(screen.getByRole("button", { name: /대기오염 정보/ }));
+
     expect(screen.getByRole("heading", { name: "기본 정보" })).toBeInTheDocument();
-    // 스텝퍼 + 헤딩 모두에 "기본 정보"가 나타난다(최소 2곳).
-    expect(screen.getAllByText("기본 정보").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByLabelText(/데이터셋 ID/)).toHaveValue("datago-air-quality");
   });
 
   it("blocks advancing while required fields are empty", async () => {
     renderWizard();
+    skipTemplateStep(); // 템플릿 → 기본 정보
     fireEvent.click(screen.getByRole("button", { name: "다음" }));
     expect(await screen.findByText(/데이터셋 ID를 입력해주세요/)).toBeInTheDocument();
-    // 검증 실패로 1단계 헤딩에 머문다.
     expect(screen.getByRole("heading", { name: "기본 정보" })).toBeInTheDocument();
   });
 
   it("advances to the source step once identity fields are filled", async () => {
     renderWizard();
+    skipTemplateStep();
     fireEvent.change(screen.getByLabelText(/데이터셋 ID/), { target: { value: "kma-daily" } });
     fireEvent.change(screen.getByLabelText(/제목/), { target: { value: "기상청 일별" } });
     fireEvent.change(screen.getByLabelText(/설명/), { target: { value: "일별 관측 데이터" } });
@@ -41,24 +54,21 @@ describe("New Build Wizard", () => {
 
   it("blocks the params step when the JSON is invalid", async () => {
     renderWizard();
-    // 1단계: 기본 정보
+    skipTemplateStep();
     fireEvent.change(screen.getByLabelText(/데이터셋 ID/), { target: { value: "kma-daily" } });
     fireEvent.change(screen.getByLabelText(/제목/), { target: { value: "기상청 일별" } });
     fireEvent.change(screen.getByLabelText(/설명/), { target: { value: "일별 관측" } });
     fireEvent.click(screen.getByRole("button", { name: "다음" }));
 
-    // 2단계: 데이터 소스
     await screen.findByRole("heading", { name: "데이터 소스" });
     fireEvent.change(screen.getByLabelText(/제공자/), { target: { value: "datago" } });
     fireEvent.change(screen.getByLabelText(/데이터셋/), { target: { value: "air-quality" } });
     fireEvent.click(screen.getByRole("button", { name: "다음" }));
 
-    // 3단계: 파라미터 — 잘못된 JSON 입력 후 다음 시도
     await screen.findByRole("heading", { name: "파라미터" });
     fireEvent.change(screen.getByLabelText(/요청 파라미터/), { target: { value: "{not json" } });
     fireEvent.click(screen.getByRole("button", { name: "다음" }));
 
-    // JSON 오류가 필드에 표시되고 단계 이동이 막힌다.
     expect(await screen.findByText(/올바른 JSON이 아닙니다/)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "파라미터" })).toBeInTheDocument();
   });

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -71,12 +71,22 @@ export function Layout() {
     closeSidebar();
   }, [closeSidebar]);
 
+  // 모바일 사이드바가 열려 있을 때 ESC로 닫을 수 있게 한다(접근성, 제안 §12.2).
+  useEffect(() => {
+    if (!isSidebarOpen) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeSidebar();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isSidebarOpen, closeSidebar]);
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="flex min-h-screen">
         {isSidebarOpen ? (
           <button
-            aria-label="Close navigation overlay"
+            aria-label="내비게이션 닫기"
             className="fixed inset-0 z-30 bg-zinc-950/45 lg:hidden"
             onClick={closeSidebar}
             type="button"
@@ -102,7 +112,7 @@ export function Layout() {
               </p>
             </div>
             <button
-              aria-label="Close sidebar"
+              aria-label="사이드바 닫기"
               className="rounded-full border border-zinc-200 p-2 text-zinc-500 lg:hidden dark:border-zinc-800 dark:text-zinc-300"
               onClick={closeSidebar}
               type="button"
@@ -160,7 +170,7 @@ export function Layout() {
             <div className="flex items-center justify-between gap-4 px-5 py-4 sm:px-8">
               <div className="flex items-center gap-3">
                 <button
-                  aria-label="Toggle sidebar"
+                  aria-label="사이드바 열기/닫기"
                   className="inline-flex rounded-full border border-zinc-200 bg-white p-2 text-zinc-700 shadow-sm lg:hidden dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100"
                   onClick={toggleSidebar}
                   type="button"

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -59,7 +59,70 @@ const initialValues: BuildFormValues = {
   exportFormats: ["jsonl"],
 };
 
+// 빌드 시작 템플릿(제안 §5.2.1). 선택 시 폼을 해당 값으로 채우고 다음 단계로 넘어간다.
+interface BuildTemplate {
+  id: string;
+  name: string;
+  description: string;
+  values: BuildFormValues;
+}
+
+const TEMPLATES: BuildTemplate[] = [
+  {
+    id: "blank",
+    name: "빈 빌드",
+    description: "아무 값 없이 처음부터 직접 설정합니다.",
+    values: initialValues,
+  },
+  {
+    id: "air_quality",
+    name: "대기오염 정보",
+    description: "data.go.kr 대기오염 측정 데이터로 시작합니다.",
+    values: {
+      datasetId: "datago-air-quality",
+      title: "대기오염 정보",
+      description: "data.go.kr 대기오염 측정 데이터셋",
+      provider: "datago",
+      sourceDataset: "air-quality",
+      sourceParams: '{"sidoName": "서울"}',
+      outputPath: "artifacts/builds/air-quality",
+      exportFormats: ["jsonl"],
+    },
+  },
+  {
+    id: "weather",
+    name: "기상 관측",
+    description: "기상청 일별 관측 데이터로 시작합니다.",
+    values: {
+      datasetId: "kma-daily-observations",
+      title: "기상청 일별 관측",
+      description: "기상청 일별 지상 관측 데이터셋",
+      provider: "kma",
+      sourceDataset: "daily-observations",
+      sourceParams: '{"stn": "108"}',
+      outputPath: "artifacts/builds/kma-daily",
+      exportFormats: ["jsonl", "parquet"],
+    },
+  },
+  {
+    id: "population",
+    name: "인구 통계",
+    description: "통계청(KOSIS) 인구 통계로 시작합니다.",
+    values: {
+      datasetId: "kosis-population",
+      title: "인구 통계",
+      description: "통계청 KOSIS 인구 통계 데이터셋",
+      provider: "kosis",
+      sourceDataset: "population",
+      sourceParams: '{"region": "11"}',
+      outputPath: "artifacts/builds/population",
+      exportFormats: ["jsonl"],
+    },
+  },
+];
+
 const STEPS: StepItem[] = [
+  { id: "template", label: "템플릿" },
   { id: "identity", label: "기본 정보" },
   { id: "source", label: "데이터 소스" },
   { id: "params", label: "파라미터" },
@@ -68,8 +131,9 @@ const STEPS: StepItem[] = [
   { id: "review", label: "검증·실행" },
 ];
 
-// 각 단계에서 Next 진입 전에 검증할 폼 필드. Preview/Review 단계는 입력 필드가 없다.
+// 각 단계에서 Next 진입 전에 검증할 폼 필드. Template/Preview/Review 단계는 입력 필드가 없다.
 const STEP_FIELDS: Array<Array<keyof BuildFormValues>> = [
+  [],
   ["datasetId", "title", "description"],
   ["provider", "sourceDataset"],
   ["sourceParams"],
@@ -164,12 +228,19 @@ export function NewBuildPage() {
     trigger,
     watch,
     getValues,
+    reset,
   } = useForm<BuildFormValues>({ defaultValues: initialValues, mode: "onChange" });
 
   const values = watch();
   const specPreview = useMemo(() => toBuildSpec(values), [values]);
 
   const draftStatus = validation.isValid ? "validated" : isDirty ? "dirty" : "new";
+
+  // 템플릿을 선택하면 폼을 해당 값으로 채우고 기본 정보 단계로 넘어간다 (#11).
+  function selectTemplate(template: BuildTemplate) {
+    reset(template.values);
+    setStep(1);
+  }
 
   async function goNext() {
     const fields = STEP_FIELDS[step];
@@ -230,6 +301,30 @@ export function NewBuildPage() {
         <Card>
           {step === 0 ? (
             <div className="space-y-4">
+              <h3 className="text-xl font-semibold tracking-tight">템플릿 선택</h3>
+              <p className="text-sm text-zinc-600 dark:text-zinc-300">
+                자주 쓰는 공공데이터 조합으로 시작하거나 빈 빌드로 처음부터 설정하세요.
+              </p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {TEMPLATES.map((template) => (
+                  <button
+                    key={template.id}
+                    type="button"
+                    onClick={() => selectTemplate(template)}
+                    className="rounded-2xl border border-zinc-200/80 bg-white/80 p-4 text-left transition hover:border-zinc-300 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-800 dark:bg-zinc-950/70"
+                  >
+                    <p className="text-base font-semibold tracking-tight">{template.name}</p>
+                    <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-300">
+                      {template.description}
+                    </p>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {step === 1 ? (
+            <div className="space-y-4">
               <h3 className="text-xl font-semibold tracking-tight">기본 정보</h3>
               <FormField
                 id="datasetId"
@@ -273,7 +368,7 @@ export function NewBuildPage() {
             </div>
           ) : null}
 
-          {step === 1 ? (
+          {step === 2 ? (
             <div className="space-y-4">
               <h3 className="text-xl font-semibold tracking-tight">데이터 소스</h3>
               <FormField id="provider" label="제공자 (Provider)" required error={errors.provider?.message}>
@@ -306,7 +401,7 @@ export function NewBuildPage() {
             </div>
           ) : null}
 
-          {step === 2 ? (
+          {step === 3 ? (
             <div className="space-y-4">
               <h3 className="text-xl font-semibold tracking-tight">파라미터</h3>
               <FormField
@@ -330,7 +425,7 @@ export function NewBuildPage() {
             </div>
           ) : null}
 
-          {step === 3 ? (
+          {step === 4 ? (
             <div className="space-y-4">
               <div className="flex items-center justify-between">
                 <h3 className="text-xl font-semibold tracking-tight">미리보기</h3>
@@ -369,7 +464,7 @@ export function NewBuildPage() {
             </div>
           ) : null}
 
-          {step === 4 ? (
+          {step === 5 ? (
             <div className="space-y-4">
               <h3 className="text-xl font-semibold tracking-tight">출력 형식</h3>
               <fieldset>
@@ -418,7 +513,7 @@ export function NewBuildPage() {
             </div>
           ) : null}
 
-          {step === 5 ? (
+          {step === 6 ? (
             <div className="space-y-4">
               <div className="flex items-center justify-between">
                 <h3 className="text-xl font-semibold tracking-tight">검증·실행</h3>

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -237,8 +237,11 @@ export function NewBuildPage() {
   const draftStatus = validation.isValid ? "validated" : isDirty ? "dirty" : "new";
 
   // 템플릿을 선택하면 폼을 해당 값으로 채우고 기본 정보 단계로 넘어간다 (#11).
+  // 이전 템플릿에서 로드된 미리보기/검증 결과가 남지 않도록 함께 초기화한다.
   function selectTemplate(template: BuildTemplate) {
     reset(template.values);
+    setPreview({ status: "idle", rows: [], schema: {} });
+    setValidation({ status: "idle", isValid: false, errors: [] });
     setStep(1);
   }
 


### PR DESCRIPTION
New Build 마법사 첫 단계에 **템플릿 선택**을 추가합니다 (UI/UX §5.2.1, #11).

## 포함
- 마법사 0단계 "템플릿": 빈 빌드 / 대기오염 정보 / 기상 관측 / 인구 통계
- 템플릿 선택 시 폼을 프리셋 값으로 채우고(reset) 기본 정보 단계로 이동 → 빈 화면에서 시작하지 않음
- 기존 콘텐츠 단계 인덱스 +1 재배치, STEPS/STEP_FIELDS에 템플릿 단계 추가
- 테스트: 템플릿 시작 / 선택 시 프리필 / 단계 오프셋 반영 검증

## 검증
tsc/eslint/vitest/build 통과 (31 tests).

Closes #11

## 스택 안내
`feat/a11y-shell`(#46) 위에 쌓여 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)