### PR TITLE
fix: do not retry POST /build (#117)

### DIFF
--- a/src/shared/lib/builderApi.test.ts
+++ b/src/shared/lib/builderApi.test.ts
@@ -37,16 +37,25 @@ describe("builderApi retry policy", () => {
   });
 
   it("retries idempotent GET /version on 5xx", async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(jsonResponse(500, { error: "temp" }))
-      .mockResolvedValueOnce(
-        jsonResponse(200, { service: "kpubdata-builder", api_version: "1.0.0" }),
-      );
+    // 실제 백오프 대기(500ms)를 기다리지 않도록 fake timer로 시간을 직접 진행시킨다.
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(jsonResponse(500, { error: "temp" }))
+        .mockResolvedValueOnce(
+          jsonResponse(200, { service: "kpubdata-builder", api_version: "1.0.0" }),
+        );
 
-    const result = await builderApi.version();
+      const pending = builderApi.version();
+      // 첫 번째 재시도 전 백오프(500ms)를 즉시 소리을 통과시킨다.
+      await vi.advanceTimersByTimeAsync(500);
+      const result = await pending;
 
-    expect(result.api_version).toBe("1.0.0");
-    expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+      expect(result.api_version).toBe("1.0.0");
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/shared/lib/builderApi.test.ts
+++ b/src/shared/lib/builderApi.test.ts
@@ -1,0 +1,52 @@
+/**
+ * builderApi 재시도 정책 테스트 (#117).
+ *
+ * 비멱등 POST /build는 5xx에도 재시도하지 않아야 하며, 멱등 GET은 재시도한다.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { builderApi } from "./builderApi";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("builderApi retry policy", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not retry POST /build on 5xx (#117)", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(500, { error: "boom" }));
+
+    await expect(builderApi.build("dataset_id: x")).rejects.toMatchObject({
+      status: 500,
+    });
+
+    // 최초 1회만 호출되어야 한다 (재시도 없음).
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries idempotent GET /version on 5xx", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(500, { error: "temp" }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, { service: "kpubdata-builder", api_version: "1.0.0" }),
+      );
+
+    const result = await builderApi.version();
+
+    expect(result.api_version).toBe("1.0.0");
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+  });
+});

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -279,12 +279,13 @@ export const builderApi = {
   preview: (specYaml: string, signal?: AbortSignal) =>
     apiFetch<PreviewResponse>("/preview", { method: "POST", body: { spec: specYaml }, signal }),
 
-  /** POST /build — 빌드 실행. run_id 생략 가능. */
+  /** POST /build — 빌드 실행. run_id 생략 가능. 비멱등 요청이므로 재시도하지 않는다 (#117). */
   build: (specYaml: string, runId?: string, signal?: AbortSignal) =>
     apiFetch<BuildResponse>("/build", {
       method: "POST",
       body: runId ? { spec: specYaml, run_id: runId } : { spec: specYaml },
       signal,
+      retries: 0,
     }),
 
   /** GET /artifacts/{runId} — 실행 산출물 파일 목록. */


### PR DESCRIPTION
## 요약
- `builderApi.build()`에 `retries: 0`을 전달하여 비멱등 `POST /build`가 5xx/네트워크 오류 시 재시도되지 않도록 수정 (중복 빌드 방지)
- 멱등 GET 요청은 기존대로 재시도 유지

## 검증
- vitest: build 5xx 시 fetch 1회만 호출, GET은 재시도 확인 (2 tests pass)
- `tsc --noEmit`, `eslint` 통과

Closes #117