### PR TITLE
feat(builder-api): fetch timeout/retry + wire preview to Builder (#93, #94)

### DIFF
--- a/__tests__/builderApiTimeout.test.ts
+++ b/__tests__/builderApiTimeout.test.ts
@@ -1,0 +1,115 @@
+/**
+ * apiFetch 타임아웃/재시도 동작 테스트 (#94).
+ *
+ * Builder 응답 지연 시 UI가 무한 대기에 빠지지 않도록 자동 타임아웃이 걸리는지, 네트워크
+ * 일시 장애와 5xx에 제한 재시도(지수 백오프)가 동작하는지, 호출자 취소는 즉시 전파되는지 검증한다.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError, apiFetch } from "@/shared/lib/builderApi";
+
+function okResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function serverError(): Response {
+  return {
+    ok: false,
+    status: 503,
+    text: async () => JSON.stringify({ error: "unavailable" }),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("apiFetch retry (#94)", () => {
+  it("retries on a network error and then succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(okResponse({ service: "kpubdata-builder" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await apiFetch<{ service: string }>("/version", { retries: 1, timeoutMs: 0 });
+
+    expect(result.service).toBe("kpubdata-builder");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on a 5xx response and then succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(serverError())
+      .mockResolvedValueOnce(okResponse({ service: "ok" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await apiFetch<{ service: string }>("/version", { retries: 1, timeoutMs: 0 });
+
+    expect(result.service).toBe("ok");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on a 4xx response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({ error: "bad spec" }),
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiFetch("/validate", { retries: 2, timeoutMs: 0 })).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after exhausting retries on persistent network failure", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const error = await apiFetch("/version", { retries: 1, timeoutMs: 0 }).catch((cause) => cause);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws a 408 ApiError when the request times out with no retries left", async () => {
+    // fetch가 결합된 timeout signal에서 abort되면 TimeoutError로 거부한다.
+    const fetchMock = vi.fn().mockImplementation((_url, init: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const error = await apiFetch("/build", { method: "POST", timeoutMs: 5, retries: 0 }).catch(
+      (cause) => cause,
+    );
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(408);
+  });
+
+  it("propagates caller cancellation without retrying", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn().mockImplementation((_url, init: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = apiFetch("/version", { signal: controller.signal, retries: 2, timeoutMs: 0 });
+    controller.abort(new DOMException("Aborted", "AbortError"));
+
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/previewApi.test.ts
+++ b/__tests__/previewApi.test.ts
@@ -1,0 +1,108 @@
+/**
+ * preview API 진입점 테스트 (#93).
+ *
+ * 실연동 모드에서 Builder `/preview`의 실제 와이어 형태({dataset_id, previews})를 UI가 쓰는
+ * {rows, schema}로 변환하는지, mock 모드에서는 네트워크 없이 결정적 mock 데이터를 반환하는지 검증한다.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { previewBuild } from "@/features/preview/api";
+import type { BuildSpec } from "@/shared/lib/types";
+
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+const SPEC: BuildSpec = {
+  datasetId: "air-quality",
+  title: "대기오염 정보",
+  description: "테스트",
+  sources: [{ provider: "datago", dataset: "air-quality", params: {} }],
+  exports: [{ format: "jsonl" }],
+  metadata: {},
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("previewBuild (#93)", () => {
+  it("calls Builder /preview and maps the {dataset_id, previews} shape to {rows, schema} in real mode", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, {
+        dataset_id: "air-quality",
+        previews: [
+          {
+            source_key: "datago.air-quality",
+            status: "ok",
+            error: null,
+            schema: [
+              { name: "region", dtype: "string", nullable: false, unique_count: 3 },
+              { name: "value", dtype: "int64", nullable: true, unique_count: 3 },
+            ],
+            sample: [
+              { region: "서울", value: 42 },
+              { region: "부산", value: 37 },
+            ],
+            total_rows: 2,
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await previewBuild(SPEC);
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/preview");
+    expect(fetchMock.mock.calls[0][1].method).toBe("POST");
+    expect(result.schema).toEqual({ region: "string", value: "int64" });
+    expect(result.rows).toEqual([
+      { region: "서울", value: 42 },
+      { region: "부산", value: 37 },
+    ]);
+  });
+
+  it("prefers the first ok source when multiple previews are returned", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse(200, {
+          dataset_id: "multi",
+          previews: [
+            { source_key: "a", status: "failed", error: "boom", schema: [], sample: [], total_rows: 0 },
+            {
+              source_key: "b",
+              status: "ok",
+              error: null,
+              schema: [{ name: "id", dtype: "string", nullable: false, unique_count: 1 }],
+              sample: [{ id: "x" }],
+              total_rows: 1,
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await previewBuild(SPEC);
+
+    expect(result.schema).toEqual({ id: "string" });
+    expect(result.rows).toEqual([{ id: "x" }]);
+  });
+
+  it("returns deterministic mock data without network in mock mode", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await previewBuild(SPEC);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.rows.length).toBeGreaterThan(0);
+    expect(Object.keys(result.schema).length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/preview/api/index.ts
+++ b/src/features/preview/api/index.ts
@@ -1,20 +1,71 @@
 /**
- * 빌드 결과 미리보기 API 진입점.
+ * 빌드 결과 미리보기 API 진입점 (#93).
  *
- * 실제 구현 시 Builder가 반환한 샘플 행과 스키마를 UI가 바로 사용할 수 있는 형태로 전달한다.
+ * 실연동 모드(`VITE_USE_REAL_BUILDER=true`)면 Builder `/preview`를 호출하고, 아니면
+ * UI 개발/검증용 결정적 mock 데이터를 반환한다. Builder가 반환한 소스별 샘플 행과 스키마를
+ * UI가 바로 사용할 수 있는 `{ rows, schema }` 형태로 변환한다(runs/api의 실연동 분기 패턴과 동일).
  */
-import { API_BASE } from "@/shared/config/env";
+import { serializeSpec } from "@/features/build-spec/specMapping";
+import {
+  builderApi,
+  isRealBuilderEnabled,
+  type PreviewResponse,
+} from "@/shared/lib/builderApi";
 import type { BuildSpec } from "@/shared/lib/types";
+
+/** 미리보기 결과(샘플 행 배열과 컬럼명→타입 스키마 맵). */
+export interface PreviewResult {
+  rows: Record<string, unknown>[];
+  schema: Record<string, string>;
+}
+
+/** mock 모드에서 보여줄 결정적 샘플 행. */
+const MOCK_ROWS: Record<string, unknown>[] = [
+  { region: "서울", value: 42, measured_at: "2026-06-21T09:00:00Z" },
+  { region: "부산", value: 37, measured_at: "2026-06-21T09:00:00Z" },
+  { region: "대구", value: 51, measured_at: "2026-06-21T09:00:00Z" },
+];
+
+/** mock 모드에서 보여줄 결정적 컬럼 스키마. */
+const MOCK_SCHEMA: Record<string, string> = {
+  region: "string",
+  value: "int64",
+  measured_at: "string",
+};
+
+/**
+ * Builder /preview 응답을 UI가 쓰는 `{ rows, schema }`로 변환한다.
+ *
+ * /preview는 소스별 배열(`previews`)을 반환한다. 미리보기 화면은 단일 표를 보여주므로
+ * 첫 번째 성공 소스를 대표로 사용한다(소스가 없으면 빈 결과).
+ *
+ * @param response - Builder /preview 응답.
+ * @returns 대표 소스의 샘플 행과 컬럼명→타입 스키마.
+ */
+function transformPreviewResponse(response: PreviewResponse): PreviewResult {
+  const source =
+    response.previews.find((preview) => preview.status === "ok") ?? response.previews[0];
+  if (!source) return { rows: [], schema: {} };
+
+  const schema: Record<string, string> = {};
+  for (const column of source.schema) {
+    schema[column.name] = column.dtype;
+  }
+  return { rows: source.sample, schema };
+}
 
 /**
  * 현재 빌드 스펙으로 미리보기 데이터를 요청한다.
  *
- * @param _spec - 미리보기를 생성할 대상 빌드 스펙.
+ * @param spec - 미리보기를 생성할 대상 빌드 스펙.
+ * @param signal - 취소용 AbortSignal(선택).
  * @returns 샘플 행 배열과 컬럼 스키마 맵.
  */
-export async function previewBuild(
-  _spec: BuildSpec,
-): Promise<{ rows: Record<string, unknown>[]; schema: Record<string, string> }> {
-  void API_BASE;
-  return { rows: [], schema: {} };
+export async function previewBuild(spec: BuildSpec, signal?: AbortSignal): Promise<PreviewResult> {
+  if (!isRealBuilderEnabled()) {
+    return { rows: MOCK_ROWS, schema: MOCK_SCHEMA };
+  }
+
+  const response = await builderApi.preview(serializeSpec(spec), signal);
+  return transformPreviewResponse(response);
 }

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -39,28 +39,119 @@ interface RequestOptions {
   method?: "GET" | "POST";
   body?: unknown;
   signal?: AbortSignal;
+  /** 자동 타임아웃(ms). 미지정 시 DEFAULT_TIMEOUT_MS. 0 이하이면 타임아웃 비활성화. */
+  timeoutMs?: number;
+  /** 네트워크 오류·5xx 발생 시 추가 재시도 횟수(지수 백오프). 미지정 시 DEFAULT_RETRIES. */
+  retries?: number;
+}
+
+/** 자동 타임아웃 기본값(ms). Builder /build는 외부 API를 호출해 느릴 수 있어 넉넉히 잡는다. */
+export const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** 네트워크 오류·5xx에 대한 기본 재시도 횟수(최초 시도 외 추가 횟수). */
+export const DEFAULT_RETRIES = 2;
+
+/** 타임아웃으로 요청이 중단됐는지 식별하는 ApiError 상태값. */
+const TIMEOUT_STATUS = 408;
+
+/** 재시도 사이 지수 백오프 지연(ms)을 만든다. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * 사용자 취소 signal과 타임아웃 signal을 결합해, 둘 중 먼저 발화하는 쪽이 요청을 중단하게 한다.
+ *
+ * @param signal - 호출자가 넘긴 취소 signal(선택).
+ * @param timeoutMs - 자동 타임아웃(ms). 0 이하이면 타임아웃 없이 signal만 사용한다.
+ * @returns 결합된 signal과, 타임아웃 타이머를 해제하는 cleanup 함수.
+ */
+function withTimeout(
+  signal: AbortSignal | undefined,
+  timeoutMs: number,
+): { signal: AbortSignal | undefined; cleanup: () => void } {
+  if (timeoutMs <= 0) return { signal, cleanup: () => {} };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new DOMException("Timeout", "TimeoutError")), timeoutMs);
+  const cleanup = () => clearTimeout(timer);
+
+  if (!signal) return { signal: controller.signal, cleanup };
+  if (signal.aborted) {
+    cleanup();
+    return { signal, cleanup: () => {} };
+  }
+  // 사용자 취소가 발생하면 타임아웃 컨트롤러도 함께 중단해 fetch를 즉시 끊는다.
+  signal.addEventListener("abort", () => controller.abort(signal.reason), { once: true });
+  return { signal: controller.signal, cleanup };
+}
+
+/** 타임아웃 때문에 발생한 abort인지 판별한다(사용자 취소와 구분). */
+function isTimeoutAbort(cause: unknown): boolean {
+  return cause instanceof DOMException && cause.name === "TimeoutError";
 }
 
 /**
  * Builder API에 JSON 요청을 보내고 JSON 응답을 파싱한다.
  *
+ * 네트워크 일시 장애와 5xx에는 지수 백오프로 제한 재시도하고(#94), 응답이 없을 경우
+ * UI가 무한 대기에 빠지지 않도록 자동 타임아웃을 건다(#94). 호출자 취소 signal은 그대로 존중한다.
+ *
  * @param path - 선행 슬래시를 포함한 엔드포인트 경로(예: "/version").
- * @param options - 메서드/바디/취소 시그널.
+ * @param options - 메서드/바디/취소 시그널/타임아웃/재시도.
  * @returns 파싱된 응답 본문.
- * @throws ApiError 응답이 2xx가 아니거나 네트워크/파싱 오류가 발생한 경우.
+ * @throws ApiError 응답이 2xx가 아니거나 네트워크/파싱/타임아웃 오류가 발생한 경우.
  */
 export async function apiFetch<T>(path: string, options: RequestOptions = {}): Promise<T> {
-  const { method = "GET", body, signal } = options;
-  let response: Response;
-  try {
-    response = await fetch(`${API_BASE}${path}`, {
-      method,
-      signal,
-      headers: { "Content-Type": "application/json" },
-      body: body === undefined ? undefined : JSON.stringify(body),
-    });
-  } catch (cause) {
-    throw new ApiError(0, "Builder API에 연결하지 못했습니다.", cause);
+  const {
+    method = "GET",
+    body,
+    signal,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    retries = DEFAULT_RETRIES,
+  } = options;
+
+  let response: Response | undefined;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const { signal: combined, cleanup } = withTimeout(signal, timeoutMs);
+    try {
+      response = await fetch(`${API_BASE}${path}`, {
+        method,
+        signal: combined,
+        headers: { "Content-Type": "application/json" },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+    } catch (cause) {
+      cleanup();
+      // 호출자가 명시적으로 취소한 경우엔 재시도하지 않고 그대로 전파한다.
+      if (signal?.aborted) throw cause;
+      if (isTimeoutAbort(cause)) {
+        if (attempt < retries) {
+          await delay(500 * 2 ** attempt);
+          continue;
+        }
+        throw new ApiError(TIMEOUT_STATUS, "Builder API 응답이 시간 내에 오지 않았습니다.", cause);
+      }
+      // 네트워크 오류: 남은 재시도가 있으면 백오프 후 다시 시도한다.
+      if (attempt < retries) {
+        await delay(500 * 2 ** attempt);
+        continue;
+      }
+      throw new ApiError(0, "Builder API에 연결하지 못했습니다.", cause);
+    }
+    cleanup();
+
+    // 5xx는 일시 장애일 수 있어 제한 재시도한다. 4xx는 즉시 처리(재시도 무의미).
+    if (response.status >= 500 && attempt < retries) {
+      await delay(500 * 2 ** attempt);
+      response = undefined;
+      continue;
+    }
+    break;
+  }
+
+  if (!response) {
+    throw new ApiError(0, "Builder API에 연결하지 못했습니다.");
   }
 
   const text = await response.text();
@@ -147,11 +238,32 @@ export interface ArtifactsResponse {
   files: string[];
 }
 
-export interface PreviewResponse {
+/** /preview 응답의 소스별 컬럼 스키마 항목(service app.py 기준). */
+export interface PreviewColumn {
+  name: string;
+  dtype: string;
+  nullable: boolean;
+  unique_count: number;
+}
+
+/** /preview 응답의 소스별 미리보기 항목(service app.py 기준). */
+export interface PreviewSource {
+  source_key: string;
   status: string;
-  /** 미리보기 샘플 레코드(소스별, Builder 구현에 따라 형태가 달라질 수 있어 느슨하게 둔다). */
-  preview: unknown;
-  api_version: string;
+  error: string | null;
+  schema: PreviewColumn[];
+  sample: Record<string, unknown>[];
+  total_rows: number;
+}
+
+/**
+ * POST /preview 응답 와이어 형태(builder service app.py 기준).
+ *
+ * `{ dataset_id, previews: [...] }` — 소스별로 스키마와 샘플 행을 담는다.
+ */
+export interface PreviewResponse {
+  dataset_id: string;
+  previews: PreviewSource[];
 }
 
 /** Builder service 엔드포인트를 감싼 클라이언트. */


### PR DESCRIPTION
## Summary

Hardens the Builder HTTP client and connects the preview feature to the real Builder.

### #94 — apiFetch timeout/retry (P2)
- `apiFetch` now combines the caller's `AbortSignal` with an automatic `AbortController`-based timeout (default **30s**, configurable per request via `timeoutMs`). The UI can no longer hang forever when the Builder is slow.
- Retries **network errors** and **5xx** responses with exponential backoff (default **2** retries, configurable via `retries`).
- 4xx responses are not retried (retry is pointless), and explicit caller cancellation is propagated immediately without retrying.
- Timeouts surface as a structured `ApiError(408)`.

### #93 — preview wired to Builder `/preview` (P2)
- `previewBuild` is no longer a stub returning `{ rows: [], schema: {} }`.
- Real mode (`VITE_USE_REAL_BUILDER=true`): serializes the spec and calls `builderApi.preview()`, then transforms the **real** wire shape `{ dataset_id, previews: [...] }` into the `{ rows, schema }` form the New Build wizard consumes (first `ok` source is used as the representative table).
- Mock mode: returns deterministic sample rows/schema so the wizard preview step is exercisable without a live Builder.
- Corrected the `PreviewResponse` type to match the actual Builder service response (`service/app.py`) — it previously claimed `{ status, preview, api_version }`, which the Builder never returns.

## Design notes / alternatives
- **Retry on POST**: `/validate` and `/preview` are pure; `/build` dedupes by `run_id`, so limited retry on network/5xx is safe here. Retry count and timeout are per-request overridable if a caller wants stricter behavior.
- **Representative preview source**: the wizard renders a single table, so the first successful source is shown. A future multi-source preview UI can consume the full `previews[]` (already typed).

## Verification
- `npx tsc --noEmit` — clean
- `npx eslint .` — clean
- `npx vitest run` — 28 files / 112 tests pass (adds `previewApi.test.ts`, `builderApiTimeout.test.ts`)

Closes #93
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)