### PR TITLE
fix: unmount-abort and minor hardening bundle (#73, #74)

### DIFF
--- a/__tests__/ui/components.test.tsx
+++ b/__tests__/ui/components.test.tsx
@@ -56,6 +56,11 @@ describe("Stepper", () => {
     render(<Stepper steps={steps} current={1} />);
     expect(screen.getByText("템플릿").closest("li")).not.toHaveAttribute("aria-current");
   });
+
+  it("clamps an out-of-range current so aria-current stays on the last step (#74)", () => {
+    render(<Stepper steps={steps} current={5} />);
+    expect(screen.getByText("검증").closest("li")).toHaveAttribute("aria-current", "step");
+  });
 });
 
 describe("FormField", () => {

--- a/__tests__/useBuildJob.test.tsx
+++ b/__tests__/useBuildJob.test.tsx
@@ -118,4 +118,29 @@ describe("useBuildJob (#39)", () => {
     expect(result.current.status).toBe("failed");
     expect(result.current.error).toBe("top-level build error");
   });
+
+  it("aborts an in-flight build on unmount (#73)", async () => {
+    // executeBuild를 영원히 보류되는(pending) 호출로 대체하고, 전달된 AbortSignal을 캡처한다.
+    let capturedSignal: AbortSignal | undefined;
+    const executeBuildMock = vi
+      .spyOn(await import("@/features/runs/api"), "executeBuild")
+      .mockImplementation(
+        (_spec, signal) =>
+          new Promise(() => {
+            capturedSignal = signal;
+          }),
+      );
+
+    const { result, unmount } = renderHook(() => useBuildJob());
+    act(() => {
+      void result.current.start(spec);
+    });
+
+    expect(capturedSignal?.aborted).toBe(false);
+
+    unmount();
+
+    expect(capturedSignal?.aborted).toBe(true);
+    executeBuildMock.mockRestore();
+  });
 });

--- a/src/features/runs/useBuildJob.ts
+++ b/src/features/runs/useBuildJob.ts
@@ -5,7 +5,7 @@
  * 제공한다. Builder의 /build가 동기식인 현재는 단일 호출을 감싸지만, Builder에 job
  * 제출/폴링 엔드포인트가 생기면 이 훅 내부만 폴링으로 확장하면 된다(호출부 변경 없음).
  */
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { executeBuild } from "@/features/runs/api";
 import { ApiError, extractErrorMessage } from "@/shared/lib/builderApi";
 import type { BuildRun, BuildSpec } from "@/shared/lib/types";
@@ -61,6 +61,9 @@ export function useBuildJob(): BuildJob {
           ? (extractErrorMessage(cause.details) ?? cause.message)
           : "빌드 실행에 실패했습니다.";
       setError(message);
+    } finally {
+      // 실행이 끝나면(성공/실패/취소) 더 이상 유효하지 않은 컨트롤러 참조를 정리한다.
+      if (controllerRef.current === controller) controllerRef.current = null;
     }
   }, []);
 
@@ -68,6 +71,9 @@ export function useBuildJob(): BuildJob {
     controllerRef.current?.abort();
     setStatus((current) => (current === "running" ? "cancelled" : current));
   }, []);
+
+  // 언마운트 시 진행 중인 실행을 중단해 unmount 이후 setState를 방지한다(#73).
+  useEffect(() => () => controllerRef.current?.abort(), []);
 
   return { status, run, error, start, cancel };
 }

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -436,7 +436,6 @@ export function NewBuildPage() {
               >
                 {(field) => (
                   <Textarea
-                    className="font-sans"
                     {...field}
                     {...register("description", { required: "설명을 입력해주세요." })}
                   />
@@ -489,6 +488,7 @@ export function NewBuildPage() {
               >
                 {(field) => (
                   <Textarea
+                    mono
                     rows={8}
                     {...field}
                     {...register("sourceParams", {

--- a/src/shared/ui/Stepper.tsx
+++ b/src/shared/ui/Stepper.tsx
@@ -56,11 +56,14 @@ export function Stepper({
   onStepClick,
   className,
 }: StepperProps) {
+  // current가 범위를 벗어나면(예: 마지막 단계 이후의 terminal 값) 마지막 단계로 고정해
+  // 어떤 단계도 current로 표시되지 않아 aria-current가 사라지는 문제를 막는다(#74).
+  const clampedCurrent = steps.length === 0 ? 0 : Math.min(Math.max(current, 0), steps.length - 1);
   return (
     <ol className={cn("flex w-full items-center gap-2 overflow-x-auto", className)}>
       {steps.map((step, index) => {
-        const state = resolveState(index, current, errorSteps);
-        const clickable = Boolean(onStepClick) && index < current;
+        const state = resolveState(index, clampedCurrent, errorSteps);
+        const clickable = Boolean(onStepClick) && index < clampedCurrent;
         const circle = (
           <span
             className={cn(

--- a/src/shared/ui/Textarea.tsx
+++ b/src/shared/ui/Textarea.tsx
@@ -9,13 +9,15 @@ import { cn } from "./cn";
 export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   /** 검증 오류 상태. true이면 빨간 테두리와 aria-invalid를 적용한다. */
   invalid?: boolean;
+  /** true이면 monospace 글꼴을 적용한다(JSON 등 코드 입력용). 기본은 본문 글꼴. */
+  mono?: boolean;
 }
 
 /**
  * 스타일과 오류 상태를 갖춘 멀티라인 입력 컨트롤.
  */
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
-  { invalid, className, rows = 4, ...rest },
+  { invalid, mono, className, rows = 4, ...rest },
   ref,
 ) {
   return (
@@ -24,7 +26,8 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function 
       rows={rows}
       aria-invalid={invalid || undefined}
       className={cn(
-        "w-full rounded-xl border bg-white px-3 py-2 font-mono text-sm text-zinc-900 transition placeholder:text-zinc-400",
+        "w-full rounded-xl border bg-white px-3 py-2 text-sm text-zinc-900 transition placeholder:text-zinc-400",
+        mono && "font-mono",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0",
         "dark:bg-zinc-950 dark:text-zinc-100",
         invalid

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,3 +4,15 @@
  * `import.meta.env` 같은 Vite 전용 API를 안전하게 사용할 수 있도록 기본 타입을 포함한다.
  */
 /// <reference types="vite/client" />
+
+/** Studio가 사용하는 커스텀 `VITE_*` 환경 변수 타입(#74). */
+interface ImportMetaEnv {
+  /** Builder API 베이스 URL. 미설정 시 로컬 기본값으로 폴백한다. */
+  readonly VITE_BUILDER_API_URL?: string;
+  /** "true"이면 mock 대신 실제 Builder API를 호출한다. */
+  readonly VITE_USE_REAL_BUILDER?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
Robustness bundle: one unmount-safety fix plus four micro-hardenings.

- **#73 useBuildJob setState-after-unmount** — added an unmount cleanup effect that aborts the in-flight controller, and the controller ref is nulled once a run settles. Prevents setState on an unmounted component. Added an unmount-abort test.
- **#74a Stepper** — `current` is clamped into `[0, steps.length - 1]` so a terminal or out-of-range value no longer drops `aria-current` from every step.
- **#74b ImportMetaEnv** — `src/vite-env.d.ts` now types the custom `VITE_BUILDER_API_URL` and `VITE_USE_REAL_BUILDER` vars.
- **#74c Textarea** — `font-mono` is now opt-in via a `mono` prop instead of hardcoded. The description field uses the default body font (the previous `font-sans` override is removed) and the JSON params field opts into `mono`.
- **#74d** — sorting BuildsPage by `new Date(x).getTime()` instead of `localeCompare` on ISO strings landed alongside the #71 error-state work in PR #86 (#70/#71/#72), so it is not duplicated here.

## Verification
- `npx tsc --noEmit` ✅
- `npx eslint .` ✅
- `npx vitest run` ✅ (92 passed) — added tests for unmount-abort and Stepper clamp.

Closes #73
Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)