### PR TITLE
docs: STATE_MODEL 상태 전이도를 mermaid로 통일

### DIFF
--- a/STATE_MODEL.md
+++ b/STATE_MODEL.md
@@ -19,13 +19,7 @@
 - `validated`: 모든 설정값이 올바른지 확인(검증)을 마친 상태
 - `invalid`: 설정값에 오류가 있어 수정이 필요한 상태
 
-### 상태 전이 흐름 (ASCII 다이어그램)
-```text
-[new] --(수정)--> [dirty] --(검증 요청)--> [validated]
-                     ^           |
-                     |           | (오류 발견)
-                     +-----------+-------- [invalid]
-```
+### 상태 전이 흐름
 
 ```mermaid
 stateDiagram-v2
@@ -56,14 +50,7 @@ stateDiagram-v2
 - `failed`: 작업 도중 오류가 발생하여 중단됨
 - `cancelled`: 사용자가 수동으로 작업을 멈춤
 
-### 상태 전이 흐름 (ASCII 다이어그램)
-```text
-[queued] -> [running] --(성공)--> [succeeded]
-               |
-               +--(실패)--> [failed]
-               |
-               +--(취소)--> [cancelled]
-```
+### 상태 전이 흐름
 
 ```mermaid
 stateDiagram-v2
@@ -94,6 +81,8 @@ stateDiagram-v2
 - `publishing`: 데이터를 외부로 전송 중
 - `published`: 전송이 완료되어 공개된 상태
 - `publish_failed`: 전송 도중 오류 발생
+
+### 상태 전이 흐름
 
 ```mermaid
 stateDiagram-v2


### PR DESCRIPTION
## 배경

`STATE_MODEL.md`의 §1(Draft), §2(Build Run)은 ASCII 다이어그램과 mermaid `stateDiagram-v2`를 **중복**으로 갖고 있었고, §3(Publish)은 이미 mermaid만 사용하고 있어 섹션 간 형식이 불일치했다.

## 변경 내용

- §1, §2의 중복 ASCII 상태 전이도 블록 제거 (mermaid `stateDiagram-v2`가 이미 동일 내용을 표현)
- §1~§3 모두 `### 상태 전이 흐름` 헤딩으로 통일하여 렌더링 사이트에서 단계별로 하나의 일관된 상태 다이어그램만 표시

## 참고: ER 다이어그램은 studio에 해당 없음

Studio는 영속 데이터 엔티티를 소유하지 않는 control surface이므로 ER 다이어그램 대상이 아니다. 도메인 엔티티 관계도는 builder(`DOMAIN_MODEL.md`)가 소유한다. Studio의 모델은 상태 머신/사용자 흐름이며, 이번 정리로 상태 다이어그램 표현을 일관화했다.

## 검증

- mermaid-cli로 5개 다이어그램 전부 렌더 확인 ✅
- `mkdocs build --strict` → 경고/오류 0건 ✅