### PR TITLE
docs: 절차형 순서도 시작/종료 터미네이터 표준화

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -282,17 +282,17 @@ API 호출에 실패했을 때 서버가 보내주는 표준 에러 형식입니
 
 ```mermaid
 flowchart TD
-    Request[Studio API Request] --> Status{HTTP Status?}
-    Status -->|200| Success[성공 처리 / 데이터 UI 반영]
+    Request([Studio API Request]) --> Status{HTTP Status?}
+    Status -->|200| Success([성공 처리 / 데이터 UI 반영])
     Status -->|400| BadRequest[입력값/스펙 오류]
     Status -->|404| NotFound[데이터 없음]
     Status -->|502| UpstreamFail[소스 실패: outcomes 표시]
     Status -->|500| ServerError[서버 내부 오류]
 
-    BadRequest --> ShowDetail[UI에 구체적 오류 사유 표시]
-    NotFound --> EmptyState[데이터 없음 안내 UI]
-    UpstreamFail --> SourceDetail[소스별 실패 원인 + 재시도 버튼]
-    ServerError --> RetryToast[잠시 후 다시 시도 토스트 메시지]
+    BadRequest --> ShowDetail([UI에 구체적 오류 사유 표시])
+    NotFound --> EmptyState([데이터 없음 안내 UI])
+    UpstreamFail --> SourceDetail([소스별 실패 원인 + 재시도 버튼])
+    ServerError --> RetryToast([잠시 후 다시 시도 토스트 메시지])
 ```
 
 ---

--- a/UI_SPEC.md
+++ b/UI_SPEC.md
@@ -4,7 +4,7 @@
 
 ```mermaid
 flowchart TD
-    Home["Home / Dashboard"] -->|Create New| Editor[Build Editor]
+    Home(["Home / Dashboard"]) -->|Create New| Editor[Build Editor]
     Home -->|View Recent| Run["Build Run / History"]
     Editor -->|Validate/Run| Run
     Run -->|Success| Artifacts[Artifact Viewer]

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -142,22 +142,22 @@ sequenceDiagram
 
 ```mermaid
 flowchart TD
-    Error[오류 발생] --> Type{오류 종류}
+    Error([오류 발생]) --> Type{오류 종류}
     Type --> BuildFail[빌드 실패]
     Type --> NetFail[네트워크 오류]
     Type --> ValFail[검증 실패]
 
     BuildFail --> BuildLog[빌드 로그 분석]
     BuildLog --> EditSpec["명세(Spec) 수정"]
-    EditSpec --> Retry[재시도]
+    EditSpec --> Retry([재시도])
 
     NetFail --> Offline[오프라인 모드 알림]
     Offline --> Reconnect[자동 재연결 대기]
-    Reconnect --> Resume[작업 재개]
+    Reconnect --> Resume([작업 재개])
 
     ValFail --> InputHighlight[잘못된 입력 강조]
     InputHighlight --> CorrectInput[사용자 수정]
-    CorrectInput --> ReValidate[자동 다시 검증]
+    CorrectInput --> ReValidate([자동 다시 검증])
 ```
 
 ---


### PR DESCRIPTION
## 요약

절차/분기형 다이어그램(진짜 순서도)에 **시작/종료 터미네이터(스타디움 기호)** 와 분기(마름모) 규약을 일관되게 적용합니다. 구조도(계층·의존 관계도, 파일 트리)는 순서도가 아니므로 **변경하지 않습니다.**

## 변경 사항
- `USER_FLOWS.md` — 에러 복구 흐름 시작/종료 터미네이터
- `UI_SPEC.md` — 화면 내비게이션 흐름 시작(허브) 터미네이터
- `API_CONTRACT.md` — HTTP 상태 분기 흐름 시작/종료 터미네이터

## 유지(변환 제외)
- `ARCHITECTURE.md`/`README.md`/`INFORMATION_ARCHITECTURE.md`의 `graph TD/LR` 구조도, `STATE_MODEL.md` 상태 다이어그램

## 검증
- mermaid-cli 렌더 정상
- `mkdocs build --strict` 통과 (exit 0)