### PR TITLE
fix: 빌드 요청에 생성된 run_id 전달 (#118)

### DIFF
--- a/src/features/runs/api/index.test.ts
+++ b/src/features/runs/api/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { generateRunId } from "./index";
+
+describe("generateRunId", () => {
+  it("dataset id를 경로 안전한 슬러그로 정규화한다", () => {
+    const runId = generateRunId("My Dataset/2024!");
+    expect(runId).toMatch(/^my-dataset-2024-\d+$/);
+  });
+
+  it("빈/비영숫자 dataset id는 'build' 기본값으로 대체한다", () => {
+    const runId = generateRunId("!!!");
+    expect(runId).toMatch(/^build-\d+$/);
+  });
+
+  it("호출마다 서로 다른 값을 생성한다", async () => {
+    const first = generateRunId("ds");
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    const second = generateRunId("ds");
+    expect(first).not.toBe(second);
+  });
+});

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -12,6 +12,23 @@ import type { BuildRun, BuildSpec } from "@/shared/lib/types";
 const MOCK_TIME = "1970-01-01T00:00:00.000Z";
 
 /**
+ * BuildSpec으로부터 경로 안전한 run_id를 생성한다.
+ *
+ * Builder는 run_id를 산출물 디렉터리 이름으로 사용하므로 안전한 세그먼트
+ * (영숫자/하이픈)만 남긴다. dataset id와 타임스탬프를 결합해 사람이 식별 가능하면서도
+ * 충돌하지 않는 값을 만든다.
+ */
+export function generateRunId(datasetId: string): string {
+  const slug = datasetId
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+  const base = slug.length > 0 ? slug : "build";
+  return `${base}-${Date.now()}`;
+}
+
+/**
  * 새 빌드 실행을 시작하고 실행 결과를 반환한다.
  *
  * @param spec - 실행할 빌드 스펙.
@@ -30,8 +47,9 @@ export async function executeBuild(spec: BuildSpec, signal?: AbortSignal): Promi
   }
 
   // 실연동 모드에서는 실제 실행 시각을 기록한다(이력/상세 화면에서 잘못된 1970 값 방지).
+  const runId = generateRunId(spec.datasetId);
   const startedAt = new Date().toISOString();
-  const result = await builderApi.build(serializeSpec(spec), undefined, signal);
+  const result = await builderApi.build(serializeSpec(spec), runId, signal);
   return {
     id: result.run_id,
     spec,


### PR DESCRIPTION
## 요약
- `executeBuild`가 `builderApi.build(...)`에 `run_id`로 `undefined`를 넘겨 Builder가 산출물 디렉터리를 식별할 수 없던 문제 수정 (#118)
- `generateRunId(datasetId)` 헬퍼 추가: dataset id를 경로 안전한 슬러그(영숫자/하이픈, 최대 40자)로 정규화하고 `Date.now()`를 결합해 충돌 없는 식별 가능한 run_id 생성. 비영숫자/빈 값은 `build` 기본값으로 대체.

## 테스트
- `src/features/runs/api/index.test.ts` 신규: 슬러그 정규화, 기본값 대체, 유니크성 3케이스
- `npx vitest run` 통과, `tsc --noEmit` / `eslint` 통과

Closes #118