### PR TITLE
데모 대시보드에 builder 스펙 기반 시드 데이터 추가

### DIFF
--- a/__tests__/HomePage.test.tsx
+++ b/__tests__/HomePage.test.tsx
@@ -16,19 +16,20 @@ describe("HomePage", () => {
         name: /공공데이터 수집부터 결과물 생성까지 한 번에 관리하세요/,
       }),
     ).toBeInTheDocument();
-    // 상태 요약 카드 라벨
-    expect(screen.getByText("초안")).toBeInTheDocument();
+    // 상태 요약 카드 라벨(실행 상태 기반)
+    expect(screen.getByText("실행 중")).toBeInTheDocument();
     expect(screen.getByText("성공")).toBeInTheDocument();
   });
 
-  it("shows an empty state with a CTA to create the first build", () => {
+  it("loads recent builds from the mock builder data", async () => {
     render(
       <MemoryRouter>
         <HomePage />
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("아직 생성된 빌드가 없습니다")).toBeInTheDocument();
+    // 데모 빌드 이력이 최근 빌드 목록에 표시된다.
+    expect(await screen.findByText("대기오염 정보")).toBeInTheDocument();
     // 빠른 시작 카드의 새 빌드 링크
     expect(
       screen.getAllByRole("link", { name: /새 빌드 만들기/ }).length,

--- a/__tests__/buildsHistory.test.tsx
+++ b/__tests__/buildsHistory.test.tsx
@@ -20,21 +20,21 @@ describe("Builds run history (#12)", () => {
   it("renders rows with status badges and a view link", async () => {
     renderBuilds();
     expect(await screen.findByText("대기오염 정보")).toBeInTheDocument();
-    expect(screen.getByText("성공")).toBeInTheDocument(); // succeeded badge
+    expect(screen.getAllByText("성공").length).toBeGreaterThan(0); // succeeded badges
     expect(screen.getByText("실패")).toBeInTheDocument(); // failed badge
-    expect(screen.getAllByRole("link", { name: "보기" }).length).toBe(3);
+    expect(screen.getAllByRole("link", { name: "보기" }).length).toBe(6);
   });
 
   it("filters the history by title search", async () => {
     renderBuilds();
     await screen.findByText("대기오염 정보");
 
-    fireEvent.change(screen.getByLabelText("빌드 제목 검색"), { target: { value: "인구" } });
+    fireEvent.change(screen.getByLabelText("빌드 제목 검색"), { target: { value: "병용" } });
 
     await waitFor(() => {
       expect(screen.queryByText("대기오염 정보")).not.toBeInTheDocument();
     });
-    expect(screen.getByText("인구 통계")).toBeInTheDocument();
+    expect(screen.getByText("병용금기 품목정보")).toBeInTheDocument();
   });
 
   it("shows an error state with retry when listing fails (#71)", async () => {

--- a/__tests__/listBuilds.test.ts
+++ b/__tests__/listBuilds.test.ts
@@ -15,7 +15,7 @@ afterEach(() => {
 describe("listBuilds (#95)", () => {
   it("returns deterministic mock history in mock mode", async () => {
     const builds = await listBuilds();
-    expect(builds.length).toBe(3);
+    expect(builds.length).toBe(6);
     expect(builds.map((b) => b.spec.title)).toContain("대기오염 정보");
   });
 

--- a/src/features/artifacts/api/index.ts
+++ b/src/features/artifacts/api/index.ts
@@ -11,6 +11,20 @@ import { findDemoDataset } from "@/shared/lib/demoDatasets";
 import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
 import type { BuildManifest } from "@/shared/lib/types";
 
+import type { ExportTarget } from "@/shared/lib/types";
+
+/**
+ * export 형식별 산출물 파일 확장자. specMapping의 output_path 규칙과 동일하게 맞춰
+ * (`.../data.<ext>`) mock/실연동 manifest의 파일 목록 표기를 일관되게 유지한다.
+ * huggingface는 파일이 아닌 리포지토리 레이아웃이라 데이터 파일을 생성하지 않는다.
+ */
+const EXPORT_EXTENSION: Record<ExportTarget["format"], string> = {
+  jsonl: "jsonl",
+  markdown: "md",
+  parquet: "parquet",
+  huggingface: "",
+};
+
 /**
  * 빌드 ID 기반의 결정적 mock manifest를 만든다(#30, #29 연동 전 임시).
  *
@@ -19,7 +33,7 @@ import type { BuildManifest } from "@/shared/lib/types";
  */
 function mockManifest(buildId: string): BuildManifest {
   const dataset = findDemoDataset(buildId);
-  const sourceKey = `datago.${dataset.slug}`;
+  const sourceKey = `datago.${dataset.providerDataset}`;
   const succeeded = dataset.status === "succeeded";
 
   return {
@@ -38,7 +52,12 @@ function mockManifest(buildId: string): BuildManifest {
       : null,
     outputs: succeeded
       ? [
-          `artifacts/builds/${buildId}/data/train.parquet`,
+          ...dataset.exports
+            .filter((target) => target.format !== "huggingface")
+            .map(
+              (target) =>
+                `artifacts/builds/${buildId}/data.${EXPORT_EXTENSION[target.format]}`,
+            ),
           `artifacts/builds/${buildId}/README.md`,
           `artifacts/builds/${buildId}/manifest.json`,
         ]
@@ -58,7 +77,7 @@ function mockManifest(buildId: string): BuildManifest {
       ? [
           {
             provider: "datago",
-            dataset: dataset.slug,
+            dataset: dataset.providerDataset,
             fetched_at: dataset.finishedAt ?? dataset.startedAt,
             record_count: dataset.recordCount,
             data_checksum: `sha256:${dataset.slug.replace(/-/g, "").padEnd(64, "1").slice(0, 64)}`,

--- a/src/features/artifacts/api/index.ts
+++ b/src/features/artifacts/api/index.ts
@@ -7,6 +7,7 @@
  * 매핑한다. /artifacts가 제공하지 않는 필드(recordCount/sources 등)는 안전한 기본값으로
  * 채워 페이지가 누락 필드로 깨지지 않게 한다(#75).
  */
+import { findDemoDataset } from "@/shared/lib/demoDatasets";
 import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
 import type { BuildManifest } from "@/shared/lib/types";
 
@@ -17,47 +18,55 @@ import type { BuildManifest } from "@/shared/lib/types";
  * @returns mock BuildManifest.
  */
 function mockManifest(buildId: string): BuildManifest {
-  const sourceKey = "datago.air-quality";
+  const dataset = findDemoDataset(buildId);
+  const sourceKey = `datago.${dataset.slug}`;
+  const succeeded = dataset.status === "succeeded";
+
   return {
     schema_version: "1.0.0",
     build_id: buildId,
-    started_at: "2026-06-21T00:00:00.000Z",
-    finished_at: "2026-06-21T00:00:08.000Z",
+    started_at: dataset.startedAt,
+    finished_at: dataset.finishedAt ?? "",
     build_environment: {
       python_version: "3.12.3",
       kpubdata_version: "0.4.0",
       builder_version: "0.4.0",
     },
     inputs: [sourceKey],
-    inputs_fingerprint: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-    outputs: [
-      `artifacts/builds/${buildId}/data.jsonl`,
-      `artifacts/builds/${buildId}/README.md`,
-      `artifacts/builds/${buildId}/manifest.json`,
-    ],
+    inputs_fingerprint: succeeded
+      ? `sha256:${dataset.slug.replace(/-/g, "").padEnd(64, "0").slice(0, 64)}`
+      : null,
+    outputs: succeeded
+      ? [
+          `artifacts/builds/${buildId}/data/train.parquet`,
+          `artifacts/builds/${buildId}/README.md`,
+          `artifacts/builds/${buildId}/manifest.json`,
+        ]
+      : [],
     warnings: [],
-    errors: [],
-    row_counts: { [sourceKey]: 12304 },
-    schema_summaries: {
-      [sourceKey]: {
-        fields: [
-          { name: "sidoName", type: "string", nullable: false },
-          { name: "pm10Value", type: "int64", nullable: true },
-        ],
-        total_fields: 2,
-      },
-    },
-    provenance: [
-      {
-        provider: "datago",
-        dataset: "air-quality",
-        fetched_at: "2026-06-21T00:00:05.000Z",
-        record_count: 12304,
-        data_checksum: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
-        api_version: "unknown",
-        params: { sidoName: "서울" },
-      },
-    ],
+    errors: dataset.errors ?? [],
+    row_counts: succeeded ? { [sourceKey]: dataset.recordCount } : {},
+    schema_summaries: succeeded
+      ? {
+          [sourceKey]: {
+            fields: dataset.fields,
+            total_fields: dataset.fields.length,
+          },
+        }
+      : {},
+    provenance: succeeded
+      ? [
+          {
+            provider: "datago",
+            dataset: dataset.slug,
+            fetched_at: dataset.finishedAt ?? dataset.startedAt,
+            record_count: dataset.recordCount,
+            data_checksum: `sha256:${dataset.slug.replace(/-/g, "").padEnd(64, "1").slice(0, 64)}`,
+            api_version: "unknown",
+            params: dataset.params,
+          },
+        ]
+      : [],
   };
 }
 

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -7,6 +7,7 @@
  */
 import { serializeSpec } from "@/features/build-spec/specMapping";
 import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
+import { DEMO_DATASETS, type DemoDataset } from "@/shared/lib/demoDatasets";
 import type { BuildRun, BuildSpec } from "@/shared/lib/types";
 
 const MOCK_TIME = "1970-01-01T00:00:00.000Z";
@@ -59,42 +60,36 @@ export async function executeBuild(spec: BuildSpec, signal?: AbortSignal): Promi
   };
 }
 
-/** 목록/이력 UI 개발용 결정적 mock 스펙을 만든다. */
-function mockSpec(datasetId: string, title: string): BuildSpec {
+/** 데모 카탈로그 항목을 목록/이력 UI용 BuildSpec으로 변환한다. */
+function mockSpec(dataset: DemoDataset): BuildSpec {
   return {
-    datasetId,
-    title,
-    description: `${title} 빌드`,
-    sources: [{ provider: "datago", dataset: datasetId, params: {} }],
-    exports: [{ format: "jsonl" }],
-    metadata: {},
+    datasetId: dataset.slug,
+    title: dataset.title,
+    description: dataset.description,
+    sources: [
+      {
+        provider: "datago",
+        dataset: dataset.providerDataset,
+        params: dataset.params,
+      },
+    ],
+    exports: dataset.exports,
+    metadata: {
+      source_url: dataset.sourceUrl,
+      hf_repo: dataset.hfRepo,
+    },
   };
 }
 
-/** mock 모드에서 보여줄 결정적 빌드 이력. */
+/** mock 모드에서 보여줄 결정적 빌드 이력(실제 builder 데이터셋 스펙 기반). */
 function mockBuilds(): BuildRun[] {
-  return [
-    {
-      id: "run-air-quality-3",
-      spec: mockSpec("air-quality", "대기오염 정보"),
-      status: "succeeded",
-      startedAt: "2026-06-21T09:00:00.000Z",
-      finishedAt: "2026-06-21T09:00:08.000Z",
-    },
-    {
-      id: "run-weather-2",
-      spec: mockSpec("kma-daily", "기상청 일별 관측"),
-      status: "failed",
-      startedAt: "2026-06-20T18:30:00.000Z",
-      finishedAt: "2026-06-20T18:30:05.000Z",
-    },
-    {
-      id: "run-population-1",
-      spec: mockSpec("kosis-population", "인구 통계"),
-      status: "running",
-      startedAt: "2026-06-21T10:15:00.000Z",
-    },
-  ];
+  return DEMO_DATASETS.map((dataset) => ({
+    id: dataset.buildId,
+    spec: mockSpec(dataset),
+    status: dataset.status,
+    startedAt: dataset.startedAt,
+    finishedAt: dataset.finishedAt,
+  }));
 }
 
 /**

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,18 +2,28 @@
  * Studio 홈 대시보드 화면.
  *
  * 사용자가 가장 먼저 보는 화면으로, 빌드 상태 요약, 최근 빌드, 빠른 시작 진입점을
- * 보여준다(제안 §5.1). 실제 수치/목록은 #29 Builder API 연동 시 채운다.
+ * 보여준다(제안 §5.1). 상태 요약 수치와 최근 빌드 목록은 `listBuilds()`(mock 모드에서는
+ * 실제 builder 스펙 기반 데모 데이터, 실연동 모드에서는 Builder API) 결과로 채운다.
  */
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import type { BuildRun } from "@/shared/lib/types";
-import { Card, EmptyState, LinkButton, PageHeader, type StatusValue } from "@/shared/ui";
+import { listBuilds } from "@/features/runs/api";
+import type { BuildRun, BuildRunStatus } from "@/shared/lib/types";
+import {
+  Card,
+  EmptyState,
+  LinkButton,
+  PageHeader,
+  StatusBadge,
+  type StatusValue,
+} from "@/shared/ui";
 
-// 상태 요약 카드. 수치는 Builder API 연동 전까지 0으로 둔다.
-const STATUS_SUMMARY: { status: StatusValue; label: string; count: number }[] = [
-  { status: "draft", label: "초안", count: 0 },
-  { status: "running", label: "실행 중", count: 0 },
-  { status: "failed", label: "실패", count: 0 },
-  { status: "succeeded", label: "성공", count: 0 },
+/** 대시보드 상태 요약 카드에 표시할 실행 상태와 라벨. */
+const SUMMARY_CARDS: { status: Extract<StatusValue, BuildRunStatus>; label: string }[] = [
+  { status: "queued", label: "대기 중" },
+  { status: "running", label: "실행 중" },
+  { status: "succeeded", label: "성공" },
+  { status: "failed", label: "실패" },
 ];
 
 const QUICK_ACTIONS = [
@@ -34,13 +44,49 @@ const QUICK_ACTIONS = [
   },
 ];
 
+/** ISO 시작 시각을 timestamp로 안전하게 변환한다(파싱 실패 시 0). */
+function startedAtMillis(iso: string): number {
+  const ms = new Date(iso).getTime();
+  return Number.isNaN(ms) ? 0 : ms;
+}
+
+/** ISO 시각을 한국어 로케일 문자열로 표시한다. */
+function formatTime(iso?: string): string {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? iso : date.toLocaleString("ko-KR");
+}
+
 /**
  * 상태 요약·최근 빌드·빠른 시작을 보여주는 대시보드 페이지.
  *
  * @returns Studio 대시보드 메인 화면.
  */
 export function HomePage() {
-  const recentBuilds: BuildRun[] = [];
+  const [builds, setBuilds] = useState<BuildRun[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    listBuilds()
+      .then((result) => {
+        if (active) setBuilds(result);
+      })
+      .catch(() => {
+        if (active) setBuilds([]);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const counts = builds.reduce<Record<string, number>>((acc, run) => {
+    acc[run.status] = (acc[run.status] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const recentBuilds = [...builds]
+    .sort((a, b) => startedAtMillis(b.startedAt) - startedAtMillis(a.startedAt))
+    .slice(0, 5);
 
   return (
     <main className="flex flex-1 flex-col gap-8 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
@@ -53,10 +99,12 @@ export function HomePage() {
 
       {/* 상태 요약 카드 (§5.1) */}
       <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        {STATUS_SUMMARY.map((item) => (
+        {SUMMARY_CARDS.map((item) => (
           <Card key={item.status} className="flex items-center justify-between">
             <span className="text-sm text-muted-foreground">{item.label}</span>
-            <span className="text-2xl font-semibold tracking-tight">{item.count}</span>
+            <span className="text-2xl font-semibold tracking-tight">
+              {counts[item.status] ?? 0}
+            </span>
           </Card>
         ))}
       </section>
@@ -68,11 +116,31 @@ export function HomePage() {
           {recentBuilds.length === 0 ? (
             <EmptyState
               title="아직 생성된 빌드가 없습니다"
-              description="공공데이터 템플릿으로 첫 빌드를 만들어보세요. 실행 이력은 Builder API 연동(#29) 후 여기에 표시됩니다."
+              description="공공데이터 템플릿으로 첫 빌드를 만들어보세요. 실행 이력은 여기에 표시됩니다."
               actionLabel="새 빌드 만들기"
               actionHref="/builds/new"
             />
-          ) : null}
+          ) : (
+            <ul>
+              {recentBuilds.map((run) => (
+                <li
+                  key={run.id}
+                  className="grid grid-cols-[1.4fr_0.7fr_0.9fr_0.6fr] items-center gap-4 border-b border-border px-6 py-3 text-sm last:border-0"
+                >
+                  <span className="font-medium">{run.spec.title}</span>
+                  <span>
+                    <StatusBadge status={run.status} />
+                  </span>
+                  <span className="text-muted-foreground">{formatTime(run.startedAt)}</span>
+                  <span className="text-right">
+                    <LinkButton variant="secondary" size="sm" to={`/builds/${run.id}`}>
+                      보기
+                    </LinkButton>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
         </Card>
       </section>
 

--- a/src/shared/lib/demoDatasets.ts
+++ b/src/shared/lib/demoDatasets.ts
@@ -1,0 +1,234 @@
+/**
+ * 데모(mock) 모드에서 사용하는 결정적 데이터셋 카탈로그.
+ *
+ * 정적 데모(GitHub Pages)에서 빌드 목록·상세·manifest 뷰어가 비어 보이지 않도록,
+ * 실제 `kpubdata-builder`의 데이터셋 빌드 스펙(`scripts/configs/*.yaml`)과 Builder가
+ * 기록하는 manifest 와이어 형태를 그대로 본떠 만든 시드 데이터다.
+ *
+ * 여기서 만든 데이터는 실서비스 값이 아니라 데모 표시용이며, `VITE_USE_REAL_BUILDER=true`
+ * 실연동 모드에서는 사용하지 않는다(Builder 실데이터로 대체). Builder의 실제 컬럼명/출처/
+ * HuggingFace 레이아웃을 반영하므로 UI가 실제와 유사한 모습으로 동작한다.
+ */
+import type {
+  BuildRunStatus,
+  ExportTarget,
+  ManifestFieldSummary,
+} from "@/shared/lib/types";
+
+/** 데모 카탈로그의 단일 데이터셋 정의. */
+export interface DemoDataset {
+  /** 경로 안전한 데이터셋 슬러그(빌드 ID prefix로도 사용). */
+  slug: string;
+  /** 빌드 실행 ID(목록/상세/manifest 조회 키). */
+  buildId: string;
+  /** 사람이 읽는 제목. */
+  title: string;
+  /** 빌드 목적 설명. */
+  description: string;
+  /** provider 내부 dataset 식별자(underscore, 예: air_quality). */
+  providerDataset: string;
+  /** data.go.kr 원본 오픈API 주소. */
+  sourceUrl: string;
+  /** provider 요청 파라미터 스냅샷. */
+  params: Record<string, string>;
+  /** 산출물 export 형식 목록. */
+  exports: ExportTarget[];
+  /** HuggingFace Hub 리포지토리 경로. */
+  hfRepo: string;
+  /** 현재 실행 상태. */
+  status: BuildRunStatus;
+  /** 실행 시작 시각(ISO). */
+  startedAt: string;
+  /** 실행 종료 시각(ISO). running/queued면 미정. */
+  finishedAt?: string;
+  /** 수집한 레코드 수. */
+  recordCount: number;
+  /** 결과 표 컬럼 스키마(Builder column_mapping 기반). */
+  fields: ManifestFieldSummary[];
+  /** 실패 상태일 때의 에러 메시지. */
+  errors?: string[];
+}
+
+/** DUR 계열 데이터셋의 공통 오픈API 주소(DURPrdlstInfoService03). */
+const DUR_SOURCE_URL = "https://www.data.go.kr/data/15075057/openapi.do";
+
+function str(name: string, nullable = true): ManifestFieldSummary {
+  return { name, type: "string", nullable };
+}
+
+function f64(name: string): ManifestFieldSummary {
+  return { name, type: "float64", nullable: true };
+}
+
+/**
+ * 데모 데이터셋 카탈로그.
+ *
+ * 실제 builder 스펙(대기오염정보, DUR 품목/병용금기/임부금기/노인주의/용량주의)을 본떠
+ * 다양한 상태(성공/실행 중/실패/대기)를 포함하도록 구성한다.
+ */
+export const DEMO_DATASETS: DemoDataset[] = [
+  {
+    slug: "air-quality",
+    buildId: "air-quality-20260621",
+    title: "대기오염 정보",
+    description: "한국환경공단 AirKorea 대기오염정보(SO2/CO/O3/NO2/PM10/PM2.5, 통합대기환경지수) 데이터셋 빌드",
+    providerDataset: "air_quality",
+    sourceUrl: "https://www.data.go.kr/data/15073861/openapi.do",
+    params: { stationName: "종로구", dataTerm: "MONTH" },
+    exports: [{ format: "parquet" }, { format: "huggingface" }],
+    hfRepo: "kpubdata/air-quality",
+    status: "succeeded",
+    startedAt: "2026-06-21T09:00:00.000Z",
+    finishedAt: "2026-06-21T09:00:12.000Z",
+    recordCount: 12304,
+    fields: [
+      str("station_name", false),
+      str("data_time", false),
+      f64("pm10"),
+      f64("pm25"),
+      f64("o3"),
+      f64("no2"),
+      f64("co"),
+      f64("so2"),
+      f64("khai_index"),
+      str("khai_grade"),
+    ],
+  },
+  {
+    slug: "dur-product-info",
+    buildId: "dur-product-info-20260620",
+    title: "DUR 품목정보",
+    description: "식약처 DUR 시스템 등록 의약품 품목 마스터(품목기준코드/품목명/업체명/약효분류) 데이터셋 빌드",
+    providerDataset: "dur_product_info",
+    sourceUrl: DUR_SOURCE_URL,
+    params: {},
+    exports: [{ format: "jsonl" }, { format: "huggingface" }],
+    hfRepo: "kpubdata/dur-product-info",
+    status: "succeeded",
+    startedAt: "2026-06-20T14:30:00.000Z",
+    finishedAt: "2026-06-20T14:31:47.000Z",
+    recordCount: 48512,
+    fields: [
+      str("item_seq", false),
+      str("item_name", false),
+      str("company_name"),
+      str("formulation"),
+      str("class_code"),
+      str("class_name"),
+      str("etc_otc_code"),
+      str("item_permit_date"),
+      str("change_date"),
+    ],
+  },
+  {
+    slug: "dur-usjnt-taboo",
+    buildId: "dur-usjnt-taboo-20260620",
+    title: "병용금기 품목정보",
+    description: "식약처 DUR 병용금기 의약품 조합(함께 복용하면 안 되는 약제 쌍과 금기 사유) 데이터셋 빌드",
+    providerDataset: "dur_usjnt_taboo",
+    sourceUrl: DUR_SOURCE_URL,
+    params: {},
+    exports: [{ format: "jsonl" }, { format: "huggingface" }],
+    hfRepo: "kpubdata/dur-usjnt-taboo",
+    status: "succeeded",
+    startedAt: "2026-06-19T22:10:00.000Z",
+    finishedAt: "2026-06-19T22:12:03.000Z",
+    recordCount: 31894,
+    fields: [
+      str("item_seq", false),
+      str("item_name", false),
+      str("company_name"),
+      str("class_name"),
+      str("mixture_item_seq"),
+      str("mixture_item_name"),
+      str("mixture_company_name"),
+      str("prohibition_content"),
+      str("remark"),
+      str("item_permit_date"),
+      str("change_date"),
+    ],
+  },
+  {
+    slug: "dur-pregnancy-taboo",
+    buildId: "dur-pregnancy-taboo-20260621",
+    title: "임부금기 의약품",
+    description: "식약처 DUR 임부금기 의약품(임신 중 사용 금기 약제와 금기 내용) 데이터셋 빌드",
+    providerDataset: "dur_pregnancy_taboo",
+    sourceUrl: DUR_SOURCE_URL,
+    params: {},
+    exports: [{ format: "jsonl" }, { format: "huggingface" }],
+    hfRepo: "kpubdata/dur-pregnancy-taboo",
+    status: "running",
+    startedAt: "2026-06-21T10:15:00.000Z",
+    recordCount: 0,
+    fields: [
+      str("item_seq", false),
+      str("item_name", false),
+      str("company_name"),
+      str("class_name"),
+      str("prohibition_content"),
+      str("remark"),
+      str("item_permit_date"),
+      str("change_date"),
+    ],
+  },
+  {
+    slug: "dur-older-adult-caution",
+    buildId: "dur-older-adult-caution-20260618",
+    title: "노인주의 의약품",
+    description: "식약처 DUR 노인주의 의약품 데이터셋 빌드(원본 오픈API 응답 지연으로 실패)",
+    providerDataset: "dur_older_adult_caution",
+    sourceUrl: DUR_SOURCE_URL,
+    params: {},
+    exports: [{ format: "jsonl" }, { format: "huggingface" }],
+    hfRepo: "kpubdata/dur-older-adult-caution",
+    status: "failed",
+    startedAt: "2026-06-18T03:05:00.000Z",
+    finishedAt: "2026-06-18T03:05:31.000Z",
+    recordCount: 0,
+    errors: ["원본 오픈API 응답 시간 초과(gateway timeout) — Bronze 단계 수집 실패"],
+    fields: [
+      str("item_seq", false),
+      str("item_name", false),
+      str("company_name"),
+      str("class_name"),
+      str("prohibition_content"),
+      str("remark"),
+    ],
+  },
+  {
+    slug: "dur-dosage-caution",
+    buildId: "dur-dosage-caution-20260621",
+    title: "용량주의 의약품",
+    description: "식약처 DUR 용량주의 의약품(1일 최대 투여량 주의 약제) 데이터셋 빌드(실행 대기 중)",
+    providerDataset: "dur_dosage_caution",
+    sourceUrl: DUR_SOURCE_URL,
+    params: {},
+    exports: [{ format: "jsonl" }, { format: "huggingface" }],
+    hfRepo: "kpubdata/dur-dosage-caution",
+    status: "queued",
+    startedAt: "2026-06-21T10:20:00.000Z",
+    recordCount: 0,
+    fields: [
+      str("item_seq", false),
+      str("item_name", false),
+      str("company_name"),
+      str("class_name"),
+      str("max_dosage_content"),
+      str("remark"),
+    ],
+  },
+];
+
+/**
+ * 빌드 ID로 데모 데이터셋을 찾는다. 정확 일치 후 슬러그 prefix 매칭을 시도한다.
+ *
+ * @param buildId - 조회할 빌드 실행 ID.
+ * @returns 매칭되는 데모 데이터셋(없으면 첫 항목).
+ */
+export function findDemoDataset(buildId: string): DemoDataset {
+  const exact = DEMO_DATASETS.find((d) => d.buildId === buildId);
+  if (exact) return exact;
+  const bySlug = DEMO_DATASETS.find((d) => buildId.startsWith(d.slug));
+  return bySlug ?? DEMO_DATASETS[0];
+}


### PR DESCRIPTION
## 요약
- 정적 데모(GitHub Pages, mock 모드)가 빈 상태로 보이던 문제를 해결하기 위해, 실제 `kpubdata-builder` 데이터셋 빌드 스펙(`scripts/configs/*.yaml`)과 Builder manifest 와이어 형태를 본뜬 결정적 데모 시드 데이터를 추가했습니다.
- 홈 대시보드가 실제로 상태 요약 수치와 최근 빌드 목록을 표시합니다.

## 변경 사항
- **`src/shared/lib/demoDatasets.ts` 신규**: 실제 데이터셋(대기오염정보, DUR 품목/병용금기/임부금기/노인주의/용량주의)을 본뜬 카탈로그. 실제 컬럼명·source_url·HF repo·파라미터·레코드 수를 반영하고, 성공/실행 중/실패/대기 등 다양한 상태를 포함합니다.
- **`features/runs/api`**: `mockSpec`/`mockBuilds`를 카탈로그 기반으로 재작성.
- **`features/artifacts/api`**: `mockManifest`를 데이터셋별 실제 스키마/출처/행 수로 생성(Builder manifest 와이어 형태 준수).
- **`pages/HomePage`**: `listBuilds()`를 호출해 상태 요약 카운트와 최근 빌드 목록을 렌더링(기존 하드코딩 0/빈 목록 제거).
- 영향받은 유닛 테스트 갱신.

## 설계 메모
- 실연동 모드(`VITE_USE_REAL_BUILDER=true`)에서는 이 데모 데이터를 사용하지 않습니다(Builder 실데이터로 대체). 라이브 백엔드가 필요 없어 정적 데모에서 바로 동작합니다.
- Manifest 스키마 소유권은 Builder에 있으므로, 데모 manifest는 Builder 와이어 형태를 그대로 따릅니다.

## 검증
- `npx tsc --noEmit` ✅
- `npm run lint` ✅ (0 warnings)
- `npx vitest run` ✅ (131 passed)
- `npm run build` ✅