### PR TITLE
docs: fix broken mermaid diagrams

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ npx tsc --noEmit
 우리는 `main` 브랜치에 직접 코드를 올리지 않습니다. 반드시 기능별 브랜치를 만들어 작업합니다.
 
 ```mermaid
-gitgraph
+gitGraph
     commit id: "initial"
     branch feat/issue-5-dashboard-page
     checkout feat/issue-5-dashboard-page

--- a/INFORMATION_ARCHITECTURE.md
+++ b/INFORMATION_ARCHITECTURE.md
@@ -58,11 +58,11 @@ graph TD
 
 ```mermaid
 graph LR
-    Root[/] --> Dashboard[HomePage]
-    Root --> Builds[/builds]
+    Root["/"] --> Dashboard[HomePage]
+    Root --> Builds["/builds"]
 
     Builds --> BuildList[BuildsPage]
-    Builds --> New[/new]
+    Builds --> New["/new"]
 ```
 
 | 경로 | 화면 내용 | 폴더 위치 |

--- a/UI_SPEC.md
+++ b/UI_SPEC.md
@@ -4,8 +4,8 @@
 
 ```mermaid
 flowchart TD
-    Home[Home / Dashboard] -->|Create New| Editor[Build Editor]
-    Home -->|View Recent| Run[Build Run / History]
+    Home["Home / Dashboard"] -->|Create New| Editor[Build Editor]
+    Home -->|View Recent| Run["Build Run / History"]
     Editor -->|Validate/Run| Run
     Run -->|Success| Artifacts[Artifact Viewer]
     Artifacts -->|Share| Publish[Publish Page]
@@ -48,17 +48,17 @@ flowchart TD
 
 ```mermaid
 graph TD
-    subgraph EditorPage [Build Editor Page]
-        Header[Editor Header: Validate/Run Buttons]
-        subgraph MainContent [Main Configuration Area]
+    subgraph EditorPage ["Build Editor Page"]
+        Header["Editor Header: Validate/Run Buttons"]
+        subgraph MainContent ["Main Configuration Area"]
             direction LR
-            SourceArea[1. Source: Provider/Dataset/Params]
-            ExportArea[2. Export Config: Format/Target]
+            SourceArea["1. Source: Provider/Dataset/Params"]
+            ExportArea["2. Export Config: Format/Target"]
         end
-        subgraph FeedbackArea [Feedback Panels]
+        subgraph FeedbackArea ["Feedback Panels"]
             direction LR
-            PreviewPanel[3. Preview Panel: Data Table]
-            ValidationPanel[4. Validation Panel: Errors/Warnings]
+            PreviewPanel["3. Preview Panel: Data Table"]
+            ValidationPanel["4. Validation Panel: Errors/Warnings"]
         end
         Header --> MainContent
         MainContent --> FeedbackArea
@@ -120,7 +120,7 @@ graph TD
 
 ```mermaid
 graph LR
-    subgraph Screens [Studio 화면]
+    subgraph Screens ["Studio 화면"]
         HomeS[Home Dashboard]
         EditorS[Build Editor]
         RunS[Build Run Tracking]
@@ -129,12 +129,12 @@ graph LR
         SettingsS[Settings]
     end
 
-    subgraph APIEndpoints [Builder API 엔드포인트]
-        GET_Version[GET /version]
-        POST_Validate[POST /validate]
-        POST_Preview[POST /preview]
-        POST_Build[POST /build]
-        GET_Artifacts[GET /artifacts/{run_id}]
+    subgraph APIEndpoints ["Builder API 엔드포인트"]
+        GET_Version["GET /version"]
+        POST_Validate["POST /validate"]
+        POST_Preview["POST /preview"]
+        POST_Build["POST /build"]
+        GET_Artifacts["GET /artifacts/{run_id}"]
     end
 
     SettingsS --> GET_Version

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -127,7 +127,7 @@ flowchart TD
     Type --> ValFail[검증 실패]
 
     BuildFail --> BuildLog[빌드 로그 분석]
-    BuildLog --> EditSpec[명세(Spec) 수정]
+    BuildLog --> EditSpec["명세(Spec) 수정"]
     EditSpec --> Retry[재시도]
 
     NetFail --> Offline[오프라인 모드 알림]


### PR DESCRIPTION
## 요약
- CONTRIBUTING.md, INFORMATION_ARCHITECTURE.md, UI_SPEC.md, USER_FLOWS.md의 렌더링되지 않던 mermaid 다이어그램 수정
- 슬래시/중괄호/괄호가 포함된 노드 라벨을 따옴표 처리하고 `gitGraph` 대소문자 교정

## 검증
- 전역 설치된 `mmdc`(mermaid CLI)로 모든 mermaid 블록 렌더링 성공 확인