### PR TITLE
fix(contracts): align BuildManifest to Builder shape + real-mode-aware listBuilds (#95, #98)

### DIFF
--- a/__tests__/artifactsApi.test.ts
+++ b/__tests__/artifactsApi.test.ts
@@ -35,14 +35,15 @@ describe("getBuildManifest (#75)", () => {
     const manifest = await getBuildManifest("run-99");
 
     expect(String(fetchMock.mock.calls[0][0])).toContain("/artifacts/run-99");
-    expect(manifest.buildId).toBe("run-99");
-    expect(manifest.artifactPaths).toEqual([
+    expect(manifest.build_id).toBe("run-99");
+    expect(manifest.outputs).toEqual([
       "artifacts/builds/run-99/data.jsonl",
       "artifacts/builds/run-99/README.md",
     ]);
     // /artifacts가 제공하지 않는 필드는 안전한 기본값(페이지가 깨지지 않음).
-    expect(manifest.recordCount).toBe(0);
-    expect(manifest.sources).toEqual([]);
+    expect(manifest.row_counts).toEqual({});
+    expect(manifest.provenance).toEqual([]);
+    expect(manifest.inputs_fingerprint).toBeNull();
   });
 
   it("returns the mock manifest without network in mock mode", async () => {
@@ -52,7 +53,8 @@ describe("getBuildManifest (#75)", () => {
     const manifest = await getBuildManifest("mock-build");
 
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(manifest.buildId).toBe("mock-build");
-    expect(manifest.recordCount).toBeGreaterThan(0);
+    expect(manifest.build_id).toBe("mock-build");
+    const total = Object.values(manifest.row_counts).reduce((sum, n) => sum + n, 0);
+    expect(total).toBeGreaterThan(0);
   });
 });

--- a/__tests__/listBuilds.test.ts
+++ b/__tests__/listBuilds.test.ts
@@ -1,0 +1,28 @@
+/**
+ * listBuilds 실연동 모드 분기 테스트 (#95).
+ *
+ * mock 모드에서는 결정적 mock 이력을 반환하고, 실연동 모드에서는 Builder에 아직 GET /builds가
+ * 없으므로(builder #250) 가짜 이력 대신 빈 목록을 반환하는지 검증한다. 실연동 모드에서 mock
+ * 데이터를 그대로 노출하면 사용자를 오도한다.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listBuilds } from "@/features/runs/api";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("listBuilds (#95)", () => {
+  it("returns deterministic mock history in mock mode", async () => {
+    const builds = await listBuilds();
+    expect(builds.length).toBe(3);
+    expect(builds.map((b) => b.spec.title)).toContain("대기오염 정보");
+  });
+
+  it("returns an empty list in real mode (no Builder GET /builds yet, builder #250)", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    const builds = await listBuilds();
+    // 가짜 mock 이력을 실데이터처럼 노출하지 않는다.
+    expect(builds).toEqual([]);
+  });
+});

--- a/__tests__/manifestContract.test.ts
+++ b/__tests__/manifestContract.test.ts
@@ -1,0 +1,69 @@
+/**
+ * BuildManifest 타입 ↔ Builder manifest 와이어 형태 정합성 테스트 (#98).
+ *
+ * Builder `manifest/writer.py`가 디스크에 기록하는 JSON payload를 그대로 Studio의 BuildManifest로
+ * 받아도 타입 오류 없이 모든 필드가 매핑되는지 고정한다. 한쪽 구조가 바뀌면 컴파일/테스트가 깨져
+ * 크로스 레포 불일치를 조기에 잡는다. (이전 camelCase·recordCount 단일 합계 형태는 실제 출력과 달랐다.)
+ */
+import { describe, expect, it } from "vitest";
+import type { BuildManifest } from "@/shared/lib/types";
+
+// Builder manifest/writer.py payload 그대로(snake_case, 정렬 키).
+const WIRE_MANIFEST: BuildManifest = {
+  schema_version: "1.0.0",
+  build_id: "run-air-quality-1",
+  started_at: "2026-06-21T00:00:00+00:00",
+  finished_at: "2026-06-21T00:00:08+00:00",
+  build_environment: {
+    python_version: "3.12.3",
+    kpubdata_version: "0.4.0",
+    builder_version: "0.4.0",
+  },
+  inputs: ["datago.air-quality"],
+  inputs_fingerprint: "sha256:abc",
+  outputs: ["artifacts/builds/run-air-quality-1/data.jsonl"],
+  warnings: [],
+  errors: [],
+  row_counts: { "datago.air-quality": 12304 },
+  schema_summaries: {
+    "datago.air-quality": {
+      fields: [{ name: "sidoName", type: "string", nullable: false }],
+      total_fields: 1,
+    },
+  },
+  provenance: [
+    {
+      provider: "datago",
+      dataset: "air-quality",
+      fetched_at: "2026-06-21T00:00:05+00:00",
+      record_count: 12304,
+      data_checksum: "sha256:def",
+      api_version: "unknown",
+      params: { sidoName: "서울" },
+    },
+  ],
+};
+
+describe("BuildManifest contract (#98)", () => {
+  it("accepts the real Builder manifest wire shape with all fields populated", () => {
+    expect(WIRE_MANIFEST.build_id).toBe("run-air-quality-1");
+    expect(WIRE_MANIFEST.row_counts["datago.air-quality"]).toBe(12304);
+    expect(WIRE_MANIFEST.schema_summaries["datago.air-quality"].total_fields).toBe(1);
+    expect(WIRE_MANIFEST.provenance[0].data_checksum).toBe("sha256:def");
+    expect(WIRE_MANIFEST.build_environment?.builder_version).toBe("0.4.0");
+  });
+
+  it("allows null build_environment and inputs_fingerprint (no inputs case)", () => {
+    const empty: BuildManifest = {
+      ...WIRE_MANIFEST,
+      build_environment: null,
+      inputs: [],
+      inputs_fingerprint: null,
+      row_counts: {},
+      schema_summaries: {},
+      provenance: [],
+    };
+    expect(empty.build_environment).toBeNull();
+    expect(empty.inputs_fingerprint).toBeNull();
+  });
+});

--- a/src/features/artifacts/api/index.ts
+++ b/src/features/artifacts/api/index.ts
@@ -17,19 +17,47 @@ import type { BuildManifest } from "@/shared/lib/types";
  * @returns mock BuildManifest.
  */
 function mockManifest(buildId: string): BuildManifest {
+  const sourceKey = "datago.air-quality";
   return {
-    buildId,
-    startedAt: "2026-06-21T00:00:00.000Z",
-    finishedAt: "2026-06-21T00:00:08.000Z",
-    sources: [{ provider: "datago", dataset: "air-quality", params: { sidoName: "서울" } }],
-    artifactPaths: [
+    schema_version: "1.0.0",
+    build_id: buildId,
+    started_at: "2026-06-21T00:00:00.000Z",
+    finished_at: "2026-06-21T00:00:08.000Z",
+    build_environment: {
+      python_version: "3.12.3",
+      kpubdata_version: "0.4.0",
+      builder_version: "0.4.0",
+    },
+    inputs: [sourceKey],
+    inputs_fingerprint: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    outputs: [
       `artifacts/builds/${buildId}/data.jsonl`,
       `artifacts/builds/${buildId}/README.md`,
       `artifacts/builds/${buildId}/manifest.json`,
     ],
-    recordCount: 12304,
     warnings: [],
     errors: [],
+    row_counts: { [sourceKey]: 12304 },
+    schema_summaries: {
+      [sourceKey]: {
+        fields: [
+          { name: "sidoName", type: "string", nullable: false },
+          { name: "pm10Value", type: "int64", nullable: true },
+        ],
+        total_fields: 2,
+      },
+    },
+    provenance: [
+      {
+        provider: "datago",
+        dataset: "air-quality",
+        fetched_at: "2026-06-21T00:00:05.000Z",
+        record_count: 12304,
+        data_checksum: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        api_version: "unknown",
+        params: { sidoName: "서울" },
+      },
+    ],
   };
 }
 
@@ -43,14 +71,19 @@ function mockManifest(buildId: string): BuildManifest {
  */
 function artifactsToManifest(runId: string, files: string[]): BuildManifest {
   return {
-    buildId: runId,
-    startedAt: "",
-    finishedAt: "",
-    sources: [],
-    artifactPaths: files,
-    recordCount: 0,
+    schema_version: "1.0.0",
+    build_id: runId,
+    started_at: "",
+    finished_at: "",
+    build_environment: null,
+    inputs: [],
+    inputs_fingerprint: null,
+    outputs: files,
     warnings: [],
     errors: [],
+    row_counts: {},
+    schema_summaries: {},
+    provenance: [],
   };
 }
 

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -53,15 +53,8 @@ function mockSpec(datasetId: string, title: string): BuildSpec {
   };
 }
 
-/**
- * 빌드 실행 이력 목록을 조회한다 (#12).
- *
- * #29 Builder API 연동 전까지는 결정적 mock 목록을 반환해 이력 표/검색/정렬 UI를
- * 개발·검증할 수 있게 한다.
- *
- * @returns 빌드 실행 목록(mock).
- */
-export async function listBuilds(): Promise<BuildRun[]> {
+/** mock 모드에서 보여줄 결정적 빌드 이력. */
+function mockBuilds(): BuildRun[] {
   return [
     {
       id: "run-air-quality-3",
@@ -84,5 +77,28 @@ export async function listBuilds(): Promise<BuildRun[]> {
       startedAt: "2026-06-21T10:15:00.000Z",
     },
   ];
+}
+
+/**
+ * 빌드 실행 이력 목록을 조회한다 (#12, #95).
+ *
+ * mock 모드(`VITE_USE_REAL_BUILDER` 미설정)에서는 이력 표/검색/정렬 UI를 개발·검증할 수
+ * 있도록 결정적 mock 목록을 반환한다.
+ *
+ * 실연동 모드에서는 Builder에 이력 목록 엔드포인트(`GET /builds`)가 아직 없다(builder #250).
+ * 그 전까지 mock 데이터를 실데이터처럼 보여주면 사용자를 오도하므로, 실연동 모드에서는
+ * 가짜 이력을 만들지 않고 빈 목록을 반환한다. Builder에 `GET /builds`가 추가되면 이 분기에서
+ * 해당 API를 호출하고 응답을 BuildRun[]으로 매핑하도록 확장한다(executeBuild의 실연동 패턴과 동일).
+ *
+ * @returns 빌드 실행 목록(mock 모드: 결정적 mock, 실연동 모드: 현재는 빈 목록).
+ */
+export async function listBuilds(): Promise<BuildRun[]> {
+  if (!isRealBuilderEnabled()) {
+    return mockBuilds();
+  }
+
+  // TODO(builder #250): Builder에 GET /builds가 추가되면 실제 이력을 호출·매핑한다.
+  // 그 전까지는 가짜 이력 대신 빈 목록을 반환해 실연동 모드에서 mock을 노출하지 않는다.
+  return [];
 }
 

--- a/src/pages/BuildArtifactsPage.tsx
+++ b/src/pages/BuildArtifactsPage.tsx
@@ -53,8 +53,12 @@ export function BuildArtifactsPage() {
 
   const manifest = state.manifest;
   const formats = manifest
-    ? [...new Set(manifest.artifactPaths.map((path) => describeFile(path).format))]
+    ? [...new Set(manifest.outputs.map((path) => describeFile(path).format))]
     : [];
+  // Builder는 소스별 row_counts(dict)를 주므로 UI 요약에서는 합계로 보여준다.
+  const totalRecords = manifest
+    ? Object.values(manifest.row_counts).reduce((sum, count) => sum + count, 0)
+    : 0;
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
@@ -91,7 +95,7 @@ export function BuildArtifactsPage() {
               <div>
                 <dt className="text-zinc-500 dark:text-zinc-400">레코드 수</dt>
                 <dd className="text-zinc-800 dark:text-zinc-100">
-                  {manifest.recordCount.toLocaleString("ko-KR")}
+                  {totalRecords.toLocaleString("ko-KR")}
                 </dd>
               </div>
               <div>
@@ -101,12 +105,12 @@ export function BuildArtifactsPage() {
               <div>
                 <dt className="text-zinc-500 dark:text-zinc-400">소스</dt>
                 <dd className="text-zinc-800 dark:text-zinc-100">
-                  {manifest.sources.map((s) => `${s.provider}.${s.dataset}`).join(", ")}
+                  {manifest.provenance.map((p) => `${p.provider}.${p.dataset}`).join(", ")}
                 </dd>
               </div>
               <div>
                 <dt className="text-zinc-500 dark:text-zinc-400">빌드 ID</dt>
-                <dd className="break-all text-zinc-800 dark:text-zinc-100">{manifest.buildId}</dd>
+                <dd className="break-all text-zinc-800 dark:text-zinc-100">{manifest.build_id}</dd>
               </div>
             </dl>
           </Card>
@@ -117,11 +121,11 @@ export function BuildArtifactsPage() {
               <span>형식</span>
               <span>액션</span>
             </div>
-            {manifest.artifactPaths.length === 0 ? (
+            {manifest.outputs.length === 0 ? (
               <EmptyState title="생성된 파일이 없습니다" />
             ) : (
               <ul>
-                {manifest.artifactPaths.map((path) => {
+                {manifest.outputs.map((path) => {
                   const { name, format } = describeFile(path);
                   return (
                     <li

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -55,23 +55,87 @@ export interface ExportTarget {
   options?: Record<string, string>;
 }
 
+/** manifest 스키마 요약의 단일 컬럼 정보(Builder schema_summary.py FieldSummary). */
+export interface ManifestFieldSummary {
+  /** 컬럼명 */
+  name: string;
+  /** 컬럼 타입의 문자열 표현 */
+  type: string;
+  /** 컬럼에 null 값이 존재할 수 있는지 여부 */
+  nullable: boolean;
+}
+
+/** 소스(산출물)별 스키마 요약(Builder schema_summary.py SchemaSummary). */
+export interface ManifestSchemaSummary {
+  /** 컬럼 순서를 보존한 필드 요약 목록 */
+  fields: ManifestFieldSummary[];
+  /** 컬럼 개수(fields 길이와 동일) */
+  total_fields: number;
+}
+
+/** 소스별 상세 출처 정보(Builder provenance.py SourceProvenance). */
+export interface ManifestSourceProvenance {
+  /** 데이터 제공자 식별자(예: datago) */
+  provider: string;
+  /** 데이터셋 식별자 */
+  dataset: string;
+  /** fetch 완료 시각(UTC ISO 8601 문자열) */
+  fetched_at: string;
+  /** 가져온 레코드 수 */
+  record_count: number;
+  /** 데이터의 재현 가능한 체크섬("sha256:..." 형식) */
+  data_checksum: string;
+  /** 소스 API 버전. 알 수 없으면 "unknown" */
+  api_version: string;
+  /** fetch 요청 파라미터 스냅샷 */
+  params: Record<string, unknown>;
+}
+
+/** 빌드를 생성한 실행 환경 스냅샷(Builder environment.py BuildEnvironment). */
+export interface ManifestBuildEnvironment {
+  /** 빌드를 실행한 Python 버전 */
+  python_version: string;
+  /** 설치된 kpubdata 버전. 알 수 없으면 "unknown" */
+  kpubdata_version: string;
+  /** 설치된 kpubdata-builder 버전. 알 수 없으면 "unknown" */
+  builder_version: string;
+}
+
+/**
+ * Builder가 디스크에 기록하는 manifest JSON의 와이어 형태와 1:1 정렬된 타입 (#98).
+ *
+ * Builder `manifest/writer.py`의 직렬화 payload를 그대로 따른다(snake_case). 기존의
+ * camelCase·단일 합계(recordCount)·SourceRef[] 형태는 실제 Builder 출력과 달라 매핑이
+ * 깨졌었다. 이 타입은 Builder가 반환하는 풍부한 정보(provenance/schema/환경/지문)를
+ * UI가 그대로 활용할 수 있게 한다.
+ */
 export interface BuildManifest {
+  /** manifest 직렬화 형식 버전(semver, Builder MANIFEST_SCHEMA_VERSION) */
+  schema_version: string;
   /** 실행된 빌드를 추적하는 고유 ID */
-  buildId: string;
-  /** 빌드 시작 시각 ISO 문자열 */
-  startedAt: string;
-  /** 빌드 종료 시각 ISO 문자열 */
-  finishedAt: string;
-  /** 실행에 사용된 원본 소스 목록 */
-  sources: SourceRef[];
-  /** 생성된 파일 경로 목록 */
-  artifactPaths: string[];
-  /** 처리된 총 레코드 수 */
-  recordCount: number;
+  build_id: string;
+  /** 빌드 시작 시각 ISO 문자열(UTC) */
+  started_at: string;
+  /** 빌드 종료 시각 ISO 문자열(UTC) */
+  finished_at: string;
+  /** 빌드를 생성한 실행 환경. 캡처하지 못했으면 null */
+  build_environment: ManifestBuildEnvironment | null;
+  /** 입력 파일 또는 소스 식별자 목록 */
+  inputs: string[];
+  /** 입력 데이터 전체의 재현성 지문("sha256:..."). 입력이 없으면 null */
+  inputs_fingerprint: string | null;
+  /** 생성된 결과물 경로 목록 */
+  outputs: string[];
   /** 치명적이지 않지만 확인이 필요한 경고 목록 */
   warnings: string[];
-  /** 실행 실패 또는 검토 필요 오류 목록 */
+  /** 실행 실패 또는 부분 실패 메시지 목록 */
   errors: string[];
+  /** 단계별 또는 산출물별 레코드 수 요약(소스 키 → 건수) */
+  row_counts: Record<string, number>;
+  /** 소스(산출물) 키별 스키마 요약. row_counts와 동일한 키를 사용한다 */
+  schema_summaries: Record<string, ManifestSchemaSummary>;
+  /** 소스별 상세 출처(fetch 시각/파라미터/레코드 수/체크섬) 목록 */
+  provenance: ManifestSourceProvenance[];
 }
 
 export interface BuildDraft {


### PR DESCRIPTION
## Summary

Cross-repo contract correctness: align the manifest type to what the Builder actually emits, and stop faking build history in real mode.

### #98 — BuildManifest type matches the real Builder manifest (P2)
The Studio `BuildManifest` was camelCase, used a single `recordCount`, and modeled `sources` as `SourceRef[]` — none of which match what the Builder writes in `manifest/writer.py`. As a result, mapping the real manifest into Studio silently dropped fields (`recordCount` was always undefined against the real payload).

Realigned the type **1:1 with the Builder JSON wire shape** (snake_case):
- `schema_version`, `build_id`, `started_at`, `finished_at`
- `build_environment` (`{ python_version, kpubdata_version, builder_version }` or `null`)
- `inputs: string[]`, `inputs_fingerprint: string | null`
- `outputs: string[]`, `warnings: string[]`, `errors: string[]`
- `row_counts: Record<string, number>` (per-source, not a single total)
- `schema_summaries: Record<string, { fields: {name,type,nullable}[]; total_fields }>`
- `provenance: { provider, dataset, fetched_at, record_count, data_checksum, api_version, params }[]`

Added the nested types (`ManifestFieldSummary`, `ManifestSchemaSummary`, `ManifestSourceProvenance`, `ManifestBuildEnvironment`) and updated the `artifacts/api` mock + real-mode mapper and the `BuildArtifactsPage` consumer (`outputs`, summed `row_counts`, `provenance`, `build_id`). A new `manifestContract.test.ts` locks the type to the Builder wire payload so future drift breaks CI.

> Cross-checked against the Builder source: `src/kpubdata_builder/manifest/{writer,models,provenance,schema_summary,environment}.py`. Note the real payload also includes `schema_version`, which the issue's field table omitted — it is included here.

### #95 — listBuilds is real-mode-aware, not faked (P2)
`listBuilds()` always returned the same 3 hardcoded mock runs, even with `VITE_USE_REAL_BUILDER=true`.

- Mock mode: unchanged deterministic history (keeps the history table/search/sort UI testable).
- Real mode: returns an **empty list**. The Builder has **no `GET /builds` endpoint yet** (builder #250), so real history genuinely isn't available from Studio's side. Returning mock data in real mode would mislead users into thinking those builds exist. The real-mode branch is the documented extension point (with a `builder #250` reference) for when that endpoint lands.

## Cross-repo dependency
Fully resolving #95 (real history) is **blocked on builder #250** (`GET /builds`). This PR does the Studio-side half safely and honestly rather than fabricating data; flip the real-mode branch to call the endpoint once it exists.

## Verification
- `npx tsc --noEmit` — clean (no remaining consumers of the old fields)
- `npx eslint .` — clean
- `npx vitest run` — 28 files / 107 tests pass (adds `listBuilds.test.ts`, `manifestContract.test.ts`; updates `artifactsApi.test.ts`)
- `npx vite build` — succeeds

Closes #95
Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)