### PR TITLE
fix: validate export target options schema

### DIFF
--- a/src/shared/lib/schemas.ts
+++ b/src/shared/lib/schemas.ts
@@ -16,6 +16,9 @@ export const exportFormatSchema = z.enum([
 /** 문자열 키와 문자열 값만 허용하는 공통 레코드 스키마 */
 export const recordSchema = z.record(z.string(), z.string());
 
+/** export 옵션은 문자열 키에 임의 값(unknown)을 허용한다 (ExportTarget.options 규약과 정렬) */
+export const exportOptionsSchema = z.record(z.string(), z.unknown());
+
 /** 단일 원본 데이터 참조가 가져야 할 필드를 검증하는 스키마 */
 export const sourceRefSchema = z.object({
   provider: z.string().min(1, "Provider is required."),
@@ -27,7 +30,7 @@ export const sourceRefSchema = z.object({
 /** 결과물 export 대상 정의를 검증하는 스키마 */
 export const exportTargetSchema = z.object({
   format: exportFormatSchema,
-  options: recordSchema.optional(),
+  options: exportOptionsSchema.optional(),
 });
 
 /** 새 빌드 작성 화면에서 생성하는 전체 스펙 구조를 검증하는 스키마 */


### PR DESCRIPTION
## 요약
- `exportOptionsSchema = z.record(z.string(), z.unknown())`를 추가하여 `exportTargetSchema.options`가 `ExportTarget.options: Record<string, unknown>` 타입과 일치하도록 수정
- 공용 `recordSchema`는 변경하지 않음

## 검증
- LSP 진단 클린