### PR TITLE
fix: StatusBadge fallback, BuildsPage error state, reset stale validation (#70, #71, #72)

### DIFF
--- a/__tests__/buildsHistory.test.tsx
+++ b/__tests__/buildsHistory.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as runsApi from "@/features/runs/api";
 import { BuildsPage } from "@/pages/BuildsPage";
 
 function renderBuilds() {
@@ -10,6 +11,10 @@ function renderBuilds() {
     </MemoryRouter>,
   );
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("Builds run history (#12)", () => {
   it("renders rows with status badges and a view link", async () => {
@@ -30,5 +35,21 @@ describe("Builds run history (#12)", () => {
       expect(screen.queryByText("대기오염 정보")).not.toBeInTheDocument();
     });
     expect(screen.getByText("인구 통계")).toBeInTheDocument();
+  });
+
+  it("shows an error state with retry when listing fails (#71)", async () => {
+    const realBuilds = await runsApi.listBuilds();
+    const spy = vi
+      .spyOn(runsApi, "listBuilds")
+      .mockRejectedValueOnce(new Error("네트워크 오류"));
+    renderBuilds();
+
+    expect(await screen.findByText("빌드 목록을 불러오지 못했습니다")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("네트워크 오류");
+
+    // 재시도하면 실제 목록을 다시 불러온다.
+    spy.mockResolvedValueOnce(realBuilds);
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+    expect(await screen.findByText("대기오염 정보")).toBeInTheDocument();
   });
 });

--- a/__tests__/newBuildRun.test.tsx
+++ b/__tests__/newBuildRun.test.tsx
@@ -44,4 +44,23 @@ describe("New Build wizard — run build (#39 wiring)", () => {
 
     expect(await screen.findByText(/빌드 성공/)).toBeInTheDocument();
   });
+
+  it("resets validation so an edited (unvalidated) spec cannot be run (#72)", async () => {
+    await goToReviewAndValidate();
+    expect(screen.getByRole("button", { name: "빌드 실행" })).toBeEnabled();
+
+    // 검증 이후 출력 형식 단계로 돌아가 입력을 수정한다.
+    fireEvent.click(screen.getByRole("button", { name: "이전" }));
+    await screen.findByRole("heading", { name: "출력 형식" });
+    fireEvent.change(screen.getByLabelText(/출력 경로/), {
+      target: { value: "artifacts/builds/edited" },
+    });
+
+    // 검증·실행 단계로 다시 이동하면 검증 결과가 초기화되어 실행이 막혀야 한다.
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    await screen.findByRole("heading", { name: "검증·실행" });
+
+    expect(screen.queryByText("검증을 통과했습니다. 빌드를 실행할 수 있습니다.")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "빌드 실행" })).toBeDisabled();
+  });
 });

--- a/__tests__/ui/components.test.tsx
+++ b/__tests__/ui/components.test.tsx
@@ -37,6 +37,11 @@ describe("StatusBadge", () => {
     render(<StatusBadge status="running" />);
     expect(screen.getByText("실행 중")).toBeInTheDocument();
   });
+
+  it("falls back to a neutral badge showing the raw label for an unknown status (#70)", () => {
+    render(<StatusBadge status="publish_failed" />);
+    expect(screen.getByText("publish_failed")).toBeInTheDocument();
+  });
 });
 
 describe("Stepper", () => {

--- a/src/pages/BuildsPage.tsx
+++ b/src/pages/BuildsPage.tsx
@@ -4,24 +4,36 @@
  * 전체 빌드 실행 이력을 표로 보여주고, 제목 검색과 시작 시각 정렬을 제공한다(제안 §5.6/§12).
  * 현재 목록은 mock이며 #29 Builder API 연동 시 실제 데이터로 교체된다.
  */
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { listBuilds } from "@/features/runs/api";
 import type { BuildRun } from "@/shared/lib/types";
 import {
   Button,
   Card,
   EmptyState,
+  ErrorState,
   LinkButton,
   PageHeader,
   StatusBadge,
   TextInput,
-  type StatusValue,
 } from "@/shared/ui";
+
+interface BuildsState {
+  status: "loading" | "loaded" | "error";
+  runs?: BuildRun[];
+  error?: string;
+}
 
 function formatTime(iso?: string): string {
   if (!iso) return "—";
   const date = new Date(iso);
   return Number.isNaN(date.getTime()) ? iso : date.toLocaleString("ko-KR");
+}
+
+/** ISO 시작 시각을 timestamp로 정렬하기 위한 안전한 변환(파싱 실패 시 0). */
+function startedAtMillis(iso: string): number {
+  const ms = new Date(iso).getTime();
+  return Number.isNaN(ms) ? 0 : ms;
 }
 
 /**
@@ -30,27 +42,39 @@ function formatTime(iso?: string): string {
  * @returns 빌드 목록 화면.
  */
 export function BuildsPage() {
-  const [runs, setRuns] = useState<BuildRun[] | null>(null);
+  const [state, setState] = useState<BuildsState>({ status: "loading" });
   const [query, setQuery] = useState("");
   const [newestFirst, setNewestFirst] = useState(true);
 
-  useEffect(() => {
+  const load = useCallback(() => {
     let active = true;
-    listBuilds().then((result) => {
-      if (active) setRuns(result);
-    });
+    setState({ status: "loading" });
+    listBuilds()
+      .then((result) => {
+        if (active) setState({ status: "loaded", runs: result });
+      })
+      .catch((cause: unknown) => {
+        if (!active) return;
+        setState({
+          status: "error",
+          error: cause instanceof Error ? cause.message : "빌드 목록을 불러오지 못했습니다.",
+        });
+      });
     return () => {
       active = false;
     };
   }, []);
 
+  useEffect(() => load(), [load]);
+
+  const runs = state.runs;
   const visible = useMemo(() => {
     if (!runs) return [];
     const filtered = runs.filter((run) =>
       run.spec.title.toLowerCase().includes(query.trim().toLowerCase()),
     );
     return [...filtered].sort((a, b) => {
-      const diff = a.startedAt.localeCompare(b.startedAt);
+      const diff = startedAtMillis(a.startedAt) - startedAtMillis(b.startedAt);
       return newestFirst ? -diff : diff;
     });
   }, [runs, query, newestFirst]);
@@ -89,10 +113,16 @@ export function BuildsPage() {
           <span>액션</span>
         </div>
 
-        {runs === null ? (
+        {state.status === "loading" ? (
           <div className="px-6 py-10 text-center text-sm text-zinc-500 dark:text-zinc-400">
             불러오는 중입니다…
           </div>
+        ) : state.status === "error" ? (
+          <ErrorState
+            title="빌드 목록을 불러오지 못했습니다"
+            message={state.error}
+            onRetry={() => load()}
+          />
         ) : visible.length === 0 ? (
           <EmptyState
             title={query ? "검색 결과가 없습니다" : "아직 생성된 빌드가 없습니다"}
@@ -113,7 +143,7 @@ export function BuildsPage() {
               >
                 <span className="font-medium">{run.spec.title}</span>
                 <span>
-                  <StatusBadge status={run.status as StatusValue} />
+                  <StatusBadge status={run.status} />
                 </span>
                 <span className="text-zinc-600 dark:text-zinc-300">{formatTime(run.startedAt)}</span>
                 <span>

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -6,7 +6,7 @@
  * 각 단계 진행 전에 해당 단계 필드만 검증한다. Preview/Validate는 독립 페이지가 아니라
  * 마법사 내부 단계로 통합되어 있다(§5.3/§5.4).
  */
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useParams } from "react-router-dom";
 import { clearDraft, hasDraft, loadDraft, saveDraft } from "@/features/build-spec/draftStorage";
@@ -244,6 +244,25 @@ export function NewBuildPage() {
   const values = watch();
   const specPreview = useMemo(() => toBuildSpec(values), [values]);
 
+  // 마지막으로 검증한 폼 입력의 스냅샷. 검증 이후 입력이 바뀌면 검증 결과를 초기화하기 위해
+  // 비교 기준으로 사용한다(stale validation 방지, #72).
+  const validatedSnapshotRef = useRef<string | null>(null);
+
+  // 검증을 통과/완료한 뒤 watch된 폼 값이 바뀌면, 검증되지 않은(수정된) 스펙이 그대로
+  // 실행되지 않도록 검증 상태를 idle/invalid로 되돌린다(#72).
+  useEffect(() => {
+    if (validation.status === "idle") return;
+    const current = JSON.stringify(values);
+    if (validatedSnapshotRef.current === null) {
+      validatedSnapshotRef.current = current;
+      return;
+    }
+    if (current !== validatedSnapshotRef.current) {
+      validatedSnapshotRef.current = null;
+      setValidation({ status: "idle", isValid: false, errors: [] });
+    }
+  }, [values, validation.status]);
+
   const draftStatus = validation.isValid ? "validated" : isDirty ? "dirty" : "new";
 
   // 템플릿을 선택하면 폼을 해당 값으로 채우고 기본 정보 단계로 넘어간다 (#11).
@@ -252,6 +271,7 @@ export function NewBuildPage() {
     reset(template.values);
     setPreview({ status: "idle", rows: [], schema: {} });
     setValidation({ status: "idle", isValid: false, errors: [] });
+    validatedSnapshotRef.current = null;
     setStep(1);
   }
 
@@ -317,6 +337,9 @@ export function NewBuildPage() {
   }
 
   async function runValidate() {
+    // 검증 대상 입력의 스냅샷을 기록한다. 이후 폼이 바뀌면 effect가 이를 감지해 검증 상태를
+    // 초기화한다(#72).
+    validatedSnapshotRef.current = JSON.stringify(getValues());
     const next = toBuildSpec(getValues());
     if (next.error || !next.spec) {
       setValidation({ status: "validated", isValid: false, errors: [next.error ?? "스펙 오류"] });

--- a/src/shared/ui/StatusBadge.tsx
+++ b/src/shared/ui/StatusBadge.tsx
@@ -43,9 +43,20 @@ const STATUS_META: Record<StatusValue, StatusMeta> = {
   published: { label: "게시됨", className: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300" },
 };
 
+/** 알 수 없는 상태값에 사용할 중립 배지 스타일 */
+const FALLBACK_META: StatusMeta = {
+  label: "",
+  className: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200",
+};
+
 export interface StatusBadgeProps {
-  /** 표시할 상태값 */
-  status: StatusValue;
+  /**
+   * 표시할 상태값.
+   *
+   * 알려진 `StatusValue`면 해당 라벨/색상으로, 그 외 임의 문자열이면 원본 라벨을 가진
+   * 중립 배지로 안전하게 표시한다(매핑 누락 시 크래시 방지).
+   */
+  status: StatusValue | (string & {});
   /** 추가 className */
   className?: string;
 }
@@ -53,11 +64,14 @@ export interface StatusBadgeProps {
 /**
  * 상태값에 대응하는 한국어 라벨과 색상을 가진 배지를 렌더링한다.
  *
+ * 알 수 없는 상태값은 원본 문자열을 라벨로 사용하는 중립 배지로 폴백한다.
+ *
  * @param props - status와 추가 className.
  * @returns 상태 배지 엘리먼트.
  */
 export function StatusBadge({ status, className }: StatusBadgeProps) {
-  const meta = STATUS_META[status];
+  const known = STATUS_META[status as StatusValue] as StatusMeta | undefined;
+  const meta = known ?? { ...FALLBACK_META, label: status };
   const isLive = status === "running" || status === "publishing";
 
   return (


### PR DESCRIPTION
## Summary
Three data-integrity bug fixes in Studio pages.

- **#70 StatusBadge crash on unknown status** — `StatusBadge` dereferenced `STATUS_META[status]` with no fallback, so any status outside the union (e.g. publish statuses `not_started`/`ready`/`publish_failed`) would crash. It now falls back to a neutral badge that shows the raw label. The prop type is widened so the unsafe `as StatusValue` cast in `BuildsPage` is removed and TS catches future misuse.
- **#71 BuildsPage stuck on "불러오는 중" forever** — `listBuilds()` had no `.catch`, so any failure left the page loading indefinitely. Added an error state + `ErrorState` retry UI mirroring `BuildArtifactsPage`'s loading/error handling.
- **#72 NewBuildPage stale validation** — `validation.isValid` gated the run button but was never reset when inputs changed after a successful validate, allowing an edited (unvalidated) spec to be run. Added an effect that resets validation to idle/invalid whenever watched form values change post-validation.

## Verification
- `npx tsc --noEmit` ✅
- `npx eslint .` ✅
- `npx vitest run` ✅ (93 passed) — added tests for StatusBadge fallback, BuildsPage error/retry, and stale-validation reset.

Closes #70
Closes #71
Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)