### PR TITLE
fix: fromBuilderSpec에서 output_path 보존 및 kind 검증 (#121)

### DIFF
--- a/src/features/build-spec/specMapping.test.ts
+++ b/src/features/build-spec/specMapping.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import type { BuilderSpec } from "./specMapping";
+import { fromBuilderSpec } from "./specMapping";
+
+const baseBuilderSpec: BuilderSpec = {
+  dataset_id: "sample",
+  title: "샘플",
+  description: "설명",
+  sources: [{ provider: "github", dataset: "repos", params: {} }],
+  exports: [
+    { kind: "jsonl", output_path: "artifacts/builds/sample/data.jsonl" },
+  ],
+  metadata: {},
+};
+
+describe("fromBuilderSpec", () => {
+  it("Builder export의 output_path를 options.outputPath로 보존한다", () => {
+    const result = fromBuilderSpec(baseBuilderSpec);
+    expect(result.exports[0]?.options?.["outputPath"]).toBe(
+      "artifacts/builds/sample/data.jsonl",
+    );
+  });
+
+  it("기존 options를 유지하면서 output_path를 병합한다", () => {
+    const spec: BuilderSpec = {
+      ...baseBuilderSpec,
+      exports: [
+        {
+          kind: "huggingface",
+          output_path: "datasets/sample",
+          options: { repoId: "org/sample" },
+        },
+      ],
+    };
+    const result = fromBuilderSpec(spec);
+    expect(result.exports[0]?.options).toMatchObject({
+      repoId: "org/sample",
+      outputPath: "datasets/sample",
+    });
+  });
+
+  it("알 수 없는 kind는 즉시 예외를 던진다", () => {
+    const spec: BuilderSpec = {
+      ...baseBuilderSpec,
+      exports: [{ kind: "unknown-format", output_path: "x" }],
+    };
+    expect(() => fromBuilderSpec(spec)).toThrow(/알 수 없는 export kind/);
+  });
+});

--- a/src/features/build-spec/specMapping.ts
+++ b/src/features/build-spec/specMapping.ts
@@ -41,6 +41,23 @@ const FORMAT_EXTENSION: Record<ExportTarget["format"], string> = {
   huggingface: "",
 };
 
+/** Studio가 지원하는 export 형식 집합. Builder 응답의 kind 검증에 사용한다. */
+const KNOWN_FORMATS = new Set<ExportTarget["format"]>(
+  Object.keys(FORMAT_EXTENSION) as ExportTarget["format"][],
+);
+
+/**
+ * Builder export의 kind를 Studio 형식으로 검증·변환한다.
+ *
+ * 알 수 없는 kind는 조용히 잘못된 스펙을 만들지 않도록 즉시 실패시킨다(#121).
+ */
+function parseExportFormat(kind: string): ExportTarget["format"] {
+  if (KNOWN_FORMATS.has(kind as ExportTarget["format"])) {
+    return kind as ExportTarget["format"];
+  }
+  throw new Error(`알 수 없는 export kind입니다: ${kind}`);
+}
+
 /** export별 output_path를 파생한다. huggingface는 디렉터리, 그 외는 파일 경로. */
 function deriveOutputPath(spec: BuildSpec, target: ExportTarget): string {
   const base = spec.metadata["outputPath"] ?? `artifacts/builds/${spec.datasetId}`;
@@ -104,10 +121,17 @@ export function fromBuilderSpec(spec: BuilderSpec): BuildSpec {
       params: source.params,
       ...(source.alias ? { alias: source.alias } : {}),
     })),
-    exports: spec.exports.map((e) => ({
-      format: e.kind as ExportTarget["format"],
-      ...(e.options ? { options: e.options } : {}),
-    })),
+    exports: spec.exports.map((e) => {
+      // Builder의 output_path는 Studio ExportTarget에 대응 필드가 없어 options에 보존한다(#121).
+      const options: Record<string, unknown> = { ...(e.options ?? {}) };
+      if (e.output_path) {
+        options["outputPath"] = e.output_path;
+      }
+      return {
+        format: parseExportFormat(e.kind),
+        ...(Object.keys(options).length > 0 ? { options } : {}),
+      };
+    }),
     metadata: spec.metadata,
   };
 }


### PR DESCRIPTION
## 요약
- `fromBuilderSpec`이 Builder export의 `output_path`를 버리고 `kind`를 무검증으로 강제 캐스팅하던 문제 수정 (#121)
- `output_path`를 Studio `ExportTarget.options.outputPath`에 보존해 라운드트립 시 손실되지 않도록 함 (Studio 모델에는 output_path 전용 필드가 없음)
- `parseExportFormat()` 추가: 알려진 형식 집합(`KNOWN_FORMATS`)으로 `kind`를 검증하고, 알 수 없는 값은 즉시 명확히 실패

## 테스트
- `src/features/build-spec/specMapping.test.ts` 신규: output_path 보존, 기존 options 병합, 알 수 없는 kind 예외 3케이스
- `npx vitest run` 통과, `tsc --noEmit` / `eslint` 통과

Closes #121