### PR TITLE
feat: Builder API 클라이언트 토대 + /version 연동 (#29)

### DIFF
--- a/__tests__/buildRoutes.test.tsx
+++ b/__tests__/buildRoutes.test.tsx
@@ -35,9 +35,11 @@ describe("build-centric routes", () => {
     expect(screen.getByText("수집")).toBeInTheDocument();
   });
 
-  it("renders the artifacts page with a manifest section", () => {
+  it("renders the artifacts page with a manifest section", async () => {
     renderAt("/builds/abc/artifacts", <BuildArtifactsPage />);
-    expect(screen.getByText("Manifest 요약")).toBeInTheDocument();
+    // manifest는 비동기로 로드되므로 로드 후 요약이 나타난다.
+    expect(await screen.findByText("Manifest 요약")).toBeInTheDocument();
+    expect(screen.getByText(/12,304/)).toBeInTheDocument();
   });
 
   it("renders the publish page with destination options", () => {

--- a/__tests__/builderApi.test.ts
+++ b/__tests__/builderApi.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError, apiFetch, builderApi } from "@/shared/lib/builderApi";
+
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("builderApi client (#29)", () => {
+  it("version() GETs /version and returns the parsed body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { service: "kpubdata-builder", api_version: "1.0.0" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await builderApi.version();
+
+    expect(result.api_version).toBe("1.0.0");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/version");
+    expect(init.method).toBe("GET");
+  });
+
+  it("build() POSTs spec + run_id as JSON", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, {
+        status: "ok",
+        run_id: "run1",
+        outcomes: [],
+        manifest: "m.json",
+        api_version: "1.0.0",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await builderApi.build("dataset_id: x", "run1");
+
+    expect(result.run_id).toBe("run1");
+    const init = fetchMock.mock.calls[0][1];
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ spec: "dataset_id: x", run_id: "run1" });
+  });
+
+  it("throws ApiError with the server message on a non-2xx response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse(400, { error: "bad spec" })));
+
+    await expect(apiFetch("/validate", { method: "POST", body: { spec: "" } })).rejects.toMatchObject(
+      { name: "ApiError", status: 400, message: "bad spec" },
+    );
+  });
+
+  it("throws ApiError(0) when the network call fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+
+    const error = await apiFetch("/version").catch((cause) => cause);
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(0);
+  });
+});

--- a/__tests__/buildsHistory.test.tsx
+++ b/__tests__/buildsHistory.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { BuildsPage } from "@/pages/BuildsPage";
+
+function renderBuilds() {
+  return render(
+    <MemoryRouter>
+      <BuildsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("Builds run history (#12)", () => {
+  it("renders rows with status badges and a view link", async () => {
+    renderBuilds();
+    expect(await screen.findByText("대기오염 정보")).toBeInTheDocument();
+    expect(screen.getByText("성공")).toBeInTheDocument(); // succeeded badge
+    expect(screen.getByText("실패")).toBeInTheDocument(); // failed badge
+    expect(screen.getAllByRole("link", { name: "보기" }).length).toBe(3);
+  });
+
+  it("filters the history by title search", async () => {
+    renderBuilds();
+    await screen.findByText("대기오염 정보");
+
+    fireEvent.change(screen.getByLabelText("빌드 제목 검색"), { target: { value: "인구" } });
+
+    await waitFor(() => {
+      expect(screen.queryByText("대기오염 정보")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("인구 통계")).toBeInTheDocument();
+  });
+});

--- a/__tests__/draftStorage.test.ts
+++ b/__tests__/draftStorage.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { clearDraft, hasDraft, loadDraft, saveDraft } from "@/features/build-spec/draftStorage";
+
+describe("draftStorage", () => {
+  beforeEach(() => clearDraft());
+
+  it("reports no draft initially", () => {
+    expect(hasDraft()).toBe(false);
+    expect(loadDraft()).toBeNull();
+  });
+
+  it("saves and loads a draft round-trip", () => {
+    saveDraft({ datasetId: "kma-daily", title: "기상" });
+    expect(hasDraft()).toBe(true);
+    expect(loadDraft<{ datasetId: string; title: string }>()).toEqual({
+      datasetId: "kma-daily",
+      title: "기상",
+    });
+  });
+
+  it("clears a saved draft", () => {
+    saveDraft({ a: 1 });
+    clearDraft();
+    expect(hasDraft()).toBe(false);
+  });
+
+  it("returns null on corrupted data", () => {
+    localStorage.setItem("kpubdata-studio:new-build-draft", "{not json");
+    expect(loadDraft()).toBeNull();
+  });
+});

--- a/__tests__/newBuildDraft.test.tsx
+++ b/__tests__/newBuildDraft.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { NewBuildPage } from "@/pages/NewBuildPage";
+import { clearDraft } from "@/features/build-spec/draftStorage";
+
+function renderWizard() {
+  return render(
+    <MemoryRouter>
+      <NewBuildPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("New Build draft persistence (#10)", () => {
+  beforeEach(() => clearDraft());
+  afterEach(() => clearDraft());
+
+  it("saves the current input and restores it on a fresh mount", async () => {
+    const first = renderWizard();
+    // 템플릿 → 기본 정보
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    fireEvent.change(screen.getByLabelText(/데이터셋 ID/), { target: { value: "kma-daily" } });
+    fireEvent.click(screen.getByRole("button", { name: "초안 저장" }));
+    expect(screen.getByRole("button", { name: /저장됨/ })).toBeInTheDocument();
+
+    // 새로 마운트하면 복원 배너가 보인다.
+    first.unmount();
+    renderWizard();
+    expect(screen.getByText("저장된 초안이 있습니다. 이어서 편집할까요?")).toBeInTheDocument();
+
+    // 불러오면 저장한 값으로 채워진 기본 정보 단계로 이동한다.
+    fireEvent.click(screen.getByRole("button", { name: "불러오기" }));
+    expect(screen.getByRole("heading", { name: "기본 정보" })).toBeInTheDocument();
+    expect(screen.getByLabelText(/데이터셋 ID/)).toHaveValue("kma-daily");
+  });
+
+  it("discards the saved draft and hides the banner", () => {
+    const first = renderWizard();
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    fireEvent.click(screen.getByRole("button", { name: "초안 저장" }));
+    first.unmount();
+
+    renderWizard();
+    fireEvent.click(screen.getByRole("button", { name: "삭제" }));
+    expect(
+      screen.queryByText("저장된 초안이 있습니다. 이어서 편집할까요?"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/remainingPages.test.tsx
+++ b/__tests__/remainingPages.test.tsx
@@ -13,10 +13,11 @@ function renderPage(element: ReactNode) {
 }
 
 describe("remaining pages", () => {
-  it("BuildsPage shows the Korean heading and an empty-state CTA", () => {
+  it("BuildsPage shows the Korean heading and loads run history", async () => {
     renderPage(<BuildsPage />);
     expect(screen.getByRole("heading", { name: "빌드 목록" })).toBeInTheDocument();
-    expect(screen.getByText("아직 생성된 빌드가 없습니다")).toBeInTheDocument();
+    // mock 실행 이력이 로드된다.
+    expect(await screen.findByText("대기오염 정보")).toBeInTheDocument();
   });
 
   it("SettingsPage shows the API base URL section", () => {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 
 const eslintConfig = defineConfig([
-  globalIgnores(["dist/**", "coverage/**", "node_modules/**"]),
+  globalIgnores(["dist/**", "coverage/**", "node_modules/**", "docs/**"]),
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -137,6 +138,7 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -252,7 +254,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -301,9 +302,42 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/core/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1220,6 +1254,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1240,6 +1275,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -1315,7 +1351,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1355,7 +1392,6 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1366,7 +1402,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1377,7 +1412,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1427,7 +1461,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -1823,7 +1856,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1864,6 +1896,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2118,6 +2151,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2137,7 +2171,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -2192,7 +2227,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2603,7 +2637,8 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -3004,6 +3039,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3208,7 +3244,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3261,6 +3296,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3276,6 +3312,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3288,7 +3325,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3305,7 +3343,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3315,7 +3352,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3746,7 +3782,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3812,7 +3847,6 @@
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/src/features/artifacts/api/index.ts
+++ b/src/features/artifacts/api/index.ts
@@ -1,19 +1,42 @@
 /**
  * 빌드 결과 아티팩트/manifest 조회 API 진입점.
  *
- * 현재는 스텁 예외를 던지지만, 이후 Builder 결과 조회 엔드포인트를 감싸게 된다.
+ * 실제 Builder 연동(#29) 전까지는 결정적 mock manifest를 반환해 뷰어 UI를 개발/검증할 수
+ * 있게 한다. #29에서 이 함수를 실제 HTTP 호출로 교체한다.
  */
 import { API_BASE } from "@/shared/config/env";
 import type { BuildManifest } from "@/shared/lib/types";
 
 /**
+ * 빌드 ID 기반의 결정적 mock manifest를 만든다(#30, #29 연동 전 임시).
+ *
+ * @param buildId - 빌드 실행 ID.
+ * @returns mock BuildManifest.
+ */
+function mockManifest(buildId: string): BuildManifest {
+  return {
+    buildId,
+    startedAt: "2026-06-21T00:00:00.000Z",
+    finishedAt: "2026-06-21T00:00:08.000Z",
+    sources: [{ provider: "datago", dataset: "air-quality", params: { sidoName: "서울" } }],
+    artifactPaths: [
+      `artifacts/builds/${buildId}/data.jsonl`,
+      `artifacts/builds/${buildId}/README.md`,
+      `artifacts/builds/${buildId}/manifest.json`,
+    ],
+    recordCount: 12304,
+    warnings: [],
+    errors: [],
+  };
+}
+
+/**
  * 특정 빌드 실행의 manifest 정보를 조회한다.
  *
- * @param _buildId - 조회 대상 빌드 실행 ID.
- * @returns 빌드 manifest 정보.
- * @throws Error 아직 실제 API 연동이 구현되지 않았을 때 발생한다.
+ * @param buildId - 조회 대상 빌드 실행 ID.
+ * @returns 빌드 manifest 정보(현재는 mock).
  */
-export async function getBuildManifest(_buildId: string): Promise<BuildManifest> {
+export async function getBuildManifest(buildId: string): Promise<BuildManifest> {
   void API_BASE;
-  throw new Error("Not implemented");
+  return mockManifest(buildId);
 }

--- a/src/features/build-spec/draftStorage.ts
+++ b/src/features/build-spec/draftStorage.ts
@@ -1,0 +1,59 @@
+/**
+ * New Build 초안을 브라우저 localStorage에 저장/복원하는 유틸 (#10).
+ *
+ * 작성 중인 빌드 초안을 임시 저장해 두고, 새로고침하거나 나중에 다시 열어 이어서
+ * 편집할 수 있게 한다. localStorage 접근 실패(SSR/프라이빗 모드 등)나 깨진 JSON은
+ * 조용히 무시하고 안전한 기본값(null/false)을 반환한다.
+ */
+const DRAFT_KEY = "kpubdata-studio:new-build-draft";
+
+/**
+ * 초안 값을 저장한다. 실패 시 조용히 무시한다.
+ *
+ * @param value - 직렬화 가능한 초안 값.
+ */
+export function saveDraft<T>(value: T): void {
+  try {
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(value));
+  } catch {
+    // localStorage 사용 불가 시 무시.
+  }
+}
+
+/**
+ * 저장된 초안을 불러온다. 없거나 손상되면 null을 반환한다.
+ *
+ * @returns 저장된 초안 값 또는 null.
+ */
+export function loadDraft<T>(): T | null {
+  try {
+    const raw = localStorage.getItem(DRAFT_KEY);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 저장된 초안을 삭제한다.
+ */
+export function clearDraft(): void {
+  try {
+    localStorage.removeItem(DRAFT_KEY);
+  } catch {
+    // 무시.
+  }
+}
+
+/**
+ * 저장된 초안이 존재하는지 확인한다.
+ *
+ * @returns 초안 존재 여부.
+ */
+export function hasDraft(): boolean {
+  try {
+    return localStorage.getItem(DRAFT_KEY) !== null;
+  } catch {
+    return false;
+  }
+}

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -17,3 +17,49 @@ export async function executeBuild(_spec: BuildSpec): Promise<BuildRun> {
   void API_BASE;
   throw new Error("Not implemented");
 }
+
+/** 목록/이력 UI 개발용 결정적 mock 스펙을 만든다. */
+function mockSpec(datasetId: string, title: string): BuildSpec {
+  return {
+    datasetId,
+    title,
+    description: `${title} 빌드`,
+    sources: [{ provider: "datago", dataset: datasetId, params: {} }],
+    exports: [{ format: "jsonl" }],
+    metadata: {},
+  };
+}
+
+/**
+ * 빌드 실행 이력 목록을 조회한다 (#12).
+ *
+ * #29 Builder API 연동 전까지는 결정적 mock 목록을 반환해 이력 표/검색/정렬 UI를
+ * 개발·검증할 수 있게 한다.
+ *
+ * @returns 빌드 실행 목록(mock).
+ */
+export async function listBuilds(): Promise<BuildRun[]> {
+  void API_BASE;
+  return [
+    {
+      id: "run-air-quality-3",
+      spec: mockSpec("air-quality", "대기오염 정보"),
+      status: "succeeded",
+      startedAt: "2026-06-21T09:00:00.000Z",
+      finishedAt: "2026-06-21T09:00:08.000Z",
+    },
+    {
+      id: "run-weather-2",
+      spec: mockSpec("kma-daily", "기상청 일별 관측"),
+      status: "failed",
+      startedAt: "2026-06-20T18:30:00.000Z",
+      finishedAt: "2026-06-20T18:30:05.000Z",
+    },
+    {
+      id: "run-population-1",
+      spec: mockSpec("kosis-population", "인구 통계"),
+      status: "running",
+      startedAt: "2026-06-21T10:15:00.000Z",
+    },
+  ];
+}

--- a/src/pages/BuildArtifactsPage.tsx
+++ b/src/pages/BuildArtifactsPage.tsx
@@ -1,11 +1,27 @@
 /**
  * 빌드 결과물 페이지 (/builds/:buildId/artifacts).
  *
- * manifest 요약, 생성 파일 목록, 다운로드/게시 액션을 보여준다(제안 §5.7).
- * 실제 manifest/파일은 #30 manifest viewer + #29 API 연동 시 채운다.
+ * manifest 요약, 생성 파일 목록, manifest 원본(JSON)을 보여준다(제안 §5.7, #30).
+ * 현재 manifest는 mock이며 #29 Builder API 연동 시 실제 데이터로 교체된다.
  */
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import { getBuildManifest } from "@/features/artifacts/api";
+import type { BuildManifest } from "@/shared/lib/types";
 import { Card, EmptyState, LinkButton, PageHeader } from "@/shared/ui";
+
+interface ManifestState {
+  status: "loading" | "loaded" | "error";
+  manifest?: BuildManifest;
+  error?: string;
+}
+
+/** 파일 경로에서 표시용 이름과 형식(확장자)을 뽑는다. */
+function describeFile(path: string): { name: string; format: string } {
+  const name = path.split("/").pop() ?? path;
+  const dot = name.lastIndexOf(".");
+  return { name, format: dot >= 0 ? name.slice(dot + 1) : "—" };
+}
 
 /**
  * 빌드가 생성한 결과물과 manifest 요약을 보여주는 페이지.
@@ -14,6 +30,31 @@ import { Card, EmptyState, LinkButton, PageHeader } from "@/shared/ui";
  */
 export function BuildArtifactsPage() {
   const { buildId = "" } = useParams();
+  const [state, setState] = useState<ManifestState>({ status: "loading" });
+
+  useEffect(() => {
+    let active = true;
+    setState({ status: "loading" });
+    getBuildManifest(buildId)
+      .then((manifest) => {
+        if (active) setState({ status: "loaded", manifest });
+      })
+      .catch((cause: unknown) => {
+        if (active)
+          setState({
+            status: "error",
+            error: cause instanceof Error ? cause.message : "manifest를 불러오지 못했습니다.",
+          });
+      });
+    return () => {
+      active = false;
+    };
+  }, [buildId]);
+
+  const manifest = state.manifest;
+  const formats = manifest
+    ? [...new Set(manifest.artifactPaths.map((path) => describeFile(path).format))]
+    : [];
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
@@ -24,27 +65,85 @@ export function BuildArtifactsPage() {
         actions={<LinkButton to={`/builds/${buildId}/publish`}>게시하기</LinkButton>}
       />
 
-      <Card>
-        <p className="text-sm font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
-          Manifest 요약
-        </p>
-        <p className="mt-3 text-sm text-zinc-600 dark:text-zinc-300">
-          datasetId · 레코드 수 · 출력 형식 등 manifest 메타데이터가 여기에 표시됩니다 (#30).
-        </p>
-      </Card>
+      {state.status === "loading" ? (
+        <Card>
+          <p className="text-sm text-zinc-600 dark:text-zinc-300">manifest를 불러오는 중입니다…</p>
+        </Card>
+      ) : null}
 
-      <Card className="p-0">
-        <div className="grid grid-cols-[1.4fr_0.6fr_0.6fr_0.8fr] gap-4 border-b border-zinc-200/80 px-6 py-4 text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
-          <span>파일</span>
-          <span>형식</span>
-          <span>크기</span>
-          <span>액션</span>
-        </div>
-        <EmptyState
-          title="생성된 파일이 없습니다"
-          description="빌드가 성공하면 생성된 파일과 다운로드/미리보기 액션이 여기에 표시됩니다."
-        />
-      </Card>
+      {state.status === "error" ? (
+        <Card variant="error">
+          <p className="text-sm text-red-700 dark:text-red-300">{state.error}</p>
+        </Card>
+      ) : null}
+
+      {state.status === "loaded" && manifest ? (
+        <>
+          <Card>
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+              Manifest 요약
+            </p>
+            <dl className="mt-3 grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
+              <div>
+                <dt className="text-zinc-500 dark:text-zinc-400">레코드 수</dt>
+                <dd className="text-zinc-800 dark:text-zinc-100">
+                  {manifest.recordCount.toLocaleString("ko-KR")}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-zinc-500 dark:text-zinc-400">출력 형식</dt>
+                <dd className="text-zinc-800 dark:text-zinc-100">{formats.join(", ")}</dd>
+              </div>
+              <div>
+                <dt className="text-zinc-500 dark:text-zinc-400">소스</dt>
+                <dd className="text-zinc-800 dark:text-zinc-100">
+                  {manifest.sources.map((s) => `${s.provider}.${s.dataset}`).join(", ")}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-zinc-500 dark:text-zinc-400">빌드 ID</dt>
+                <dd className="break-all text-zinc-800 dark:text-zinc-100">{manifest.buildId}</dd>
+              </div>
+            </dl>
+          </Card>
+
+          <Card className="p-0">
+            <div className="grid grid-cols-[1.6fr_0.6fr_0.8fr] gap-4 border-b border-zinc-200/80 px-6 py-4 text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+              <span>파일</span>
+              <span>형식</span>
+              <span>액션</span>
+            </div>
+            {manifest.artifactPaths.length === 0 ? (
+              <EmptyState title="생성된 파일이 없습니다" />
+            ) : (
+              <ul>
+                {manifest.artifactPaths.map((path) => {
+                  const { name, format } = describeFile(path);
+                  return (
+                    <li
+                      key={path}
+                      className="grid grid-cols-[1.6fr_0.6fr_0.8fr] items-center gap-4 border-b border-zinc-100 px-6 py-3 text-sm last:border-0 dark:border-zinc-900"
+                    >
+                      <span className="break-all font-medium">{name}</span>
+                      <span className="uppercase text-zinc-500 dark:text-zinc-400">{format}</span>
+                      <span className="text-zinc-400 dark:text-zinc-500">다운로드(연동 예정)</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </Card>
+
+          <Card>
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+              manifest.json
+            </p>
+            <pre className="mt-4 overflow-x-auto rounded-[1.5rem] bg-zinc-950 p-4 text-xs leading-6 text-zinc-100">
+              <code>{JSON.stringify(manifest, null, 2)}</code>
+            </pre>
+          </Card>
+        </>
+      ) : null}
     </main>
   );
 }

--- a/src/pages/BuildsPage.tsx
+++ b/src/pages/BuildsPage.tsx
@@ -1,21 +1,59 @@
 /**
  * 빌드 목록 페이지 (/builds).
  *
- * 전체 빌드와 실행 이력을 표로 보여준다(제안 §5.6). 실제 목록/상태는 #29 Builder API
- * 연동 시 useBuilds()로 채운다.
+ * 전체 빌드 실행 이력을 표로 보여주고, 제목 검색과 시작 시각 정렬을 제공한다(제안 §5.6/§12).
+ * 현재 목록은 mock이며 #29 Builder API 연동 시 실제 데이터로 교체된다.
  */
+import { useEffect, useMemo, useState } from "react";
+import { listBuilds } from "@/features/runs/api";
 import type { BuildRun } from "@/shared/lib/types";
-import { Card, EmptyState, LinkButton, PageHeader } from "@/shared/ui";
+import {
+  Button,
+  Card,
+  EmptyState,
+  LinkButton,
+  PageHeader,
+  StatusBadge,
+  TextInput,
+  type StatusValue,
+} from "@/shared/ui";
 
-const COLUMNS = ["빌드", "상태", "마지막 실행", "액션"] as const;
+function formatTime(iso?: string): string {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? iso : date.toLocaleString("ko-KR");
+}
 
 /**
- * 빌드 실행 목록 표와 새 빌드 진입점을 보여주는 페이지.
+ * 빌드 실행 목록 표(검색/정렬)와 새 빌드 진입점을 보여주는 페이지.
  *
  * @returns 빌드 목록 화면.
  */
 export function BuildsPage() {
-  const runs: BuildRun[] = [];
+  const [runs, setRuns] = useState<BuildRun[] | null>(null);
+  const [query, setQuery] = useState("");
+  const [newestFirst, setNewestFirst] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    listBuilds().then((result) => {
+      if (active) setRuns(result);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const visible = useMemo(() => {
+    if (!runs) return [];
+    const filtered = runs.filter((run) =>
+      run.spec.title.toLowerCase().includes(query.trim().toLowerCase()),
+    );
+    return [...filtered].sort((a, b) => {
+      const diff = a.startedAt.localeCompare(b.startedAt);
+      return newestFirst ? -diff : diff;
+    });
+  }, [runs, query, newestFirst]);
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
@@ -26,21 +64,67 @@ export function BuildsPage() {
         actions={<LinkButton to="/builds/new">새 빌드 만들기</LinkButton>}
       />
 
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="sm:max-w-xs sm:flex-1">
+          <label htmlFor="build-search" className="sr-only">
+            빌드 제목 검색
+          </label>
+          <TextInput
+            id="build-search"
+            placeholder="제목으로 검색…"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </div>
+        <Button variant="secondary" size="sm" onClick={() => setNewestFirst((prev) => !prev)}>
+          시작 시각 {newestFirst ? "최신순 ↓" : "오래된순 ↑"}
+        </Button>
+      </div>
+
       <Card className="overflow-hidden p-0">
         <div className="grid grid-cols-[1.4fr_0.7fr_0.9fr_0.7fr] gap-4 border-b border-zinc-200/80 px-6 py-4 text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
-          {COLUMNS.map((column) => (
-            <span key={column}>{column}</span>
-          ))}
+          <span>빌드</span>
+          <span>상태</span>
+          <span>마지막 실행</span>
+          <span>액션</span>
         </div>
 
-        {runs.length === 0 ? (
+        {runs === null ? (
+          <div className="px-6 py-10 text-center text-sm text-zinc-500 dark:text-zinc-400">
+            불러오는 중입니다…
+          </div>
+        ) : visible.length === 0 ? (
           <EmptyState
-            title="아직 생성된 빌드가 없습니다"
-            description="첫 빌드를 만들면 여기에 상태와 실행 이력이 표시됩니다. (목록 API는 #29 연동 시 연결됩니다.)"
+            title={query ? "검색 결과가 없습니다" : "아직 생성된 빌드가 없습니다"}
+            description={
+              query
+                ? "다른 검색어로 시도해보세요."
+                : "첫 빌드를 만들면 여기에 상태와 실행 이력이 표시됩니다."
+            }
             actionLabel="새 빌드 만들기"
             actionHref="/builds/new"
           />
-        ) : null}
+        ) : (
+          <ul>
+            {visible.map((run) => (
+              <li
+                key={run.id}
+                className="grid grid-cols-[1.4fr_0.7fr_0.9fr_0.7fr] items-center gap-4 border-b border-zinc-100 px-6 py-3 text-sm last:border-0 dark:border-zinc-900"
+              >
+                <span className="font-medium">{run.spec.title}</span>
+                <span>
+                  <StatusBadge status={run.status as StatusValue} />
+                </span>
+                <span className="text-zinc-600 dark:text-zinc-300">{formatTime(run.startedAt)}</span>
+                <span>
+                  <LinkButton variant="secondary" size="sm" to={`/builds/${run.id}`}>
+                    보기
+                  </LinkButton>
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
       </Card>
     </main>
   );

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -245,6 +245,12 @@ export function NewBuildPage() {
     setStep(1);
   }
 
+  // 템플릿을 선택하면 폼을 해당 값으로 채우고 기본 정보 단계로 넘어간다 (#11).
+  function selectTemplate(template: BuildTemplate) {
+    reset(template.values);
+    setStep(1);
+  }
+
   async function goNext() {
     const fields = STEP_FIELDS[step];
     const ok = fields.length === 0 ? true : await trigger(fields);

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -216,6 +216,9 @@ interface ValidationState {
  * @returns 마법사 UI.
  */
 export function NewBuildPage() {
+  // /builds/:buildId/edit 로 진입한 경우(편집 모드). 기존 스펙 로드는 Builder 연동(#29)
+  // 이후 지원하므로, 지금은 안내만 표시한다.
+  const { buildId } = useParams();
   const [step, setStep] = useState(0);
   const [preview, setPreview] = useState<PreviewState>({ status: "idle", rows: [], schema: {} });
   const [validation, setValidation] = useState<ValidationState>({
@@ -250,23 +253,26 @@ export function NewBuildPage() {
     setStep(1);
   }
 
-  // 템플릿을 선택하면 폼을 해당 값으로 채우고 기본 정보 단계로 넘어간다 (#11).
-  function selectTemplate(template: BuildTemplate) {
-    reset(template.values);
-    setStep(1);
-  }
-
   // 현재 입력을 localStorage 초안으로 저장한다 (#10).
+  // 방금 저장한 값을 기준으로 reset 하여 dirty 상태를 정리하고, 같은 세션에서 복원 배너가
+  // 뜨지 않도록 draftAvailable은 건드리지 않는다(배너는 새 마운트 시 복원용).
   function saveCurrentDraft() {
-    saveDraft(getValues());
-    setDraftAvailable(true);
+    const current = getValues();
+    saveDraft(current);
+    reset(current);
     setDraftSaved(true);
   }
 
   // 저장된 초안을 복원해 기본 정보 단계로 이동한다.
   function restoreDraft() {
     const saved = loadDraft<BuildFormValues>();
-    if (saved) reset(saved);
+    if (!saved) {
+      // 깨진 값이 남아 배너가 반복되지 않도록 정리하고, 이동/숨김은 하지 않는다.
+      clearDraft();
+      setDraftAvailable(false);
+      return;
+    }
+    reset(saved);
     setDraftAvailable(false);
     setStep(1);
   }
@@ -621,7 +627,7 @@ export function NewBuildPage() {
             </Button>
             <div className="flex gap-2">
               <Button variant="secondary" onClick={saveCurrentDraft}>
-                {draftSaved ? "저장됨 ✓" : "초안 저장"}
+                {draftSaved && !isDirty ? "저장됨 ✓" : "초안 저장"}
               </Button>
               {step < STEPS.length - 1 ? (
                 <Button onClick={() => void goNext()}>다음</Button>

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -8,6 +8,8 @@
  */
 import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
+import { useParams } from "react-router-dom";
+import { clearDraft, hasDraft, loadDraft, saveDraft } from "@/features/build-spec/draftStorage";
 import { previewBuild } from "@/features/preview/api";
 import { validateSpec } from "@/features/validation/api";
 import { buildSpecSchema, exportFormatSchema } from "@/shared/lib/schemas";
@@ -221,6 +223,9 @@ export function NewBuildPage() {
     isValid: false,
     errors: [],
   });
+  // 저장된 초안이 있으면 복원 배너를 보여준다 (#10). 마운트 시 한 번만 확인한다.
+  const [draftAvailable, setDraftAvailable] = useState(() => hasDraft());
+  const [draftSaved, setDraftSaved] = useState(false);
 
   const {
     formState: { errors, isDirty },
@@ -249,6 +254,27 @@ export function NewBuildPage() {
   function selectTemplate(template: BuildTemplate) {
     reset(template.values);
     setStep(1);
+  }
+
+  // 현재 입력을 localStorage 초안으로 저장한다 (#10).
+  function saveCurrentDraft() {
+    saveDraft(getValues());
+    setDraftAvailable(true);
+    setDraftSaved(true);
+  }
+
+  // 저장된 초안을 복원해 기본 정보 단계로 이동한다.
+  function restoreDraft() {
+    const saved = loadDraft<BuildFormValues>();
+    if (saved) reset(saved);
+    setDraftAvailable(false);
+    setStep(1);
+  }
+
+  // 저장된 초안을 삭제하고 배너를 숨긴다.
+  function discardDraft() {
+    clearDraft();
+    setDraftAvailable(false);
   }
 
   async function goNext() {
@@ -301,6 +327,31 @@ export function NewBuildPage() {
         description="데이터 소스, 파라미터, 출력 형식을 단계별로 설정합니다."
         actions={<StatusBadge status={draftStatus} />}
       />
+
+      {buildId ? (
+        <Card variant="dashed" className="p-4">
+          <p className="text-sm text-zinc-700 dark:text-zinc-200">
+            기존 빌드 <span className="font-medium">{buildId}</span> 편집은 Builder 연동(#29) 후
+            지원됩니다. 지금은 새 빌드로 작성됩니다.
+          </p>
+        </Card>
+      ) : null}
+
+      {draftAvailable ? (
+        <Card variant="dashed" className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-zinc-700 dark:text-zinc-200">
+            저장된 초안이 있습니다. 이어서 편집할까요?
+          </p>
+          <div className="flex gap-2">
+            <Button size="sm" onClick={restoreDraft}>
+              불러오기
+            </Button>
+            <Button size="sm" variant="ghost" onClick={discardDraft}>
+              삭제
+            </Button>
+          </div>
+        </Card>
+      ) : null}
 
       <Card>
         <Stepper steps={STEPS} current={step} onStepClick={setStep} />
@@ -569,7 +620,9 @@ export function NewBuildPage() {
               이전
             </Button>
             <div className="flex gap-2">
-              <Button variant="secondary">초안 저장</Button>
+              <Button variant="secondary" onClick={saveCurrentDraft}>
+                {draftSaved ? "저장됨 ✓" : "초안 저장"}
+              </Button>
               {step < STEPS.length - 1 ? (
                 <Button onClick={() => void goNext()}>다음</Button>
               ) : null}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,23 +1,57 @@
 /**
  * Studio 환경 설정 페이지 (/settings).
  *
- * 환경 변수로 주입된 Builder API 엔드포인트를 노출해 연결 상태를 점검할 수 있게 한다.
+ * 환경 변수로 주입된 Builder API 엔드포인트를 노출하고, 실제 연동 모드일 때는 Builder
+ * `/version`을 호출해 계약 버전 호환성을 점검한다(#29).
  */
+import { useEffect, useState } from "react";
 import { API_BASE } from "@/shared/config/env";
-import { Card, PageHeader } from "@/shared/ui";
+import {
+  API_CONTRACT_VERSION,
+  ApiError,
+  builderApi,
+  isRealBuilderEnabled,
+} from "@/shared/lib/builderApi";
+import { Card, PageHeader, StatusBadge } from "@/shared/ui";
+
+interface ConnectionState {
+  status: "idle" | "checking" | "ok" | "error";
+  apiVersion?: string;
+  error?: string;
+}
 
 /**
- * 환경 기반 설정 값을 보여주는 페이지 컴포넌트.
+ * 환경 기반 설정 값과 Builder 연결 상태를 보여주는 페이지 컴포넌트.
  *
  * @returns 설정 화면.
  */
 export function SettingsPage() {
+  const realEnabled = isRealBuilderEnabled();
+  const [connection, setConnection] = useState<ConnectionState>({ status: "idle" });
+
+  useEffect(() => {
+    if (!realEnabled) return;
+    const controller = new AbortController();
+    setConnection({ status: "checking" });
+    builderApi
+      .version(controller.signal)
+      .then((info) => setConnection({ status: "ok", apiVersion: info.api_version }))
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setConnection({
+          status: "error",
+          error: cause instanceof ApiError ? cause.message : "연결 확인에 실패했습니다.",
+        });
+      });
+    return () => controller.abort();
+  }, [realEnabled]);
+
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
       <PageHeader
         eyebrow="설정"
         title="환경 설정"
-        description="Builder API 엔드포인트 등 환경값을 확인합니다. 실제 저장 기능은 이후 연동됩니다."
+        description="Builder API 엔드포인트와 연결 상태를 확인합니다. 실제 저장 기능은 이후 연동됩니다."
       />
 
       <Card>
@@ -29,6 +63,41 @@ export function SettingsPage() {
           <code className="mt-3 block break-all text-sm text-emerald-700 dark:text-emerald-400">
             {API_BASE}
           </code>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+            연결 상태
+          </p>
+          <span className="text-xs text-zinc-500 dark:text-zinc-400">
+            Studio 계약 버전 {API_CONTRACT_VERSION}
+          </span>
+        </div>
+        <div className="mt-4 text-sm">
+          {!realEnabled ? (
+            <p className="text-zinc-600 dark:text-zinc-300">
+              mock 모드입니다. 실제 Builder에 연결하려면{" "}
+              <code className="text-emerald-700 dark:text-emerald-400">VITE_USE_REAL_BUILDER=true</code>
+              로 설정하세요.
+            </p>
+          ) : connection.status === "checking" ? (
+            <p className="text-zinc-600 dark:text-zinc-300">Builder 연결을 확인하는 중입니다…</p>
+          ) : connection.status === "ok" ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <StatusBadge status="succeeded" />
+              <span className="text-zinc-700 dark:text-zinc-200">
+                Builder API 버전 {connection.apiVersion}
+                {connection.apiVersion !== API_CONTRACT_VERSION ? " (버전 불일치 주의)" : ""}
+              </span>
+            </div>
+          ) : connection.status === "error" ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <StatusBadge status="failed" />
+              <span className="text-red-700 dark:text-red-300">{connection.error}</span>
+            </div>
+          ) : null}
         </div>
       </Card>
     </main>

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -1,0 +1,140 @@
+/**
+ * Builder HTTP API 클라이언트 (#29).
+ *
+ * kpubdata-builder service(`service/app.py`)가 실제로 제공하는 엔드포인트
+ * (`/version`, `/validate`, `/preview`, `/build`, `/artifacts/{run_id}`)를 감싼다.
+ * Builder API 계약(API_CONTRACT.md / builder #209)의 와이어 형태에 맞춰 요청/응답
+ * 타입을 정의하고, 비정상 응답은 구조화된 `ApiError`로 던진다.
+ *
+ * 라이브 Builder 없이도 Studio가 동작하도록, 기본값은 mock이며 실제 호출은
+ * `VITE_USE_REAL_BUILDER=true`일 때만 활성화된다(각 feature 모듈에서 분기).
+ *
+ * 주의: validate/preview/build는 Builder가 BuildSpec YAML(snake_case)을 기대하므로,
+ * Studio BuildSpec(camelCase) → Builder 스펙 매핑(#37)이 선행되어야 완전히 연결된다.
+ * 이 모듈은 그 매핑이 끝난 스펙 텍스트를 받는 저수준 계약 계층이다.
+ */
+import { API_BASE } from "@/shared/config/env";
+
+/** Builder API 계약 버전. builder #209의 API_CONTRACT_VERSION과 일치해야 한다. */
+export const API_CONTRACT_VERSION = "1.0.0";
+
+/** 실제 Builder 호출 활성화 여부(미설정 시 mock 사용). */
+export function isRealBuilderEnabled(): boolean {
+  return import.meta.env.VITE_USE_REAL_BUILDER === "true";
+}
+
+/** Builder가 반환한 비정상 응답을 표현하는 구조화 에러. */
+export class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+    readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+interface RequestOptions {
+  method?: "GET" | "POST";
+  body?: unknown;
+  signal?: AbortSignal;
+}
+
+/**
+ * Builder API에 JSON 요청을 보내고 JSON 응답을 파싱한다.
+ *
+ * @param path - 선행 슬래시를 포함한 엔드포인트 경로(예: "/version").
+ * @param options - 메서드/바디/취소 시그널.
+ * @returns 파싱된 응답 본문.
+ * @throws ApiError 응답이 2xx가 아니거나 네트워크/파싱 오류가 발생한 경우.
+ */
+export async function apiFetch<T>(path: string, options: RequestOptions = {}): Promise<T> {
+  const { method = "GET", body, signal } = options;
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE}${path}`, {
+      method,
+      signal,
+      headers: { "Content-Type": "application/json" },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  } catch (cause) {
+    throw new ApiError(0, "Builder API에 연결하지 못했습니다.", cause);
+  }
+
+  const text = await response.text();
+  let parsed: unknown = undefined;
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      if (!response.ok) throw new ApiError(response.status, text);
+      throw new ApiError(response.status, "응답 JSON을 파싱하지 못했습니다.");
+    }
+  }
+
+  if (!response.ok) {
+    const message =
+      (parsed && typeof parsed === "object" && "error" in parsed
+        ? String((parsed as { error: unknown }).error)
+        : undefined) ?? `Builder API 오류 (HTTP ${response.status})`;
+    throw new ApiError(response.status, message, parsed);
+  }
+
+  return parsed as T;
+}
+
+// --- 응답 와이어 타입 (Builder service 실제 구현 기준) ---
+
+export interface VersionResponse {
+  service: string;
+  api_version: string;
+}
+
+export type ValidateResponse =
+  | { status: "valid"; dataset_id: string; api_version: string }
+  | { status: "invalid"; problems: string[] }
+  | { status: "error"; error: string };
+
+export interface BuildOutcome {
+  source_key: string;
+  status: string;
+  stages_completed: string[];
+  error: string | null;
+}
+
+export interface BuildResponse {
+  status: string;
+  run_id: string;
+  outcomes: BuildOutcome[];
+  manifest: string;
+  api_version: string;
+}
+
+export interface ArtifactsResponse {
+  run_id: string;
+  files: string[];
+}
+
+/** Builder service 엔드포인트를 감싼 클라이언트. */
+export const builderApi = {
+  /** GET /version — 계약 버전 확인(메타). */
+  version: (signal?: AbortSignal) => apiFetch<VersionResponse>("/version", { signal }),
+
+  /** POST /validate — BuildSpec YAML 검증. */
+  validate: (specYaml: string, signal?: AbortSignal) =>
+    apiFetch<ValidateResponse>("/validate", { method: "POST", body: { spec: specYaml }, signal }),
+
+  /** POST /build — 빌드 실행. run_id 생략 가능. */
+  build: (specYaml: string, runId?: string, signal?: AbortSignal) =>
+    apiFetch<BuildResponse>("/build", {
+      method: "POST",
+      body: runId ? { spec: specYaml, run_id: runId } : { spec: specYaml },
+      signal,
+    }),
+
+  /** GET /artifacts/{runId} — 실행 산출물 파일 목록. */
+  artifacts: (runId: string, signal?: AbortSignal) =>
+    apiFetch<ArtifactsResponse>(`/artifacts/${encodeURIComponent(runId)}`, { signal }),
+};


### PR DESCRIPTION
실제 Builder HTTP 클라이언트 계층을 추가합니다 (#29).

## 포함
- `src/shared/lib/builderApi.ts`: `apiFetch`(base URL/JSON/구조화 `ApiError`), Builder service가 실제 제공하는 엔드포인트(`/version`,`/validate`,`/build`,`/artifacts/{run_id}`) 타입 메서드, 계약 버전 상수(builder #209와 일치), `isRealBuilderEnabled()` 플래그
- SettingsPage: `VITE_USE_REAL_BUILDER=true`면 `/version` 호출해 Builder API 버전·계약 호환 표시, 아니면 mock 모드 안내
- mock fetch 단위 테스트(성공/서버 오류/네트워크 실패)

## 검증
tsc/eslint/vitest/build 통과 (43 tests). 기본은 mock이라 Studio는 독립 동작합니다.

## 후속
validate/preview/build 실연동은 BuildSpec camelCase→snake_case YAML 매핑(#37)이 선행되어야 하며, 이 클라이언트 위에 올라갑니다.

Closes #29

## 스택 안내
`feat/run-history`(#53) 위에 쌓여 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)