### PR TITLE
[S-003/S-004/S-005/S-006] Studio 타입 안전성 및 UX 개선

### DIFF
--- a/src/features/build-spec/specMapping.ts
+++ b/src/features/build-spec/specMapping.ts
@@ -16,7 +16,7 @@ import type { BuildSpec, ExportTarget } from "@/shared/lib/types";
 interface BuilderExport {
   kind: string;
   output_path: string;
-  options?: Record<string, string>;
+  options?: Record<string, unknown>;
 }
 
 /** Builder가 기대하는 BuildSpec(snake_case). */
@@ -43,7 +43,7 @@ const FORMAT_EXTENSION: Record<ExportTarget["format"], string> = {
 
 /** export별 output_path를 파생한다. huggingface는 디렉터리, 그 외는 파일 경로. */
 function deriveOutputPath(spec: BuildSpec, target: ExportTarget): string {
-  const base = spec.metadata.outputPath || `artifacts/builds/${spec.datasetId}`;
+  const base = spec.metadata["outputPath"] ?? `artifacts/builds/${spec.datasetId}`;
   if (target.format === "huggingface") return target.options?.outputPath ?? base;
   return `${base}/data.${FORMAT_EXTENSION[target.format]}`;
 }

--- a/src/features/build-spec/specMapping.ts
+++ b/src/features/build-spec/specMapping.ts
@@ -44,7 +44,10 @@ const FORMAT_EXTENSION: Record<ExportTarget["format"], string> = {
 /** export별 output_path를 파생한다. huggingface는 디렉터리, 그 외는 파일 경로. */
 function deriveOutputPath(spec: BuildSpec, target: ExportTarget): string {
   const base = spec.metadata["outputPath"] ?? `artifacts/builds/${spec.datasetId}`;
-  if (target.format === "huggingface") return target.options?.outputPath ?? base;
+  if (target.format === "huggingface") {
+    const outputPath = target.options?.outputPath;
+    return typeof outputPath === "string" ? outputPath : base;
+  }
   return `${base}/data.${FORMAT_EXTENSION[target.format]}`;
 }
 
@@ -82,4 +85,29 @@ export function toBuilderSpec(spec: BuildSpec): BuilderSpec {
  */
 export function serializeSpec(spec: BuildSpec): string {
   return JSON.stringify(toBuilderSpec(spec));
+}
+
+/**
+ * Builder BuildSpec(snake_case)을 Studio BuildSpec(camelCase)으로 역변환한다.
+ *
+ * toBuilderSpec()의 역연산. Builder에서 저장된 스펙을 불러와 Studio에서
+ * 재편집할 때 사용한다.
+ */
+export function fromBuilderSpec(spec: BuilderSpec): BuildSpec {
+  return {
+    datasetId: spec.dataset_id,
+    title: spec.title,
+    description: spec.description,
+    sources: spec.sources.map((source) => ({
+      provider: source.provider,
+      dataset: source.dataset,
+      params: source.params,
+      ...(source.alias ? { alias: source.alias } : {}),
+    })),
+    exports: spec.exports.map((e) => ({
+      format: e.kind as ExportTarget["format"],
+      ...(e.options ? { options: e.options } : {}),
+    })),
+    metadata: spec.metadata,
+  };
 }

--- a/src/pages/BuildDetailPage.tsx
+++ b/src/pages/BuildDetailPage.tsx
@@ -5,7 +5,7 @@
  * 실제 데이터는 #29 Builder API 연동 시 useBuild(buildId)로 채운다.
  */
 import { Link, useParams } from "react-router-dom";
-import { Card, LinkButton, PageHeader, StatusBadge } from "@/shared/ui";
+import { Card, LinkButton, PageHeader, Skeleton } from "@/shared/ui";
 
 const SUBPAGES = [
   { segment: "edit", label: "편집", description: "스펙 수정" },
@@ -33,7 +33,7 @@ export function BuildDetailPage() {
 
       <Card className="flex flex-wrap items-center gap-3">
         <span className="text-sm text-zinc-600 dark:text-zinc-300">현재 상태</span>
-        <StatusBadge status="draft" />
+        <Skeleton className="h-5 w-16 rounded-full" />
         <span className="text-sm text-zinc-500 dark:text-zinc-400">
           Builder API 연동(#29) 후 실제 상태가 표시됩니다.
         </span>

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -52,7 +52,7 @@ export interface ExportTarget {
   /** 결과물을 어떤 형식으로 내보낼지 결정하는 식별자 */
   format: "markdown" | "jsonl" | "parquet" | "huggingface";
   /** 특정 export 형식에만 필요한 추가 옵션 집합 */
-  options?: Record<string, string>;
+  options?: Record<string, unknown>;
 }
 
 /** manifest 스키마 요약의 단일 컬럼 정보(Builder schema_summary.py FieldSummary). */


### PR DESCRIPTION
## 변경 사항

### S-003: ExportTarget 옵션 타입 확장
- `types.ts`의 `ExportTarget.options` 필드를 `Record<string, unknown>`으로 확장
- 더 유연한 옵션 값 지원

### S-004: BuilderExport 및 deriveOutputPath 개선
- `specMapping.ts`의 `BuilderExport.options` 타입을 `Record<string, unknown>`으로 확장
- `deriveOutputPath` 함수에서 메타데이터 접근 시 nullish coalescing (`??`) 사용

### S-005: BuildDetailPage 상태 배지 교체
- 로딩 스켈레톤으로 교체하여 Builder API 통합 준비
- `StatusBadge` → `Skeleton` 컴포넌트로 변경

### S-006: fromBuilderSpec 역변환 함수 추가
- Builder의 snake_case 스펙을 Studio의 camelCase로 변환하는 역함수 구현
- `toBuilderSpec()`의 완전한 역연산으로 spec 로딩/편집 지원

## 검증
- ✅ `npx tsc --noEmit` 통과 (타입 안전)
- ✅ `npm run lint` 통과 (코드 스타일)

Closes #107, #108, #109, #110