### PR TITLE
fix: persist UI theme and version+validate stored drafts (#83, #84)

### DIFF
--- a/__tests__/draftStorage.test.ts
+++ b/__tests__/draftStorage.test.ts
@@ -1,5 +1,14 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { clearDraft, hasDraft, loadDraft, saveDraft } from "@/features/build-spec/draftStorage";
+import { z } from "zod";
+import {
+  clearDraft,
+  DRAFT_VERSION,
+  hasDraft,
+  loadDraft,
+  saveDraft,
+} from "@/features/build-spec/draftStorage";
+
+const DRAFT_KEY = "kpubdata-studio:new-build-draft";
 
 describe("draftStorage", () => {
   beforeEach(() => clearDraft());
@@ -25,7 +34,37 @@ describe("draftStorage", () => {
   });
 
   it("returns null on corrupted data", () => {
-    localStorage.setItem("kpubdata-studio:new-build-draft", "{not json");
+    localStorage.setItem(DRAFT_KEY, "{not json");
     expect(loadDraft()).toBeNull();
+  });
+
+  it("wraps the saved value in a versioned envelope (#84)", () => {
+    saveDraft({ title: "기상" });
+    const raw = JSON.parse(localStorage.getItem(DRAFT_KEY) ?? "{}");
+    expect(raw.version).toBe(DRAFT_VERSION);
+    expect(raw.data).toEqual({ title: "기상" });
+    expect(typeof raw.savedAt).toBe("string");
+  });
+
+  it("ignores and clears a draft saved under a different version (#84)", () => {
+    localStorage.setItem(
+      DRAFT_KEY,
+      JSON.stringify({ version: DRAFT_VERSION + 1, data: { title: "old" }, savedAt: "x" }),
+    );
+    expect(loadDraft()).toBeNull();
+    expect(hasDraft()).toBe(false);
+  });
+
+  it("ignores and clears a draft that fails schema validation (#84)", () => {
+    const schema = z.object({ title: z.string() });
+    saveDraft({ title: 123 }); // 잘못된 타입(스키마 위반)
+    expect(loadDraft(schema)).toBeNull();
+    expect(hasDraft()).toBe(false);
+  });
+
+  it("returns the data when it passes schema validation (#84)", () => {
+    const schema = z.object({ title: z.string() });
+    saveDraft({ title: "ok" });
+    expect(loadDraft(schema)).toEqual({ title: "ok" });
   });
 });

--- a/__tests__/useUIStore.test.ts
+++ b/__tests__/useUIStore.test.ts
@@ -3,6 +3,7 @@ import { useUIStore } from "@/shared/hooks/useUIStore";
 
 describe("useUIStore", () => {
   beforeEach(() => {
+    localStorage.clear();
     useUIStore.setState({ isSidebarOpen: false, theme: "system" });
   });
 
@@ -12,5 +13,15 @@ describe("useUIStore", () => {
 
     useUIStore.getState().toggleSidebar();
     expect(useUIStore.getState().isSidebarOpen).toBe(false);
+  });
+
+  it("persists only the theme to localStorage (#83)", () => {
+    useUIStore.getState().setTheme("dark");
+    useUIStore.getState().openSidebar();
+
+    const persisted = JSON.parse(localStorage.getItem("kpubdata-studio:ui") ?? "{}");
+    expect(persisted.state.theme).toBe("dark");
+    // 사이드바 상태는 저장하지 않는다(데스크톱에서 모바일 드로어 부활 방지).
+    expect(persisted.state.isSidebarOpen).toBeUndefined();
   });
 });

--- a/src/features/build-spec/draftStorage.ts
+++ b/src/features/build-spec/draftStorage.ts
@@ -1,20 +1,44 @@
 /**
- * New Build 초안을 브라우저 localStorage에 저장/복원하는 유틸 (#10).
+ * New Build 초안을 브라우저 localStorage에 저장/복원하는 유틸 (#10, #84).
  *
  * 작성 중인 빌드 초안을 임시 저장해 두고, 새로고침하거나 나중에 다시 열어 이어서
- * 편집할 수 있게 한다. localStorage 접근 실패(SSR/프라이빗 모드 등)나 깨진 JSON은
- * 조용히 무시하고 안전한 기본값(null/false)을 반환한다.
+ * 편집할 수 있게 한다. 저장 시 `{version, data, savedAt}` 봉투(envelope)로 감싸고, 복원 시
+ * 버전과 (선택적) zod 스키마로 검증해 버전 불일치/손상된 값은 조용히 무시·정리한다.
+ * localStorage 접근 실패(SSR/프라이빗 모드 등)도 안전한 기본값(null/false)으로 폴백한다.
  */
 const DRAFT_KEY = "kpubdata-studio:new-build-draft";
 
+/** 초안 봉투 스키마 버전. 호환되지 않게 형태가 바뀌면 올린다. */
+export const DRAFT_VERSION = 1;
+
+/** localStorage에 저장되는 초안 봉투 구조. */
+interface DraftEnvelope<T> {
+  /** 봉투 스키마 버전 */
+  version: number;
+  /** 실제 초안 데이터 */
+  data: T;
+  /** 저장 시각 ISO 문자열 */
+  savedAt: string;
+}
+
+/** zod 스키마의 `safeParse`만 의존하는 최소 검증 인터페이스. */
+interface DraftValidator<T> {
+  safeParse: (value: unknown) => { success: true; data: T } | { success: false };
+}
+
 /**
- * 초안 값을 저장한다. 실패 시 조용히 무시한다.
+ * 초안 값을 버전 봉투로 감싸 저장한다. 실패 시 조용히 무시한다.
  *
  * @param value - 직렬화 가능한 초안 값.
  */
 export function saveDraft<T>(value: T): void {
   try {
-    localStorage.setItem(DRAFT_KEY, JSON.stringify(value));
+    const envelope: DraftEnvelope<T> = {
+      version: DRAFT_VERSION,
+      data: value,
+      savedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(envelope));
   } catch {
     // localStorage 사용 불가 시 무시.
   }
@@ -23,12 +47,36 @@ export function saveDraft<T>(value: T): void {
 /**
  * 저장된 초안을 불러온다. 없거나 손상되면 null을 반환한다.
  *
+ * 봉투 버전이 현재 버전과 다르거나, (검증기 제공 시) 데이터가 스키마를 통과하지 못하면
+ * 손상된 값으로 보고 정리한 뒤 null을 반환한다.
+ *
+ * @param validator - 데이터를 검증할 zod 스키마(선택). 미제공 시 버전만 확인한다.
  * @returns 저장된 초안 값 또는 null.
  */
-export function loadDraft<T>(): T | null {
+export function loadDraft<T>(validator?: DraftValidator<T>): T | null {
   try {
     const raw = localStorage.getItem(DRAFT_KEY);
-    return raw ? (JSON.parse(raw) as T) : null;
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      (parsed as DraftEnvelope<unknown>).version !== DRAFT_VERSION
+    ) {
+      // 버전 불일치/봉투 아님: 안전하게 정리.
+      clearDraft();
+      return null;
+    }
+    const data = (parsed as DraftEnvelope<unknown>).data;
+    if (validator) {
+      const result = validator.safeParse(data);
+      if (!result.success) {
+        clearDraft();
+        return null;
+      }
+      return result.data;
+    }
+    return data as T;
   } catch {
     return null;
   }

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -13,7 +13,7 @@ import { clearDraft, hasDraft, loadDraft, saveDraft } from "@/features/build-spe
 import { previewBuild } from "@/features/preview/api";
 import { useBuildJob } from "@/features/runs/useBuildJob";
 import { validateSpec } from "@/features/validation/api";
-import { buildSpecSchema, exportFormatSchema } from "@/shared/lib/schemas";
+import { buildFormValuesSchema, buildSpecSchema, exportFormatSchema } from "@/shared/lib/schemas";
 import type { BuildSpec } from "@/shared/lib/types";
 import {
   Button,
@@ -267,7 +267,8 @@ export function NewBuildPage() {
 
   // 저장된 초안을 복원해 기본 정보 단계로 이동한다.
   function restoreDraft() {
-    const saved = loadDraft<BuildFormValues>();
+    // 저장된 초안을 버전·스키마로 검증해 복원한다. 버전 불일치/손상 시 null을 받는다(#84).
+    const saved = loadDraft<BuildFormValues>(buildFormValuesSchema);
     if (!saved) {
       // 깨진 값이 남아 배너가 반복되지 않도록 정리하고, 이동/숨김은 하지 않는다.
       clearDraft();

--- a/src/shared/hooks/useUIStore.ts
+++ b/src/shared/hooks/useUIStore.ts
@@ -2,8 +2,11 @@
  * 앱 셸 전반에서 재사용하는 UI 전역 상태 스토어.
  *
  * 사이드바 열림 여부와 테마 선택처럼 페이지를 넘나들며 유지해야 하는 시각 상태를 관리한다.
+ * 테마는 `persist` 미들웨어로 localStorage에 저장해 새로고침해도 유지된다(#83). 사이드바는
+ * 데스크톱에서 모바일 드로어를 되살리지 않도록 의도적으로 저장하지 않는다(항상 닫힌 상태로 시작).
  */
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 /** 현재 Studio 셸이 지원하는 테마 모드 집합 */
 export type ThemeMode = "system" | "light" | "dark";
@@ -28,11 +31,20 @@ interface UIState {
  *
  * @returns 현재 UI 상태와 상태 변경 액션 집합.
  */
-export const useUIStore = create<UIState>((set) => ({
-  isSidebarOpen: false,
-  theme: "system",
-  toggleSidebar: () => set((state) => ({ isSidebarOpen: !state.isSidebarOpen })),
-  openSidebar: () => set({ isSidebarOpen: true }),
-  closeSidebar: () => set({ isSidebarOpen: false }),
-  setTheme: (theme) => set({ theme }),
-}));
+export const useUIStore = create<UIState>()(
+  persist(
+    (set) => ({
+      isSidebarOpen: false,
+      theme: "system",
+      toggleSidebar: () => set((state) => ({ isSidebarOpen: !state.isSidebarOpen })),
+      openSidebar: () => set({ isSidebarOpen: true }),
+      closeSidebar: () => set({ isSidebarOpen: false }),
+      setTheme: (theme) => set({ theme }),
+    }),
+    {
+      name: "kpubdata-studio:ui",
+      // 테마만 저장한다. 사이드바 열림 상태는 저장하지 않아 새로고침 시 항상 닫힌 채 시작한다.
+      partialize: (state) => ({ theme: state.theme }),
+    },
+  ),
+);

--- a/src/shared/lib/schemas.ts
+++ b/src/shared/lib/schemas.ts
@@ -40,6 +40,26 @@ export const buildSpecSchema = z.object({
   metadata: recordSchema,
 });
 
+/**
+ * New Build Wizard 폼 입력값(localStorage 초안으로 저장되는 실제 형태)을 검증하는 스키마.
+ *
+ * 저장된 초안(#84)을 복원할 때 형태가 깨졌거나 오래된 버전인 경우를 안전하게 걸러내기 위해
+ * 사용한다. 빌드 실행용 스펙(`buildSpecSchema`)이 아니라 폼 입력 형태를 기술한다.
+ */
+export const buildFormValuesSchema = z.object({
+  datasetId: z.string(),
+  title: z.string(),
+  description: z.string(),
+  provider: z.string(),
+  sourceDataset: z.string(),
+  sourceParams: z.string(),
+  outputPath: z.string(),
+  exportFormats: z.array(exportFormatSchema),
+});
+
+/** `buildFormValuesSchema`를 통과한 폼 입력 타입 추론 결과 */
+export type BuildFormValuesInput = z.infer<typeof buildFormValuesSchema>;
+
 /** `buildSpecSchema`를 통과한 입력 타입 추론 결과 */
 export type BuildSpecInput = z.infer<typeof buildSpecSchema>;
 /** `exportTargetSchema`를 통과한 입력 타입 추론 결과 */


### PR DESCRIPTION
## Summary
Persisted-state hygiene for the UI store and saved drafts.

- **#83 UI store not persisted** — `useUIStore` now uses zustand's `persist` middleware with `partialize` to persist only `theme`, so the chosen theme survives a refresh. Sidebar open state is intentionally **not** persisted so a refresh on desktop never resurrects the mobile drawer (always starts closed).
- **#84 draft localStorage had no schema versioning** — `draftStorage` previously did `JSON.parse(raw) as T` with no validation. It now wraps saves in a `{version, data, savedAt}` envelope and, on load, validates the version and an optional zod schema via `safeParse`, clearing/ignoring the stored draft on version mismatch or invalid data. `NewBuildPage` restores with a new `buildFormValuesSchema` (the actual stored form shape).

## Verification
- `npx tsc --noEmit` ✅
- `npx eslint .` ✅
- `npx vitest run` ✅ (95 passed) — added tests for theme-only persistence, the version envelope, version-mismatch/invalid clearing, and schema-validated load.

Closes #83
Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)