### PR TITLE
feat(ui): apply persisted theme to DOM + feature-level ErrorBoundaries (#96, #97)

### DIFF
--- a/__tests__/featureErrorBoundary.test.tsx
+++ b/__tests__/featureErrorBoundary.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * FeatureErrorBoundary 테스트 (#97).
+ *
+ * 단일 feature의 렌더 오류가 전역 폴백까지 버블업해 셸 전체가 사라지는 것을 막고, 해당 영역만
+ * 폴백으로 대체하는지, 주변 셸(사이드바 등)은 정상 유지되는지, ‘다시 시도’로 복구되는지 검증한다.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FeatureErrorBoundary } from "@/app/ErrorBoundary";
+
+function Boom(): never {
+  throw new Error("feature boom");
+}
+
+describe("FeatureErrorBoundary (#97)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("isolates a feature error to its own area while the shell stays mounted", () => {
+    render(
+      <div>
+        <nav>사이드바</nav>
+        <FeatureErrorBoundary feature="미리보기">
+          <Boom />
+        </FeatureErrorBoundary>
+      </div>,
+    );
+
+    // feature 영역은 영역 한정 폴백을 보여준다.
+    expect(screen.getByRole("alert")).toHaveTextContent("미리보기 화면에 문제가 발생했습니다");
+    // 셸(사이드바)은 사라지지 않는다 — 전역 폴백이 아니다.
+    expect(screen.getByText("사이드바")).toBeInTheDocument();
+    // 전역 폴백 문구는 나타나지 않는다.
+    expect(screen.queryByText("문제가 발생했습니다")).not.toBeInTheDocument();
+  });
+
+  it("renders children when nothing throws", () => {
+    render(
+      <FeatureErrorBoundary feature="설정">
+        <p>정상 콘텐츠</p>
+      </FeatureErrorBoundary>,
+    );
+
+    expect(screen.getByText("정상 콘텐츠")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("resets the boundary when 다시 시도 is clicked", () => {
+    let shouldThrow = true;
+    function MaybeBoom() {
+      if (shouldThrow) throw new Error("transient");
+      return <p>복구됨</p>;
+    }
+
+    render(
+      <FeatureErrorBoundary feature="결과물">
+        <MaybeBoom />
+      </FeatureErrorBoundary>,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("결과물 화면에 문제가 발생했습니다");
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+
+    expect(screen.getByText("복구됨")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/themeEffect.test.tsx
+++ b/__tests__/themeEffect.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * useThemeEffect 테스트 (#96).
+ *
+ * 저장된 테마 값이 실제로 `<html data-theme>`에 반영되는지(light/dark는 속성 설정, system은 제거)
+ * 검증한다. 이전에는 테마를 저장만 하고 DOM에 적용하지 않아 다크 모드 전환이 동작하지 않았다.
+ */
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useThemeEffect } from "@/shared/hooks/useThemeEffect";
+import { useUIStore } from "@/shared/hooks/useUIStore";
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+  useUIStore.setState({ theme: "system", isSidebarOpen: false });
+  // jsdom에는 matchMedia가 없으므로 system 모드 구독용으로 스텁한다.
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.documentElement.removeAttribute("data-theme");
+});
+
+describe("useThemeEffect (#96)", () => {
+  it("sets data-theme=dark on <html> when the theme is dark", () => {
+    useUIStore.setState({ theme: "dark" });
+    renderHook(() => useThemeEffect());
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("sets data-theme=light on <html> when the theme is light", () => {
+    useUIStore.setState({ theme: "light" });
+    renderHook(() => useThemeEffect());
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("removes data-theme on <html> for system mode (delegates to prefers-color-scheme)", () => {
+    document.documentElement.setAttribute("data-theme", "dark");
+    useUIStore.setState({ theme: "system" });
+    renderHook(() => useThemeEffect());
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+  });
+
+  it("updates the attribute when the theme changes", () => {
+    const { rerender } = renderHook(() => useThemeEffect());
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+
+    useUIStore.getState().setTheme("dark");
+    rerender();
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+});

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,15 +6,18 @@
 import { RouterProvider } from "react-router-dom";
 import { ErrorBoundary } from "@/app/ErrorBoundary";
 import { router } from "@/app/router";
+import { useThemeEffect } from "@/shared/hooks/useThemeEffect";
 
 /**
  * Studio 전체를 Router 컨텍스트로 감싸는 루트 컴포넌트.
  *
  * 전역 ErrorBoundary로 감싸 렌더 중 throw가 SPA 전체를 빈 화면으로 만들지 않게 한다(#81).
+ * 저장된 테마를 문서에 적용해 light/dark 선택이 실제 UI에 반영되게 한다(#96).
  *
  * @returns 전역 Provider가 적용된 라우터 렌더링 결과.
  */
 export function App() {
+  useThemeEffect();
   return (
     <ErrorBoundary>
       <RouterProvider router={router} />

--- a/src/app/ErrorBoundary.tsx
+++ b/src/app/ErrorBoundary.tsx
@@ -81,3 +81,74 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     return this.props.children;
   }
 }
+
+/**
+ * 단일 feature 영역에서만 보여줄 한국어 폴백 카드 (#97).
+ *
+ * 전역 폴백과 달리 화면 전체를 차지하지 않으며, 셸(사이드바/헤더)을 유지한 채 해당 feature
+ * 영역만 오류 UI로 대체한다. 새로고침 대신 영역만 다시 그리는 ‘다시 시도’를 제공한다.
+ *
+ * @param feature - 오류가 난 기능 이름(예: "미리보기").
+ * @param onRetry - 경계 상태를 초기화해 하위 트리를 다시 렌더하는 콜백.
+ * @returns 영역 한정 오류 안내 UI.
+ */
+function FeatureErrorFallback({ feature, onRetry }: { feature: string; onRetry: () => void }) {
+  return (
+    <main
+      role="alert"
+      className="flex flex-1 flex-col items-center justify-center gap-4 px-6 py-16 text-center"
+    >
+      <p className="text-lg font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
+        {feature} 화면에 문제가 발생했습니다
+      </p>
+      <p className="max-w-md text-sm leading-6 text-zinc-600 dark:text-zinc-300">
+        이 영역만 일시적으로 표시할 수 없습니다. 사이드바와 다른 메뉴는 정상적으로 사용할 수 있어요.
+        잠시 후 다시 시도해주세요.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex items-center justify-center rounded-full bg-zinc-900 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+      >
+        다시 시도
+      </button>
+    </main>
+  );
+}
+
+interface FeatureErrorBoundaryProps {
+  /** 폴백 메시지에 노출할 기능 이름 */
+  feature: string;
+  /** 보호할 feature 하위 트리 */
+  children: ReactNode;
+}
+
+/**
+ * 개별 feature(라우트 세그먼트)의 렌더 예외를 잡아 해당 영역만 폴백으로 대체하는 경계 (#97).
+ *
+ * 전역 `ErrorBoundary`까지 버블업해 앱 전체가 빈 화면이 되는 것을 막아, 한 기능의 오류가
+ * 나머지 셸(내비게이션/헤더)에 영향을 주지 않게 한다. ‘다시 시도’ 시 경계 상태만 초기화한다.
+ */
+export class FeatureErrorBoundary extends Component<
+  FeatureErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(`Feature error (${this.props.feature}):`, error, info.componentStack);
+  }
+
+  private readonly handleRetry = () => this.setState({ hasError: false });
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return <FeatureErrorFallback feature={this.props.feature} onRetry={this.handleRetry} />;
+    }
+    return this.props.children;
+  }
+}

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -3,8 +3,9 @@
  *
  * 공통 `Layout` 아래에 홈, 빌드 초안, 검증, 미리보기, 설정 같은 작업실 화면을 배치한다.
  */
+import type { ReactElement } from "react";
 import { createBrowserRouter } from "react-router-dom";
-import { RouteErrorBoundary } from "@/app/ErrorBoundary";
+import { FeatureErrorBoundary, RouteErrorBoundary } from "@/app/ErrorBoundary";
 import { Layout } from "@/app/Layout";
 import { ArtifactsPage } from "@/pages/ArtifactsPage";
 import { BuildArtifactsPage } from "@/pages/BuildArtifactsPage";
@@ -19,6 +20,21 @@ import { SettingsPage } from "@/pages/SettingsPage";
 import { ValidatePage } from "@/pages/ValidatePage";
 
 /**
+ * 페이지 요소를 feature 단위 ErrorBoundary로 감싼다 (#97).
+ *
+ * 한 feature의 렌더 오류가 전역 폴백까지 버블업해 앱 전체(셸 포함)를 빈 화면으로 만들지 않도록,
+ * 각 라우트 요소를 해당 영역만 폴백하는 경계로 감싼다. Layout의 `<Outlet />` 안쪽에서 동작하므로
+ * 사이드바/헤더는 유지된다.
+ *
+ * @param feature - 폴백에 노출할 기능 이름.
+ * @param element - 보호할 페이지 요소.
+ * @returns 경계로 감싼 요소.
+ */
+function withFeatureBoundary(feature: string, element: ReactElement): ReactElement {
+  return <FeatureErrorBoundary feature={feature}>{element}</FeatureErrorBoundary>;
+}
+
+/**
  * 브라우저 URL과 Studio 페이지 컴포넌트를 연결하는 전역 라우터.
  *
  * @returns 각 경로별 렌더링 규칙을 담은 브라우저 라우터 인스턴스.
@@ -31,55 +47,55 @@ export const router = createBrowserRouter([
     children: [
       {
         index: true,
-        element: <HomePage />,
+        element: withFeatureBoundary("홈", <HomePage />),
       },
       {
         path: "builds",
-        element: <BuildsPage />,
+        element: withFeatureBoundary("빌드 목록", <BuildsPage />),
       },
       {
         path: "builds/new",
-        element: <NewBuildPage />,
+        element: withFeatureBoundary("새 빌드 만들기", <NewBuildPage />),
       },
       // Build 단위 중심 라우트 (제안 §3.3): 상세 → 편집/실행/결과물/게시.
       {
         path: "builds/:buildId",
-        element: <BuildDetailPage />,
+        element: withFeatureBoundary("빌드 상세", <BuildDetailPage />),
       },
       {
         // 편집은 New Build와 동일한 에디터를 재사용한다.
         path: "builds/:buildId/edit",
-        element: <NewBuildPage />,
+        element: withFeatureBoundary("빌드 편집", <NewBuildPage />),
       },
       {
         path: "builds/:buildId/run",
-        element: <BuildRunPage />,
+        element: withFeatureBoundary("빌드 실행", <BuildRunPage />),
       },
       {
         path: "builds/:buildId/artifacts",
-        element: <BuildArtifactsPage />,
+        element: withFeatureBoundary("결과물", <BuildArtifactsPage />),
       },
       {
         path: "builds/:buildId/publish",
-        element: <BuildPublishPage />,
+        element: withFeatureBoundary("게시", <BuildPublishPage />),
       },
       // 레거시 단독 라우트: 내비게이션에서는 제거됐지만 딥링크 호환을 위해 유지한다.
       // Validate/Preview는 New Build Wizard 내부 패널로 통합 예정(§5.3/§5.4).
       {
         path: "validate",
-        element: <ValidatePage />,
+        element: withFeatureBoundary("검증", <ValidatePage />),
       },
       {
         path: "preview",
-        element: <PreviewPage />,
+        element: withFeatureBoundary("미리보기", <PreviewPage />),
       },
       {
         path: "artifacts",
-        element: <ArtifactsPage />,
+        element: withFeatureBoundary("결과물", <ArtifactsPage />),
       },
       {
         path: "settings",
-        element: <SettingsPage />,
+        element: withFeatureBoundary("설정", <SettingsPage />),
       },
     ],
   },

--- a/src/globals.css
+++ b/src/globals.css
@@ -1,5 +1,21 @@
 @import "tailwindcss";
 
+/*
+ * Tailwind `dark:` 변형을 사용자가 선택한 테마(`<html data-theme>`)에 연동한다 (#96).
+ * 기본값(prefers-color-scheme)만으로는 SettingsPage에서 고른 light/dark가 `dark:` 유틸리티에
+ * 반영되지 않으므로, 명시적 `data-theme="dark"` 또는 (속성 미설정 + OS 다크)일 때 활성화한다.
+ */
+@custom-variant dark {
+  &:where([data-theme="dark"], [data-theme="dark"] *) {
+    @slot;
+  }
+  @media (prefers-color-scheme: dark) {
+    &:where(:root:not([data-theme]), :root:not([data-theme]) *) {
+      @slot;
+    }
+  }
+}
+
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/src/shared/hooks/useThemeEffect.ts
+++ b/src/shared/hooks/useThemeEffect.ts
@@ -1,0 +1,43 @@
+/**
+ * 저장된 테마 모드를 실제 DOM에 적용하는 이펙트 훅 (#96).
+ *
+ * `useUIStore`는 테마 값(`system | light | dark`)을 localStorage에 저장하지만, 그 값을
+ * 문서에 반영하는 코드가 없었다. 이 훅은 `<html>`의 `data-theme` 속성을 갱신해
+ * `globals.css`의 테마별 CSS 변수와 Tailwind `dark:` 변형(`@custom-variant dark`)을 활성화한다.
+ *
+ * - `light` / `dark`: `data-theme`를 해당 값으로 설정한다.
+ * - `system`: `data-theme`를 제거해 `prefers-color-scheme`에 위임하고, OS 테마 변경을
+ *   실시간으로 따라가도록 미디어 쿼리 변화를 구독한다.
+ */
+import { useEffect } from "react";
+import { useUIStore } from "@/shared/hooks/useUIStore";
+
+/** 선택된 테마 모드를 `<html data-theme>`에 반영한다. system이면 속성을 제거한다. */
+function applyTheme(theme: "system" | "light" | "dark"): void {
+  const root = document.documentElement;
+  if (theme === "system") {
+    root.removeAttribute("data-theme");
+  } else {
+    root.setAttribute("data-theme", theme);
+  }
+}
+
+/**
+ * 저장된 테마를 문서에 적용하고 system 모드에서 OS 테마 변경을 따라간다.
+ *
+ * 앱 루트에서 한 번 호출한다(중복 호출해도 무해하지만 불필요하다).
+ */
+export function useThemeEffect(): void {
+  const theme = useUIStore((state) => state.theme);
+
+  useEffect(() => {
+    applyTheme(theme);
+    if (theme !== "system") return;
+
+    // system 모드: OS 테마가 바뀌면 즉시 반영되도록 prefers-color-scheme를 구독한다.
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = () => applyTheme("system");
+    media.addEventListener("change", handleChange);
+    return () => media.removeEventListener("change", handleChange);
+  }, [theme]);
+}


### PR DESCRIPTION
## Summary

Two independent UI/UX resilience fixes.

### #96 — apply the persisted theme to the DOM (P3)
`useUIStore` already persisted `theme` (`system | light | dark`) but **nothing applied it**, so the dark-mode selection had no visible effect.
- New `useThemeEffect` hook (called once from `App`) sets `data-theme` on `<html>` for `light`/`dark`, and **removes** it for `system` so `prefers-color-scheme` takes over — with a live `matchMedia` subscription so OS theme changes are followed in system mode.
- Added `@custom-variant dark` to `globals.css` so Tailwind's `dark:` utilities follow the explicit `data-theme` choice (and still honor OS dark in system mode). Previously `dark:` only tracked `prefers-color-scheme`, so a manual light/dark pick never toggled `dark:` styles.

Verified in the production build output: `dark:` utilities compile to both `:where([data-theme=dark], …)` and `@media (prefers-color-scheme:dark) :where(:root:not([data-theme]) …)`, and the existing `:root[data-theme="…"]` CSS variables already covered the rest.

### #97 — feature-level ErrorBoundary (P3)
A render error in one feature previously bubbled to the app-level boundary and blanked the **entire** shell (sidebar/header included).
- New `FeatureErrorBoundary` contains an error to its own route segment, keeping the surrounding shell mounted, and offers a local **다시 시도** that resets only the boundary (no full-page reload).
- Every route element in `router.tsx` is wrapped via a small `withFeatureBoundary(feature, element)` helper. It sits inside `Layout`'s `<Outlet />`, so the navigation shell stays intact when a single feature fails.

## Design notes
- `data-theme` (vs. a `dark` class) was chosen because the existing `globals.css` already keys its CSS variables off `:root[data-theme="…"]`; this keeps a single source of truth.
- The feature fallback intentionally reuses the same visual language as the global fallback but is non-fullscreen and reset-only.

## Verification
- `npx tsc --noEmit` — clean
- `npx eslint .` — clean
- `npx vitest run` — 28 files / 110 tests pass (adds `themeEffect.test.tsx`, `featureErrorBoundary.test.tsx`)
- `npx vite build` — succeeds; custom dark variant compiles correctly

Closes #96
Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)