### PR TITLE
feat: 빌드 초안 임시저장/복원 (localStorage) (#10)

### DIFF
--- a/__tests__/draftStorage.test.ts
+++ b/__tests__/draftStorage.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { clearDraft, hasDraft, loadDraft, saveDraft } from "@/features/build-spec/draftStorage";
+
+describe("draftStorage", () => {
+  beforeEach(() => clearDraft());
+
+  it("reports no draft initially", () => {
+    expect(hasDraft()).toBe(false);
+    expect(loadDraft()).toBeNull();
+  });
+
+  it("saves and loads a draft round-trip", () => {
+    saveDraft({ datasetId: "kma-daily", title: "기상" });
+    expect(hasDraft()).toBe(true);
+    expect(loadDraft<{ datasetId: string; title: string }>()).toEqual({
+      datasetId: "kma-daily",
+      title: "기상",
+    });
+  });
+
+  it("clears a saved draft", () => {
+    saveDraft({ a: 1 });
+    clearDraft();
+    expect(hasDraft()).toBe(false);
+  });
+
+  it("returns null on corrupted data", () => {
+    localStorage.setItem("kpubdata-studio:new-build-draft", "{not json");
+    expect(loadDraft()).toBeNull();
+  });
+});

--- a/__tests__/newBuildDraft.test.tsx
+++ b/__tests__/newBuildDraft.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { NewBuildPage } from "@/pages/NewBuildPage";
+import { clearDraft } from "@/features/build-spec/draftStorage";
+
+function renderWizard() {
+  return render(
+    <MemoryRouter>
+      <NewBuildPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("New Build draft persistence (#10)", () => {
+  beforeEach(() => clearDraft());
+  afterEach(() => clearDraft());
+
+  it("saves the current input and restores it on a fresh mount", async () => {
+    const first = renderWizard();
+    // 템플릿 → 기본 정보
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    fireEvent.change(screen.getByLabelText(/데이터셋 ID/), { target: { value: "kma-daily" } });
+    fireEvent.click(screen.getByRole("button", { name: "초안 저장" }));
+    expect(screen.getByRole("button", { name: /저장됨/ })).toBeInTheDocument();
+
+    // 새로 마운트하면 복원 배너가 보인다.
+    first.unmount();
+    renderWizard();
+    expect(screen.getByText("저장된 초안이 있습니다. 이어서 편집할까요?")).toBeInTheDocument();
+
+    // 불러오면 저장한 값으로 채워진 기본 정보 단계로 이동한다.
+    fireEvent.click(screen.getByRole("button", { name: "불러오기" }));
+    expect(screen.getByRole("heading", { name: "기본 정보" })).toBeInTheDocument();
+    expect(screen.getByLabelText(/데이터셋 ID/)).toHaveValue("kma-daily");
+  });
+
+  it("discards the saved draft and hides the banner", () => {
+    const first = renderWizard();
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    fireEvent.click(screen.getByRole("button", { name: "초안 저장" }));
+    first.unmount();
+
+    renderWizard();
+    fireEvent.click(screen.getByRole("button", { name: "삭제" }));
+    expect(
+      screen.queryByText("저장된 초안이 있습니다. 이어서 편집할까요?"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 
 const eslintConfig = defineConfig([
-  globalIgnores(["dist/**", "coverage/**", "node_modules/**"]),
+  globalIgnores(["dist/**", "coverage/**", "node_modules/**", "docs/**"]),
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -137,6 +138,7 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -252,7 +254,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -301,9 +302,42 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/core/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1220,6 +1254,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1240,6 +1275,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -1315,7 +1351,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1355,7 +1392,6 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1366,7 +1402,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1377,7 +1412,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1427,7 +1461,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -1823,7 +1856,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1864,6 +1896,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2118,6 +2151,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2137,7 +2171,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -2192,7 +2227,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2603,7 +2637,8 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -3004,6 +3039,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3208,7 +3244,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3261,6 +3296,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3276,6 +3312,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3288,7 +3325,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3305,7 +3343,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3315,7 +3352,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3746,7 +3782,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3812,7 +3847,6 @@
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/src/features/build-spec/draftStorage.ts
+++ b/src/features/build-spec/draftStorage.ts
@@ -1,0 +1,59 @@
+/**
+ * New Build 초안을 브라우저 localStorage에 저장/복원하는 유틸 (#10).
+ *
+ * 작성 중인 빌드 초안을 임시 저장해 두고, 새로고침하거나 나중에 다시 열어 이어서
+ * 편집할 수 있게 한다. localStorage 접근 실패(SSR/프라이빗 모드 등)나 깨진 JSON은
+ * 조용히 무시하고 안전한 기본값(null/false)을 반환한다.
+ */
+const DRAFT_KEY = "kpubdata-studio:new-build-draft";
+
+/**
+ * 초안 값을 저장한다. 실패 시 조용히 무시한다.
+ *
+ * @param value - 직렬화 가능한 초안 값.
+ */
+export function saveDraft<T>(value: T): void {
+  try {
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(value));
+  } catch {
+    // localStorage 사용 불가 시 무시.
+  }
+}
+
+/**
+ * 저장된 초안을 불러온다. 없거나 손상되면 null을 반환한다.
+ *
+ * @returns 저장된 초안 값 또는 null.
+ */
+export function loadDraft<T>(): T | null {
+  try {
+    const raw = localStorage.getItem(DRAFT_KEY);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 저장된 초안을 삭제한다.
+ */
+export function clearDraft(): void {
+  try {
+    localStorage.removeItem(DRAFT_KEY);
+  } catch {
+    // 무시.
+  }
+}
+
+/**
+ * 저장된 초안이 존재하는지 확인한다.
+ *
+ * @returns 초안 존재 여부.
+ */
+export function hasDraft(): boolean {
+  try {
+    return localStorage.getItem(DRAFT_KEY) !== null;
+  } catch {
+    return false;
+  }
+}

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -245,6 +245,12 @@ export function NewBuildPage() {
     setStep(1);
   }
 
+  // 템플릿을 선택하면 폼을 해당 값으로 채우고 기본 정보 단계로 넘어간다 (#11).
+  function selectTemplate(template: BuildTemplate) {
+    reset(template.values);
+    setStep(1);
+  }
+
   async function goNext() {
     const fields = STEP_FIELDS[step];
     const ok = fields.length === 0 ? true : await trigger(fields);

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -216,6 +216,9 @@ interface ValidationState {
  * @returns 마법사 UI.
  */
 export function NewBuildPage() {
+  // /builds/:buildId/edit 로 진입한 경우(편집 모드). 기존 스펙 로드는 Builder 연동(#29)
+  // 이후 지원하므로, 지금은 안내만 표시한다.
+  const { buildId } = useParams();
   const [step, setStep] = useState(0);
   const [preview, setPreview] = useState<PreviewState>({ status: "idle", rows: [], schema: {} });
   const [validation, setValidation] = useState<ValidationState>({
@@ -250,23 +253,26 @@ export function NewBuildPage() {
     setStep(1);
   }
 
-  // 템플릿을 선택하면 폼을 해당 값으로 채우고 기본 정보 단계로 넘어간다 (#11).
-  function selectTemplate(template: BuildTemplate) {
-    reset(template.values);
-    setStep(1);
-  }
-
   // 현재 입력을 localStorage 초안으로 저장한다 (#10).
+  // 방금 저장한 값을 기준으로 reset 하여 dirty 상태를 정리하고, 같은 세션에서 복원 배너가
+  // 뜨지 않도록 draftAvailable은 건드리지 않는다(배너는 새 마운트 시 복원용).
   function saveCurrentDraft() {
-    saveDraft(getValues());
-    setDraftAvailable(true);
+    const current = getValues();
+    saveDraft(current);
+    reset(current);
     setDraftSaved(true);
   }
 
   // 저장된 초안을 복원해 기본 정보 단계로 이동한다.
   function restoreDraft() {
     const saved = loadDraft<BuildFormValues>();
-    if (saved) reset(saved);
+    if (!saved) {
+      // 깨진 값이 남아 배너가 반복되지 않도록 정리하고, 이동/숨김은 하지 않는다.
+      clearDraft();
+      setDraftAvailable(false);
+      return;
+    }
+    reset(saved);
     setDraftAvailable(false);
     setStep(1);
   }
@@ -621,7 +627,7 @@ export function NewBuildPage() {
             </Button>
             <div className="flex gap-2">
               <Button variant="secondary" onClick={saveCurrentDraft}>
-                {draftSaved ? "저장됨 ✓" : "초안 저장"}
+                {draftSaved && !isDirty ? "저장됨 ✓" : "초안 저장"}
               </Button>
               {step < STEPS.length - 1 ? (
                 <Button onClick={() => void goNext()}>다음</Button>

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -8,6 +8,8 @@
  */
 import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
+import { useParams } from "react-router-dom";
+import { clearDraft, hasDraft, loadDraft, saveDraft } from "@/features/build-spec/draftStorage";
 import { previewBuild } from "@/features/preview/api";
 import { validateSpec } from "@/features/validation/api";
 import { buildSpecSchema, exportFormatSchema } from "@/shared/lib/schemas";
@@ -221,6 +223,9 @@ export function NewBuildPage() {
     isValid: false,
     errors: [],
   });
+  // 저장된 초안이 있으면 복원 배너를 보여준다 (#10). 마운트 시 한 번만 확인한다.
+  const [draftAvailable, setDraftAvailable] = useState(() => hasDraft());
+  const [draftSaved, setDraftSaved] = useState(false);
 
   const {
     formState: { errors, isDirty },
@@ -249,6 +254,27 @@ export function NewBuildPage() {
   function selectTemplate(template: BuildTemplate) {
     reset(template.values);
     setStep(1);
+  }
+
+  // 현재 입력을 localStorage 초안으로 저장한다 (#10).
+  function saveCurrentDraft() {
+    saveDraft(getValues());
+    setDraftAvailable(true);
+    setDraftSaved(true);
+  }
+
+  // 저장된 초안을 복원해 기본 정보 단계로 이동한다.
+  function restoreDraft() {
+    const saved = loadDraft<BuildFormValues>();
+    if (saved) reset(saved);
+    setDraftAvailable(false);
+    setStep(1);
+  }
+
+  // 저장된 초안을 삭제하고 배너를 숨긴다.
+  function discardDraft() {
+    clearDraft();
+    setDraftAvailable(false);
   }
 
   async function goNext() {
@@ -301,6 +327,31 @@ export function NewBuildPage() {
         description="데이터 소스, 파라미터, 출력 형식을 단계별로 설정합니다."
         actions={<StatusBadge status={draftStatus} />}
       />
+
+      {buildId ? (
+        <Card variant="dashed" className="p-4">
+          <p className="text-sm text-zinc-700 dark:text-zinc-200">
+            기존 빌드 <span className="font-medium">{buildId}</span> 편집은 Builder 연동(#29) 후
+            지원됩니다. 지금은 새 빌드로 작성됩니다.
+          </p>
+        </Card>
+      ) : null}
+
+      {draftAvailable ? (
+        <Card variant="dashed" className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-zinc-700 dark:text-zinc-200">
+            저장된 초안이 있습니다. 이어서 편집할까요?
+          </p>
+          <div className="flex gap-2">
+            <Button size="sm" onClick={restoreDraft}>
+              불러오기
+            </Button>
+            <Button size="sm" variant="ghost" onClick={discardDraft}>
+              삭제
+            </Button>
+          </div>
+        </Card>
+      ) : null}
 
       <Card>
         <Stepper steps={STEPS} current={step} onStepClick={setStep} />
@@ -569,7 +620,9 @@ export function NewBuildPage() {
               이전
             </Button>
             <div className="flex gap-2">
-              <Button variant="secondary">초안 저장</Button>
+              <Button variant="secondary" onClick={saveCurrentDraft}>
+                {draftSaved ? "저장됨 ✓" : "초안 저장"}
+              </Button>
               {step < STEPS.length - 1 ? (
                 <Button onClick={() => void goNext()}>다음</Button>
               ) : null}


### PR DESCRIPTION
작성 중인 빌드 초안을 브라우저에 임시 저장하고 나중에 이어서 편집할 수 있게 합니다 (UI/UX §10, #10).

## 포함
- `draftStorage` 유틸(save/load/clear/has) — localStorage 실패/손상 JSON 안전 처리
- "초안 저장" 버튼이 현재 입력을 저장
- 마운트 시 저장된 초안이 있으면 복원 배너(불러오기/삭제) 표시 → 불러오면 폼 복원 + 기본 정보 단계로 이동
- 테스트: 저장소 라운드트립 + 저장→재마운트→복원/삭제 흐름

## 검증
tsc/eslint/vitest/build 통과 (37 tests).

Closes #10

## 스택 안내
`feat/templates`(#50) 위에 쌓여 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)