### PR TITLE
chore: remove unused @tanstack/react-query (#82)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "kpubdata-studio",
       "version": "0.1.0",
       "dependencies": {
-        "@tanstack/react-query": "^5.99.2",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-hook-form": "^7.73.1",
@@ -1221,32 +1220,6 @@
         "@tailwindcss/oxide": "4.2.2",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.2"
-      }
-    },
-    "node_modules/@tanstack/query-core": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
-      "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/react-query": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
-      "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "5.99.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "screenshots": "node scripts/capture-screenshots.mjs"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.99.2",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.73.1",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,24 +1,16 @@
 /**
  * 애플리케이션 전역 Provider를 조립하는 최상위 앱 컴포넌트.
  *
- * 현재는 TanStack Query 클라이언트와 React Router를 연결해
- * 모든 페이지가 동일한 서버 상태 캐시와 라우팅 컨텍스트를 공유하도록 만든다.
+ * 현재는 React Router를 연결해 모든 페이지가 동일한 라우팅 컨텍스트를 공유하도록 만든다.
  */
 import { RouterProvider } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { router } from "@/app/router";
 
-const queryClient = new QueryClient();
-
 /**
- * Studio 전체를 Query/Router 컨텍스트로 감싸는 루트 컴포넌트.
+ * Studio 전체를 Router 컨텍스트로 감싸는 루트 컴포넌트.
  *
  * @returns 전역 Provider가 적용된 라우터 렌더링 결과.
  */
 export function App() {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
-  );
+  return <RouterProvider router={router} />;
 }


### PR DESCRIPTION
Closes #82

## Summary

- `@tanstack/react-query` was installed but entirely unused — `QueryClientProvider` was mounted in `App.tsx` but no `useQuery`, `useMutation`, or `useQueryClient` calls existed anywhere in the codebase.
- Removed the provider wiring from `src/app/App.tsx` and dropped the package from `package.json` / `package-lock.json`.
- Re-add when server-state caching is actually adopted.

## Verification

- `npx tsc --noEmit` — no errors
- `npx eslint .` — no errors
- `npx vitest run` — 25 test files, 90 tests passed
- `npx vite build` — built successfully (425 kB JS, 35 kB CSS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)