### PR TITLE
UI 재디자인: 모던 SaaS 대시보드 스타일

### DIFF
--- a/__tests__/ui/components.test.tsx
+++ b/__tests__/ui/components.test.tsx
@@ -133,6 +133,6 @@ describe("LinkButton", () => {
     );
     const link = screen.getByRole("link", { name: "목록" });
     expect(link).toHaveAttribute("href", "/builds");
-    expect(link).toHaveClass("rounded-full");
+    expect(link).toHaveClass("rounded-lg");
   });
 });

--- a/src/app/ErrorBoundary.tsx
+++ b/src/app/ErrorBoundary.tsx
@@ -19,17 +19,17 @@ export function ErrorFallback() {
       role="alert"
       className="flex min-h-screen flex-1 flex-col items-center justify-center gap-4 px-6 py-16 text-center"
     >
-      <p className="text-2xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
+      <p className="text-2xl font-semibold tracking-tight text-foreground">
         문제가 발생했습니다
       </p>
-      <p className="max-w-md text-sm leading-6 text-zinc-600 dark:text-zinc-300">
+      <p className="max-w-md text-sm leading-6 text-muted-foreground">
         예기치 못한 오류로 화면을 표시할 수 없습니다. 페이지를 새로고침하면 대부분 해결됩니다.
         문제가 계속되면 잠시 후 다시 시도해주세요.
       </p>
       <button
         type="button"
         onClick={() => window.location.reload()}
-        className="inline-flex items-center justify-center rounded-full bg-zinc-900 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+        className="inline-flex items-center justify-center rounded-lg bg-accent px-5 py-2.5 text-sm font-medium text-accent-foreground shadow-sm transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         새로고침
       </button>
@@ -98,17 +98,17 @@ function FeatureErrorFallback({ feature, onRetry }: { feature: string; onRetry: 
       role="alert"
       className="flex flex-1 flex-col items-center justify-center gap-4 px-6 py-16 text-center"
     >
-      <p className="text-lg font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
+      <p className="text-lg font-semibold tracking-tight text-foreground">
         {feature} 화면에 문제가 발생했습니다
       </p>
-      <p className="max-w-md text-sm leading-6 text-zinc-600 dark:text-zinc-300">
+      <p className="max-w-md text-sm leading-6 text-muted-foreground">
         이 영역만 일시적으로 표시할 수 없습니다. 사이드바와 다른 메뉴는 정상적으로 사용할 수 있어요.
         잠시 후 다시 시도해주세요.
       </p>
       <button
         type="button"
         onClick={onRetry}
-        className="inline-flex items-center justify-center rounded-full bg-zinc-900 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+        className="inline-flex items-center justify-center rounded-lg bg-accent px-5 py-2.5 text-sm font-medium text-accent-foreground shadow-sm transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         다시 시도
       </button>

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -60,10 +60,10 @@ function getResolvedTheme(theme: ReturnType<typeof useUIStore.getState>["theme"]
  */
 function navigationClassName({ isActive }: { isActive: boolean }) {
   return [
-    "group flex items-start justify-between gap-3 rounded-3xl border px-4 py-3 text-left transition",
+    "group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition",
     isActive
-      ? "border-zinc-900 bg-zinc-900 text-white shadow-lg shadow-zinc-950/10 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-950"
-      : "border-zinc-200/80 bg-white/70 text-zinc-700 hover:border-zinc-300 hover:bg-white dark:border-zinc-800 dark:bg-zinc-950/50 dark:text-zinc-200 dark:hover:border-zinc-700 dark:hover:bg-zinc-950",
+      ? "bg-accent-subtle text-accent-subtle-foreground"
+      : "text-muted-foreground hover:bg-muted hover:text-foreground",
   ].join(" ");
 }
 
@@ -113,25 +113,27 @@ export function Layout() {
 
         <aside
           className={[
-            "fixed inset-y-0 left-0 z-40 flex w-[18.5rem] flex-col border-r border-zinc-200/70 bg-white/90 px-5 py-5 backdrop-blur transition-transform dark:border-zinc-800 dark:bg-zinc-950/90 lg:static lg:translate-x-0",
+            "fixed inset-y-0 left-0 z-40 flex w-72 flex-col border-r border-border bg-card px-4 py-5 transition-transform lg:static lg:translate-x-0",
             isSidebarOpen ? "translate-x-0" : "-translate-x-full",
           ].join(" ")}
         >
-          <div className="flex items-start justify-between gap-4 border-b border-zinc-200/70 pb-5 dark:border-zinc-800">
+          <div className="flex items-start justify-between gap-3 pb-5">
             <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-600 dark:text-emerald-400">
-                KPubData Studio
-              </p>
-              <Link className="mt-2 block text-2xl font-semibold tracking-tight" to="/">
-                공공데이터 빌드 스튜디오
-              </Link>
-              <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
-                데이터 소스 선택부터 미리보기(Preview), 검증, 결과물까지 한 흐름으로 진행하세요.
+              <div className="flex items-center gap-2">
+                <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent text-sm font-bold text-accent-foreground">
+                  K
+                </span>
+                <Link className="text-base font-semibold tracking-tight" to="/">
+                  KPubData Studio
+                </Link>
+              </div>
+              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                데이터 소스 선택부터 미리보기, 검증, 결과물까지 한 흐름으로 진행하세요.
               </p>
             </div>
             <button
               aria-label="사이드바 닫기"
-              className="rounded-full border border-zinc-200 p-2 text-zinc-500 lg:hidden dark:border-zinc-800 dark:text-zinc-300"
+              className="rounded-lg border border-border p-1.5 text-muted-foreground hover:bg-muted lg:hidden"
               onClick={closeSidebar}
               type="button"
             >
@@ -139,8 +141,11 @@ export function Layout() {
             </button>
           </div>
 
-          <nav className="mt-6 flex flex-1 flex-col gap-6">
-            <div className="space-y-3">
+          <nav className="mt-2 flex flex-1 flex-col">
+            <p className="px-3 pb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              메뉴
+            </p>
+            <div className="space-y-1">
               {primaryNavItems.map((item) => (
                 <NavLink
                   className={navigationClassName}
@@ -148,30 +153,20 @@ export function Layout() {
                   key={item.to}
                   onClick={closeSidebar}
                   to={item.to}
+                  title={item.description}
                 >
-                  <div>
-                    <p className="font-medium tracking-tight">{item.label}</p>
-                    <p className="mt-1 text-sm opacity-80">{item.description}</p>
-                  </div>
-                  <span className="mt-1 text-xs uppercase tracking-[0.25em] opacity-60">
-                    열기
-                  </span>
+                  {item.label}
                 </NavLink>
               ))}
             </div>
           </nav>
 
-          <div className="rounded-3xl border border-zinc-200/80 bg-zinc-50/80 p-4 dark:border-zinc-800 dark:bg-zinc-900/70">
+          <div className="mt-4 rounded-lg border border-border bg-muted p-3">
             <div className="flex items-center justify-between gap-3">
-              <div>
-                <p className="text-sm font-medium">테마</p>
-                <p className="text-sm text-zinc-600 dark:text-zinc-300">
-                  작업 중에도 화면이 잘 보이도록 테마를 선택하세요.
-                </p>
-              </div>
+              <p className="text-sm font-medium">테마</p>
               <select
                 aria-label="테마 선택"
-                className="rounded-full border border-zinc-200 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-950"
+                className="rounded-lg border border-input bg-card px-2.5 py-1.5 text-sm"
                 onChange={(event) => setTheme(event.target.value as "system" | "light" | "dark")}
                 value={theme}
               >
@@ -184,29 +179,29 @@ export function Layout() {
         </aside>
 
         <div className="flex min-h-screen flex-1 flex-col lg:pl-0">
-          <header className="sticky top-0 z-20 border-b border-zinc-200/70 bg-white/80 backdrop-blur dark:border-zinc-800 dark:bg-zinc-950/80">
-            <div className="flex items-center justify-between gap-4 px-5 py-4 sm:px-8">
+          <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur">
+            <div className="flex items-center justify-between gap-4 px-5 py-3.5 sm:px-8">
               <div className="flex items-center gap-3">
                 <button
                   aria-label="사이드바 열기/닫기"
-                  className="inline-flex rounded-full border border-zinc-200 bg-white p-2 text-zinc-700 shadow-sm lg:hidden dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100"
+                  className="inline-flex rounded-lg border border-border bg-card p-2 text-foreground lg:hidden"
                   onClick={toggleSidebar}
                   type="button"
                 >
                   ☰
                 </button>
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+                  <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                     Builder 제어 화면
                   </p>
-                  <h1 className="text-lg font-semibold tracking-tight">
+                  <h1 className="text-base font-semibold tracking-tight">
                     학생과 메인테이너를 위한 공공데이터 빌드 워크플로
                   </h1>
                 </div>
               </div>
 
               <Link
-                className="rounded-full bg-emerald-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-400"
+                className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground shadow-sm transition hover:brightness-110"
                 to={headerCta.to}
               >
                 {headerCta.label}

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -61,6 +61,7 @@ function getResolvedTheme(theme: ReturnType<typeof useUIStore.getState>["theme"]
 function navigationClassName({ isActive }: { isActive: boolean }) {
   return [
     "group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
     isActive
       ? "bg-accent-subtle text-accent-subtle-foreground"
       : "text-muted-foreground hover:bg-muted hover:text-foreground",
@@ -133,7 +134,7 @@ export function Layout() {
             </div>
             <button
               aria-label="사이드바 닫기"
-              className="rounded-lg border border-border p-1.5 text-muted-foreground hover:bg-muted lg:hidden"
+              className="rounded-lg border border-border p-1.5 text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background lg:hidden"
               onClick={closeSidebar}
               type="button"
             >
@@ -184,7 +185,7 @@ export function Layout() {
               <div className="flex items-center gap-3">
                 <button
                   aria-label="사이드바 열기/닫기"
-                  className="inline-flex rounded-lg border border-border bg-card p-2 text-foreground lg:hidden"
+                  className="inline-flex rounded-lg border border-border bg-card p-2 text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background lg:hidden"
                   onClick={toggleSidebar}
                   type="button"
                 >
@@ -201,7 +202,7 @@ export function Layout() {
               </div>
 
               <Link
-                className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground shadow-sm transition hover:brightness-110"
+                className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground shadow-sm transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 to={headerCta.to}
               >
                 {headerCta.label}

--- a/src/features/build-spec/components/SpecDiff.tsx
+++ b/src/features/build-spec/components/SpecDiff.tsx
@@ -47,7 +47,7 @@ export function SpecDiff({ before, after }: SpecDiffProps) {
   }
 
   return (
-    <ul className="divide-y divide-zinc-100 dark:divide-zinc-900">
+    <ul className="divide-y divide-border">
       {changes.map((change) => {
         const meta = KIND_META[change.kind];
         return (
@@ -57,8 +57,8 @@ export function SpecDiff({ before, after }: SpecDiffProps) {
             >
               {meta.sign} {meta.label}
             </span>
-            <span className="font-mono text-zinc-700 dark:text-zinc-200">{change.path}</span>
-            <span className="text-zinc-500 dark:text-zinc-400">
+            <span className="font-mono text-foreground">{change.path}</span>
+            <span className="text-muted-foreground">
               {change.kind === "changed" ? (
                 <>
                   <span className="line-through">{change.before}</span> → {change.after}

--- a/src/globals.css
+++ b/src/globals.css
@@ -16,34 +16,91 @@
   }
 }
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
+/*
+ * 시맨틱 디자인 토큰.
+ *
+ * 모던 SaaS 대시보드(Linear/Vercel 계열) 룩을 위해 중립 팔레트 + 에메랄드 강조를
+ * 시맨틱 토큰으로 정의한다. 각 토큰은 light/dark 두 값을 모두 가진다.
+ *  - background/foreground: 페이지 바탕/기본 텍스트
+ *  - card/card-foreground: 카드·패널 표면
+ *  - muted/muted-foreground: 보조 배경과 보조 텍스트
+ *  - border: 얇고 선명한 경계선
+ *  - accent(에메랄드): 상호작용·강조 요소
+ */
+:root,
 :root[data-theme="light"] {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #fafafa;
+  --foreground: #18181b;
+  --card: #ffffff;
+  --card-foreground: #18181b;
+  --muted: #f4f4f5;
+  --muted-foreground: #71717a;
+  --border: #e4e4e7;
+  --input: #e4e4e7;
+  --ring: #10b981;
+  --accent: #059669;
+  --accent-foreground: #ffffff;
+  --accent-subtle: #ecfdf5;
+  --accent-subtle-foreground: #047857;
 }
 
 :root[data-theme="dark"] {
-  --background: #0a0a0a;
-  --foreground: #ededed;
+  --background: #09090b;
+  --foreground: #fafafa;
+  --card: #111113;
+  --card-foreground: #fafafa;
+  --muted: #18181b;
+  --muted-foreground: #a1a1aa;
+  --border: #27272a;
+  --input: #27272a;
+  --ring: #10b981;
+  --accent: #10b981;
+  --accent-foreground: #052e1f;
+  --accent-subtle: #052e21;
+  --accent-subtle-foreground: #6ee7b7;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --background: #09090b;
+    --foreground: #fafafa;
+    --card: #111113;
+    --card-foreground: #fafafa;
+    --muted: #18181b;
+    --muted-foreground: #a1a1aa;
+    --border: #27272a;
+    --input: #27272a;
+    --ring: #10b981;
+    --accent: #10b981;
+    --accent-foreground: #052e1f;
+    --accent-subtle: #052e21;
+    --accent-subtle-foreground: #6ee7b7;
+  }
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino,
-    Georgia, serif;
-  --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-}
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent-subtle: var(--accent-subtle);
+  --color-accent-subtle-foreground: var(--accent-subtle-foreground);
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme]) {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, "Noto Sans KR", sans-serif;
+  --font-mono: ui-monospace, "SFMono-Regular", "SF Mono", Consolas,
+    "Liberation Mono", Menlo, monospace;
+
+  --radius-lg: 0.625rem;
+  --radius-xl: 0.875rem;
+  --radius-2xl: 1.125rem;
 }
 
 body {
@@ -51,4 +108,6 @@ body {
   color: var(--foreground);
   font-family: var(--font-sans);
   min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }

--- a/src/pages/BuildArtifactsPage.tsx
+++ b/src/pages/BuildArtifactsPage.tsx
@@ -88,35 +88,35 @@ export function BuildArtifactsPage() {
       {state.status === "loaded" && manifest ? (
         <>
           <Card>
-            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+            <p className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
               Manifest 요약
             </p>
             <dl className="mt-3 grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
               <div>
-                <dt className="text-zinc-500 dark:text-zinc-400">레코드 수</dt>
-                <dd className="text-zinc-800 dark:text-zinc-100">
+                <dt className="text-muted-foreground">레코드 수</dt>
+                <dd className="text-foreground">
                   {totalRecords.toLocaleString("ko-KR")}
                 </dd>
               </div>
               <div>
-                <dt className="text-zinc-500 dark:text-zinc-400">출력 형식</dt>
-                <dd className="text-zinc-800 dark:text-zinc-100">{formats.join(", ")}</dd>
+                <dt className="text-muted-foreground">출력 형식</dt>
+                <dd className="text-foreground">{formats.join(", ")}</dd>
               </div>
               <div>
-                <dt className="text-zinc-500 dark:text-zinc-400">소스</dt>
-                <dd className="text-zinc-800 dark:text-zinc-100">
+                <dt className="text-muted-foreground">소스</dt>
+                <dd className="text-foreground">
                   {manifest.provenance.map((p) => `${p.provider}.${p.dataset}`).join(", ")}
                 </dd>
               </div>
               <div>
-                <dt className="text-zinc-500 dark:text-zinc-400">빌드 ID</dt>
-                <dd className="break-all text-zinc-800 dark:text-zinc-100">{manifest.build_id}</dd>
+                <dt className="text-muted-foreground">빌드 ID</dt>
+                <dd className="break-all text-foreground">{manifest.build_id}</dd>
               </div>
             </dl>
           </Card>
 
           <Card className="p-0">
-            <div className="grid grid-cols-[1.6fr_0.6fr_0.8fr] gap-4 border-b border-zinc-200/80 px-6 py-4 text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+            <div className="grid grid-cols-[1.6fr_0.6fr_0.8fr] gap-4 border-b border-border px-6 py-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
               <span>파일</span>
               <span>형식</span>
               <span>액션</span>
@@ -130,11 +130,11 @@ export function BuildArtifactsPage() {
                   return (
                     <li
                       key={path}
-                      className="grid grid-cols-[1.6fr_0.6fr_0.8fr] items-center gap-4 border-b border-zinc-100 px-6 py-3 text-sm last:border-0 dark:border-zinc-900"
+                      className="grid grid-cols-[1.6fr_0.6fr_0.8fr] items-center gap-4 border-b border-border px-6 py-3 text-sm last:border-0 "
                     >
                       <span className="break-all font-medium">{name}</span>
-                      <span className="uppercase text-zinc-500 dark:text-zinc-400">{format}</span>
-                      <span className="text-zinc-400 dark:text-zinc-500">다운로드(연동 예정)</span>
+                      <span className="uppercase text-muted-foreground">{format}</span>
+                      <span className="text-muted-foreground">다운로드(연동 예정)</span>
                     </li>
                   );
                 })}
@@ -143,10 +143,10 @@ export function BuildArtifactsPage() {
           </Card>
 
           <Card>
-            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+            <p className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
               manifest.json
             </p>
-            <pre className="mt-4 overflow-x-auto rounded-[1.5rem] bg-zinc-950 p-4 text-xs leading-6 text-zinc-100">
+            <pre className="mt-4 overflow-x-auto rounded-xl bg-zinc-950 p-4 text-xs leading-6 text-zinc-100">
               <code>{JSON.stringify(manifest, null, 2)}</code>
             </pre>
           </Card>

--- a/src/pages/BuildDetailPage.tsx
+++ b/src/pages/BuildDetailPage.tsx
@@ -32,9 +32,9 @@ export function BuildDetailPage() {
       />
 
       <Card className="flex flex-wrap items-center gap-3">
-        <span className="text-sm text-zinc-600 dark:text-zinc-300">현재 상태</span>
+        <span className="text-sm text-muted-foreground">현재 상태</span>
         <Skeleton className="h-5 w-16 rounded-full" />
-        <span className="text-sm text-zinc-500 dark:text-zinc-400">
+        <span className="text-sm text-muted-foreground">
           Builder API 연동(#29) 후 실제 상태가 표시됩니다.
         </span>
       </Card>
@@ -44,10 +44,10 @@ export function BuildDetailPage() {
           <Link
             key={sub.segment}
             to={`/builds/${buildId}/${sub.segment}`}
-            className="rounded-[1.5rem] border border-zinc-200/80 bg-white/80 p-5 transition hover:border-zinc-300 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-800 dark:bg-zinc-950/70"
+            className="rounded-xl border border-border bg-card p-5 transition hover:border-accent/50 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <p className="text-base font-semibold tracking-tight">{sub.label}</p>
-            <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-300">{sub.description}</p>
+            <p className="mt-1 text-sm text-muted-foreground">{sub.description}</p>
           </Link>
         ))}
       </section>

--- a/src/pages/BuildPublishPage.tsx
+++ b/src/pages/BuildPublishPage.tsx
@@ -36,22 +36,22 @@ export function BuildPublishPage() {
       />
 
       <Card>
-        <p className="text-sm font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+        <p className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
           검토 (Review)
         </p>
         <dl className="mt-3 grid gap-2 text-sm sm:grid-cols-2">
           <div>
-            <dt className="text-zinc-500 dark:text-zinc-400">빌드 ID</dt>
-            <dd className="break-all text-zinc-800 dark:text-zinc-100">{buildId || "—"}</dd>
+            <dt className="text-muted-foreground">빌드 ID</dt>
+            <dd className="break-all text-foreground">{buildId || "—"}</dd>
           </div>
           <div>
-            <dt className="text-zinc-500 dark:text-zinc-400">대상</dt>
-            <dd className="text-zinc-800 dark:text-zinc-100">
+            <dt className="text-muted-foreground">대상</dt>
+            <dd className="text-foreground">
               {DESTINATIONS.find((d) => d.id === destination)?.label}
             </dd>
           </div>
         </dl>
-        <p className="mt-3 text-sm text-zinc-500 dark:text-zinc-400">
+        <p className="mt-3 text-sm text-muted-foreground">
           제목·라이선스 등 데이터셋 카드 정보는 Builder publish 엔드포인트 연동 시 manifest에서
           채워집니다.
         </p>
@@ -59,7 +59,7 @@ export function BuildPublishPage() {
 
       <Card>
         <fieldset disabled={isPublishing}>
-          <legend className="text-sm font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+          <legend className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
             배포 대상 (Destination)
           </legend>
           <div className="mt-4 flex flex-col gap-3">
@@ -71,7 +71,7 @@ export function BuildPublishPage() {
                   value={dest.id}
                   checked={destination === dest.id}
                   onChange={() => setDestination(dest.id)}
-                  className="h-4 w-4 accent-zinc-900 dark:accent-white"
+                  className="h-4 w-4 accent-emerald-600"
                 />
                 {dest.label}
               </label>
@@ -106,7 +106,7 @@ export function BuildPublishPage() {
                 결과 보기
               </a>
             ) : (
-              <span className="text-zinc-600 dark:text-zinc-300">
+              <span className="text-muted-foreground">
                 게시가 완료되었습니다. 실제 결과 링크는 Builder 연동 후 표시됩니다.
               </span>
             )}
@@ -118,7 +118,7 @@ export function BuildPublishPage() {
           </span>
         ) : null}
         {publish.status === "cancelled" ? (
-          <span className="text-sm text-zinc-500 dark:text-zinc-400">게시가 취소되었습니다.</span>
+          <span className="text-sm text-muted-foreground">게시가 취소되었습니다.</span>
         ) : null}
       </div>
     </main>

--- a/src/pages/BuildRunPage.tsx
+++ b/src/pages/BuildRunPage.tsx
@@ -38,12 +38,12 @@ export function BuildRunPage() {
       />
 
       <Card className="flex flex-wrap items-center gap-3">
-        <span className="text-sm text-zinc-600 dark:text-zinc-300">상태</span>
+        <span className="text-sm text-muted-foreground">상태</span>
         <StatusBadge status="queued" />
       </Card>
 
       <Card>
-        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+        <p className="mb-4 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
           진행 단계
         </p>
         <Stepper steps={RUN_STEPS} current={0} />

--- a/src/pages/BuildsPage.tsx
+++ b/src/pages/BuildsPage.tsx
@@ -106,7 +106,7 @@ export function BuildsPage() {
       </div>
 
       <Card className="overflow-hidden p-0">
-        <div className="grid grid-cols-[1.4fr_0.7fr_0.9fr_0.7fr] gap-4 border-b border-zinc-200/80 px-6 py-4 text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+        <div className="grid grid-cols-[1.4fr_0.7fr_0.9fr_0.7fr] gap-4 border-b border-border px-6 py-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           <span>빌드</span>
           <span>상태</span>
           <span>마지막 실행</span>
@@ -114,7 +114,7 @@ export function BuildsPage() {
         </div>
 
         {state.status === "loading" ? (
-          <div className="px-6 py-10 text-center text-sm text-zinc-500 dark:text-zinc-400">
+          <div className="px-6 py-10 text-center text-sm text-muted-foreground">
             불러오는 중입니다…
           </div>
         ) : state.status === "error" ? (
@@ -139,13 +139,13 @@ export function BuildsPage() {
             {visible.map((run) => (
               <li
                 key={run.id}
-                className="grid grid-cols-[1.4fr_0.7fr_0.9fr_0.7fr] items-center gap-4 border-b border-zinc-100 px-6 py-3 text-sm last:border-0 dark:border-zinc-900"
+                className="grid grid-cols-[1.4fr_0.7fr_0.9fr_0.7fr] items-center gap-4 border-b border-border px-6 py-3 text-sm last:border-0 "
               >
                 <span className="font-medium">{run.spec.title}</span>
                 <span>
                   <StatusBadge status={run.status} />
                 </span>
-                <span className="text-zinc-600 dark:text-zinc-300">{formatTime(run.startedAt)}</span>
+                <span className="text-muted-foreground">{formatTime(run.startedAt)}</span>
                 <span>
                   <LinkButton variant="secondary" size="sm" to={`/builds/${run.id}`}>
                     보기

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -55,7 +55,7 @@ export function HomePage() {
       <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
         {STATUS_SUMMARY.map((item) => (
           <Card key={item.status} className="flex items-center justify-between">
-            <span className="text-sm text-zinc-600 dark:text-zinc-300">{item.label}</span>
+            <span className="text-sm text-muted-foreground">{item.label}</span>
             <span className="text-2xl font-semibold tracking-tight">{item.count}</span>
           </Card>
         ))}
@@ -84,10 +84,10 @@ export function HomePage() {
             <Link
               key={action.href}
               to={action.href}
-              className="rounded-[1.75rem] border border-zinc-200/80 bg-white/80 p-5 transition hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-lg hover:shadow-zinc-950/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-800 dark:bg-zinc-950/80 dark:hover:border-zinc-700"
+              className="rounded-xl border border-border bg-card p-5 transition hover:-translate-y-0.5 hover:border-accent/50 hover:shadow-lg hover:shadow-zinc-950/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <p className="text-lg font-medium tracking-tight">{action.label}</p>
-              <p className="mt-3 text-sm leading-6 text-zinc-600 dark:text-zinc-300">
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">
                 {action.description}
               </p>
             </Link>

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -377,7 +377,7 @@ export function NewBuildPage() {
 
       {buildId ? (
         <Card variant="dashed" className="p-4">
-          <p className="text-sm text-zinc-700 dark:text-zinc-200">
+          <p className="text-sm text-foreground">
             기존 빌드 <span className="font-medium">{buildId}</span> 편집은 Builder 연동(#29) 후
             지원됩니다. 지금은 새 빌드로 작성됩니다.
           </p>
@@ -386,7 +386,7 @@ export function NewBuildPage() {
 
       {draftAvailable ? (
         <Card variant="dashed" className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
-          <p className="text-sm text-zinc-700 dark:text-zinc-200">
+          <p className="text-sm text-foreground">
             저장된 초안이 있습니다. 이어서 편집할까요?
           </p>
           <div className="flex gap-2">
@@ -409,7 +409,7 @@ export function NewBuildPage() {
           {step === 0 ? (
             <div className="space-y-4">
               <h3 className="text-xl font-semibold tracking-tight">템플릿 선택</h3>
-              <p className="text-sm text-zinc-600 dark:text-zinc-300">
+              <p className="text-sm text-muted-foreground">
                 자주 쓰는 공공데이터 조합으로 시작하거나 빈 빌드로 처음부터 설정하세요.
               </p>
               <div className="grid gap-3 sm:grid-cols-2">
@@ -418,10 +418,10 @@ export function NewBuildPage() {
                     key={template.id}
                     type="button"
                     onClick={() => selectTemplate(template)}
-                    className="rounded-2xl border border-zinc-200/80 bg-white/80 p-4 text-left transition hover:border-zinc-300 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-800 dark:bg-zinc-950/70"
+                    className="rounded-2xl border border-border bg-card p-4 text-left transition hover:border-accent/50 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     <p className="text-base font-semibold tracking-tight">{template.name}</p>
-                    <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-300">
+                    <p className="mt-1 text-sm text-muted-foreground">
                       {template.description}
                     </p>
                   </button>
@@ -564,7 +564,7 @@ export function NewBuildPage() {
                 />
               ) : null}
               {preview.status === "loaded" && preview.rows.length > 0 ? (
-                <p className="text-sm text-zinc-600 dark:text-zinc-300">
+                <p className="text-sm text-muted-foreground">
                   {preview.rows.length}개 샘플 행 · {Object.keys(preview.schema).length}개 컬럼
                 </p>
               ) : null}
@@ -575,19 +575,19 @@ export function NewBuildPage() {
             <div className="space-y-4">
               <h3 className="text-xl font-semibold tracking-tight">출력 형식</h3>
               <fieldset>
-                <legend className="text-sm font-medium text-zinc-800 dark:text-zinc-100">
+                <legend className="text-sm font-medium text-foreground">
                   결과물 형식 (최소 1개)
                 </legend>
                 <div className="mt-3 grid gap-3 md:grid-cols-2">
                   {exportFormats.map((format) => (
                     <label
                       key={format}
-                      className="flex items-center gap-3 rounded-2xl border border-zinc-200/80 bg-zinc-50/80 px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900/70"
+                      className="flex items-center gap-3 rounded-xl border border-border bg-muted px-4 py-3"
                     >
                       <input
                         type="checkbox"
                         value={format}
-                        className="h-4 w-4 accent-zinc-900 dark:accent-white"
+                        className="h-4 w-4 accent-emerald-600"
                         {...register("exportFormats", {
                           validate: (selected) =>
                             (selected?.length ?? 0) > 0 || "출력 형식을 최소 1개 선택해주세요.",
@@ -634,13 +634,13 @@ export function NewBuildPage() {
                 </Button>
               </div>
               {validation.status === "idle" ? (
-                <p className="text-sm text-zinc-600 dark:text-zinc-300">
+                <p className="text-sm text-muted-foreground">
                   ‘다시 검증’을 눌러 입력값과 빌드 설정을 확인하세요.
                 </p>
               ) : null}
               {validation.status === "validated" && validation.isValid ? (
                 <Card variant="success" className="p-4">
-                  <p className="text-sm font-medium text-emerald-800 dark:text-emerald-300">
+                  <p className="text-sm font-medium text-accent-subtle-foreground">
                     검증을 통과했습니다. 빌드를 실행할 수 있습니다.
                   </p>
                 </Card>
@@ -674,7 +674,7 @@ export function NewBuildPage() {
                   </Button>
                 ) : null}
                 {job.status === "succeeded" ? (
-                  <span className="text-sm text-emerald-700 dark:text-emerald-300">
+                  <span className="text-sm text-accent-subtle-foreground">
                     빌드 성공 (run {job.run?.id})
                   </span>
                 ) : null}
@@ -684,14 +684,14 @@ export function NewBuildPage() {
                   </span>
                 ) : null}
                 {job.status === "cancelled" ? (
-                  <span className="text-sm text-zinc-500 dark:text-zinc-400">실행이 취소되었습니다.</span>
+                  <span className="text-sm text-muted-foreground">실행이 취소되었습니다.</span>
                 ) : null}
               </div>
             </div>
           ) : null}
 
           {/* 모바일에서는 하단 sticky action bar로 고정해 긴 폼에서도 이전/다음이 항상 보이게 한다(§13). */}
-          <div className="sticky bottom-0 z-10 -mx-6 -mb-6 mt-8 flex items-center justify-between gap-3 border-t border-zinc-200/80 bg-white/95 px-6 py-3 backdrop-blur sm:static sm:mx-0 sm:mb-0 sm:border-0 sm:bg-transparent sm:px-0 sm:py-0 sm:backdrop-blur-none dark:border-zinc-800 dark:bg-zinc-950/95 sm:dark:bg-transparent">
+          <div className="sticky bottom-0 z-10 -mx-6 -mb-6 mt-8 flex items-center justify-between gap-3 border-t border-border bg-background/95 px-6 py-3 backdrop-blur sm:static sm:mx-0 sm:mb-0 sm:border-0 sm:bg-transparent sm:px-0 sm:py-0 sm:backdrop-blur-none sm:dark:bg-transparent">
             <Button variant="ghost" onClick={goBack} disabled={step === 0}>
               이전
             </Button>
@@ -711,13 +711,13 @@ export function NewBuildPage() {
             {/* 모바일에서 공간을 아끼도록 기본 접힘(details). 데스크톱(xl)에서는 별도 컬럼에
                 표시되며 필요 시 펼친다(§13). */}
             <details className="group">
-              <summary className="flex cursor-pointer list-none items-center justify-between text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+              <summary className="flex cursor-pointer list-none items-center justify-between text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                 생성될 스펙 (Generated spec)
                 <span className="text-base transition group-open:rotate-180" aria-hidden="true">
                   ⌄
                 </span>
               </summary>
-              <pre className="mt-4 overflow-x-auto rounded-[1.5rem] bg-zinc-950 p-4 text-xs leading-6 text-zinc-100">
+              <pre className="mt-4 overflow-x-auto rounded-xl bg-zinc-950 p-4 text-xs leading-6 text-zinc-100">
                 <code>{JSON.stringify(specPreview.spec ?? values, null, 2)}</code>
               </pre>
             </details>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -56,22 +56,22 @@ export function SettingsPage() {
       />
 
       <Card>
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           워크스페이스 (Workspace)
         </p>
-        <p className="mt-2 mb-4 text-sm text-zinc-600 dark:text-zinc-300">
+        <p className="mt-2 mb-4 text-sm text-muted-foreground">
           개인/팀 워크스페이스를 전환합니다. 팀 공유·멤버십 연동은 후속(v0.3)에서 확장됩니다.
         </p>
         <WorkspaceSwitcher />
       </Card>
 
       <Card>
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           Builder API 엔드포인트
         </p>
-        <div className="mt-4 rounded-[1.5rem] border border-dashed border-zinc-300/80 bg-zinc-50/80 p-4 dark:border-zinc-700 dark:bg-zinc-900/80">
+        <div className="mt-4 rounded-xl border border-dashed border-border bg-muted p-4">
           <p className="text-sm font-medium">현재 base URL</p>
-          <code className="mt-3 block break-all text-sm text-emerald-700 dark:text-emerald-400">
+          <code className="mt-3 block break-all text-sm text-accent-subtle-foreground">
             {API_BASE}
           </code>
         </div>
@@ -79,27 +79,27 @@ export function SettingsPage() {
 
       <Card>
         <div className="flex items-center justify-between gap-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             연결 상태
           </p>
-          <span className="text-xs text-zinc-500 dark:text-zinc-400">
+          <span className="text-xs text-muted-foreground">
             Studio 계약 버전 {API_CONTRACT_VERSION}
           </span>
         </div>
         <div className="mt-4 text-sm">
           {!realEnabled ? (
-            <p className="text-zinc-600 dark:text-zinc-300">
+            <p className="text-muted-foreground">
               mock 모드입니다. 실제 Builder에 연결하려면{" "}
-              <code className="text-emerald-700 dark:text-emerald-400">VITE_USE_REAL_BUILDER=true</code>
+              <code className="text-accent-subtle-foreground">VITE_USE_REAL_BUILDER=true</code>
               로 설정하세요.
             </p>
           ) : connection.status === "checking" ? (
-            <p className="text-zinc-600 dark:text-zinc-300">Builder 연결을 확인하는 중입니다…</p>
+            <p className="text-muted-foreground">Builder 연결을 확인하는 중입니다…</p>
           ) : connection.status === "ok" ? (
             <div className="flex flex-col gap-2">
               <div className="flex flex-wrap items-center gap-2">
                 <StatusBadge status="succeeded" />
-                <span className="text-zinc-700 dark:text-zinc-200">
+                <span className="text-foreground">
                   Builder API 버전 {connection.apiVersion}
                 </span>
               </div>

--- a/src/shared/ui/Card.tsx
+++ b/src/shared/ui/Card.tsx
@@ -16,15 +16,15 @@ export interface CardProps extends HTMLAttributes<HTMLDivElement> {
 
 const VARIANT_CLASS: Record<CardVariant, string> = {
   default:
-    "border border-zinc-200/80 bg-white/80 shadow-lg shadow-zinc-950/5 dark:border-zinc-800 dark:bg-zinc-950/70",
+    "border border-border bg-card shadow-sm",
   elevated:
-    "border border-zinc-200/80 bg-white shadow-xl shadow-zinc-950/10 dark:border-zinc-800 dark:bg-zinc-950",
+    "border border-border bg-card shadow-md",
   dashed:
-    "border-2 border-dashed border-zinc-300 bg-transparent dark:border-zinc-700",
+    "border border-dashed border-border bg-transparent",
   error:
-    "border border-red-300 bg-red-50/80 dark:border-red-900/60 dark:bg-red-950/30",
+    "border border-red-300 bg-red-50 dark:border-red-900/60 dark:bg-red-950/30",
   success:
-    "border border-emerald-300 bg-emerald-50/80 dark:border-emerald-900/60 dark:bg-emerald-950/30",
+    "border border-emerald-300 bg-emerald-50 dark:border-emerald-900/60 dark:bg-emerald-950/30",
 };
 
 /**
@@ -35,7 +35,7 @@ const VARIANT_CLASS: Record<CardVariant, string> = {
  */
 export function Card({ variant = "default", className, children, ...rest }: CardProps) {
   return (
-    <div className={cn("rounded-[2rem] p-6", VARIANT_CLASS[variant], className)} {...rest}>
+    <div className={cn("rounded-xl p-6", VARIANT_CLASS[variant], className)} {...rest}>
       {children}
     </div>
   );

--- a/src/shared/ui/EmptyState.tsx
+++ b/src/shared/ui/EmptyState.tsx
@@ -46,10 +46,10 @@ export function EmptyState({
 
   return (
     <div className={cn("flex flex-col items-center px-6 py-14 text-center", className)}>
-      {icon ? <div className="mb-4 text-zinc-400 dark:text-zinc-500">{icon}</div> : null}
+      {icon ? <div className="mb-4 text-muted-foreground">{icon}</div> : null}
       <p className="text-lg font-medium tracking-tight">{title}</p>
       {description ? (
-        <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-300">
+        <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-muted-foreground">
           {description}
         </p>
       ) : null}

--- a/src/shared/ui/ErrorState.tsx
+++ b/src/shared/ui/ErrorState.tsx
@@ -38,7 +38,7 @@ export function ErrorState({
     <div role="alert" className={cn("flex flex-col items-center px-6 py-14 text-center", className)}>
       <p className="text-lg font-medium tracking-tight text-red-700 dark:text-red-300">{title}</p>
       {message ? (
-        <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-300">
+        <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-muted-foreground">
           {message}
         </p>
       ) : null}

--- a/src/shared/ui/FormField.tsx
+++ b/src/shared/ui/FormField.tsx
@@ -61,7 +61,7 @@ export function FormField({
 
   return (
     <div className={cn("flex flex-col gap-1.5", className)}>
-      <label htmlFor={id} className="text-sm font-medium text-zinc-800 dark:text-zinc-100">
+      <label htmlFor={id} className="text-sm font-medium text-foreground">
         {label}
         {required ? (
           <>
@@ -75,7 +75,7 @@ export function FormField({
       </label>
       {children({ id, "aria-describedby": describedBy, invalid: Boolean(error) })}
       {help ? (
-        <p id={helpId} className="text-xs text-zinc-500 dark:text-zinc-400">
+        <p id={helpId} className="text-xs text-muted-foreground">
           {help}
         </p>
       ) : null}

--- a/src/shared/ui/PageHeader.tsx
+++ b/src/shared/ui/PageHeader.tsx
@@ -41,13 +41,13 @@ export function PageHeader({
     >
       <div>
         {eyebrow ? (
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-zinc-500 dark:text-zinc-400">
+          <p className="text-xs font-semibold uppercase tracking-wider text-accent-subtle-foreground">
             {eyebrow}
           </p>
         ) : null}
         <h2 className="mt-2 text-3xl font-semibold tracking-tight">{title}</h2>
         {description ? (
-          <p className="mt-2 max-w-2xl text-zinc-600 dark:text-zinc-300">{description}</p>
+          <p className="mt-2 max-w-2xl text-muted-foreground">{description}</p>
         ) : null}
       </div>
       {actions ? <div className="flex items-center gap-2">{actions}</div> : null}

--- a/src/shared/ui/Select.tsx
+++ b/src/shared/ui/Select.tsx
@@ -24,12 +24,11 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select
       ref={ref}
       aria-invalid={invalid || undefined}
       className={cn(
-        "w-full rounded-xl border bg-white px-3 py-2 text-sm text-zinc-900 transition",
+        "w-full rounded-lg border bg-card px-3 py-2 text-sm text-foreground transition",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0",
-        "dark:bg-zinc-950 dark:text-zinc-100",
         invalid
           ? "border-red-400 focus-visible:ring-red-500 dark:border-red-700"
-          : "border-zinc-300 focus-visible:ring-zinc-500 dark:border-zinc-700",
+          : "border-input focus-visible:ring-ring",
         className,
       )}
       {...rest}

--- a/src/shared/ui/Skeleton.tsx
+++ b/src/shared/ui/Skeleton.tsx
@@ -21,7 +21,7 @@ export function Skeleton({ className }: SkeletonProps) {
   return (
     <div
       aria-hidden="true"
-      className={cn("animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800", className)}
+      className={cn("animate-pulse rounded-md bg-muted", className)}
     />
   );
 }

--- a/src/shared/ui/StatusBadge.tsx
+++ b/src/shared/ui/StatusBadge.tsx
@@ -29,16 +29,16 @@ interface StatusMeta {
 }
 
 const STATUS_META: Record<StatusValue, StatusMeta> = {
-  new: { label: "새 초안", className: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200" },
-  draft: { label: "초안", className: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200" },
+  new: { label: "새 초안", className: "bg-muted text-muted-foreground" },
+  draft: { label: "초안", className: "bg-muted text-muted-foreground" },
   dirty: { label: "수정됨", className: "bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300" },
   validated: { label: "검증됨", className: "bg-blue-100 text-blue-800 dark:bg-blue-950/50 dark:text-blue-300" },
   invalid: { label: "오류 있음", className: "bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300" },
-  queued: { label: "대기 중", className: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200" },
+  queued: { label: "대기 중", className: "bg-muted text-muted-foreground" },
   running: { label: "실행 중", className: "bg-blue-100 text-blue-800 dark:bg-blue-950/50 dark:text-blue-300" },
   succeeded: { label: "성공", className: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300" },
   failed: { label: "실패", className: "bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300" },
-  cancelled: { label: "취소됨", className: "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400" },
+  cancelled: { label: "취소됨", className: "bg-muted text-muted-foreground" },
   publishing: { label: "게시 중", className: "bg-blue-100 text-blue-800 dark:bg-blue-950/50 dark:text-blue-300" },
   published: { label: "게시됨", className: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300" },
 };
@@ -46,7 +46,7 @@ const STATUS_META: Record<StatusValue, StatusMeta> = {
 /** 알 수 없는 상태값에 사용할 중립 배지 스타일 */
 const FALLBACK_META: StatusMeta = {
   label: "",
-  className: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200",
+  className: "bg-muted text-muted-foreground",
 };
 
 export interface StatusBadgeProps {

--- a/src/shared/ui/Stepper.tsx
+++ b/src/shared/ui/Stepper.tsx
@@ -37,8 +37,8 @@ function resolveState(index: number, current: number, errorSteps: number[]): Ste
 }
 
 const STATE_CIRCLE: Record<StepState, string> = {
-  upcoming: "border-zinc-300 text-zinc-400 dark:border-zinc-700 dark:text-zinc-500",
-  current: "border-zinc-900 bg-zinc-900 text-white dark:border-white dark:bg-white dark:text-zinc-900",
+  upcoming: "border-border text-muted-foreground",
+  current: "border-accent bg-accent text-accent-foreground",
   complete: "border-emerald-600 bg-emerald-600 text-white",
   error: "border-red-600 bg-red-600 text-white",
 };
@@ -86,10 +86,10 @@ export function Stepper({
               <button
                 type="button"
                 onClick={() => onStepClick?.(index)}
-                className="flex items-center gap-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500"
+                className="flex items-center gap-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 {circle}
-                <span className="whitespace-nowrap text-sm font-medium text-zinc-700 dark:text-zinc-200">
+                <span className="whitespace-nowrap text-sm font-medium text-foreground">
                   {step.label}
                 </span>
               </button>
@@ -100,8 +100,8 @@ export function Stepper({
                   className={cn(
                     "whitespace-nowrap text-sm font-medium",
                     state === "upcoming"
-                      ? "text-zinc-400 dark:text-zinc-500"
-                      : "text-zinc-700 dark:text-zinc-200",
+                      ? "text-muted-foreground"
+                      : "text-foreground",
                   )}
                 >
                   {step.label}
@@ -109,7 +109,7 @@ export function Stepper({
               </div>
             )}
             {index < steps.length - 1 ? (
-              <span aria-hidden="true" className="h-px w-6 bg-zinc-300 dark:bg-zinc-700" />
+              <span aria-hidden="true" className="h-px w-6 bg-border" />
             ) : null}
           </li>
         );

--- a/src/shared/ui/TextInput.tsx
+++ b/src/shared/ui/TextInput.tsx
@@ -24,12 +24,11 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(function T
       ref={ref}
       aria-invalid={invalid || undefined}
       className={cn(
-        "w-full rounded-xl border bg-white px-3 py-2 text-sm text-zinc-900 transition placeholder:text-zinc-400",
+        "w-full rounded-lg border bg-card px-3 py-2 text-sm text-foreground transition placeholder:text-muted-foreground",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0",
-        "dark:bg-zinc-950 dark:text-zinc-100",
         invalid
           ? "border-red-400 focus-visible:ring-red-500 dark:border-red-700"
-          : "border-zinc-300 focus-visible:ring-zinc-500 dark:border-zinc-700",
+          : "border-input focus-visible:ring-ring",
         className,
       )}
       {...rest}

--- a/src/shared/ui/Textarea.tsx
+++ b/src/shared/ui/Textarea.tsx
@@ -26,13 +26,12 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function 
       rows={rows}
       aria-invalid={invalid || undefined}
       className={cn(
-        "w-full rounded-xl border bg-white px-3 py-2 text-sm text-zinc-900 transition placeholder:text-zinc-400",
+        "w-full rounded-lg border bg-card px-3 py-2 text-sm text-foreground transition placeholder:text-muted-foreground",
         mono && "font-mono",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0",
-        "dark:bg-zinc-950 dark:text-zinc-100",
         invalid
           ? "border-red-400 focus-visible:ring-red-500 dark:border-red-700"
-          : "border-zinc-300 focus-visible:ring-zinc-500 dark:border-zinc-700",
+          : "border-input focus-visible:ring-ring",
         className,
       )}
       {...rest}

--- a/src/shared/ui/buttonStyles.ts
+++ b/src/shared/ui/buttonStyles.ts
@@ -12,12 +12,12 @@ export type ButtonSize = "sm" | "md" | "lg";
 
 const VARIANT_CLASS: Record<ButtonVariant, string> = {
   primary:
-    "bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200",
+    "bg-accent text-accent-foreground shadow-sm hover:brightness-110 active:brightness-95",
   secondary:
-    "border border-zinc-300 text-zinc-700 hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900",
-  ghost: "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900",
-  danger: "bg-red-600 text-white hover:bg-red-500",
-  success: "bg-emerald-600 text-white hover:bg-emerald-500",
+    "border border-border bg-card text-foreground hover:bg-muted",
+  ghost: "text-muted-foreground hover:bg-muted hover:text-foreground",
+  danger: "bg-red-600 text-white shadow-sm hover:bg-red-500",
+  success: "bg-emerald-600 text-white shadow-sm hover:bg-emerald-500",
 };
 
 const SIZE_CLASS: Record<ButtonSize, string> = {
@@ -40,8 +40,9 @@ export function buttonClassName(
   ...extra: ClassValue[]
 ): string {
   return cn(
-    "inline-flex items-center justify-center gap-2 rounded-full font-medium transition",
-    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-950",
+    "inline-flex items-center justify-center gap-2 rounded-lg font-medium transition",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+    "disabled:pointer-events-none disabled:opacity-50",
     VARIANT_CLASS[variant],
     SIZE_CLASS[size],
     ...extra,


### PR DESCRIPTION
## 개요
현재 UI 디자인이 구식(세리프 폰트, 과도한 라운딩, `/80` 투명도 + backdrop-blur)이라는 피드백을 반영해, **Linear/Vercel 계열의 모던 SaaS 대시보드** 룩으로 전면 재디자인했습니다. Emerald 강조색은 유지했습니다.

## 주요 변경
- **디자인 토큰 (`src/globals.css`)**: `card`/`muted`/`border`/`accent` 등 시맨틱 토큰을 도입하고 라이트·다크 두 값을 모두 정의. 세리프 → 모던 sans-serif 스택으로 교체, 절제된 radius 스케일 적용.
- **앱 셸 (`Layout.tsx`)**: 카드형 대형 내비를 컴팩트한 사이드바 링크(에메랄드 active 상태)로 재구성, 헤더·테마 스위치 정리.
- **공용 프리미티브 (`src/shared/ui/*`)**: Button/Card/입력/Badge/PageHeader/Stepper/상태 컴포넌트를 시맨틱 토큰 기반으로 통일. **public prop API는 그대로 유지.**
- **전체 페이지 및 feature 표면**: 하드코딩된 zinc/white/과도한 라운딩을 시맨틱 토큰으로 마이그레이션.

## 범위 밖
- 라우팅·상태·데이터·스키마·비즈니스 로직 변경 없음 (순수 시각 변경)
- 신규 의존성 없음, 한국어 문구 유지

## 검증
- `tsc --noEmit` ✅ · `eslint` ✅ · `vite build` ✅ · `vitest` 131 passed ✅
- 라이트/다크 테마 스크린샷으로 대시보드·새 빌드 화면 육안 확인 완료