### PR TITLE
docs: PRD에 MOCK 모드/구현 상태 명시

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -6,6 +6,16 @@ KPubData Studio is a visual interface for creating and managing public-data buil
 
 It helps users define sources, preview records, configure metadata, run builds, and review outputs without hand-editing every configuration file.
 
+## 현재 구현 상태 (Current implementation status — v0.1.0)
+
+> 이 절은 현재 실제로 구현된 범위를 명확히 구분한다.
+
+- **구현된 UI 흐름**: PRD의 Core User Flows(A/B/C)에 대응하는 라우트/페이지가 존재한다 — `builds`, `builds/new`, `builds/:id`(상세/편집), `builds/:id/run`, `builds/:id/artifacts`, `builds/:id/publish`. 추가로 독립 실행형 `validate`, `preview`, `artifacts`, `settings` 페이지를 제공한다.
+- **Builder API 연동은 기본적으로 MOCK 모드**다. 라이브 Builder 없이도 동작하도록 기본값이 mock이며(`shared/lib/builderApi.ts`, `demoDatasets.ts`), 실제 Builder 호출은 `VITE_USE_REAL_BUILDER=true` 환경 변수로만 활성화된다. 즉 현재 GitHub Pages 데모 등은 실제 백엔드가 아니라 demo 데이터로 동작한다.
+- **경계 원칙 유지**: BuildSpec 검증·preview 계산·manifest 스키마·publish 실행 로직은 Builder가 소유하며 Studio는 이를 호출/표시만 한다.
+
+> 실제 Builder API 통합의 완성도는 향후 작업이며, 세부 계획은 [ROADMAP.md](./ROADMAP.md)를 참조한다.
+
 ## 2. Problem
 
 The builder pipeline is powerful but configuration-first.


### PR DESCRIPTION
## 요약

Studio PRD에 현재 구현 상태를 명확히 표기한다. 코드 변경 없음(문서만).

## 변경 내용

- **"현재 구현 상태 (v0.1.0)" 절 추가**:
  - PRD Core User Flows(A/B/C)가 실제 라우트/페이지(`builds`, `builds/new`, `builds/:id`, `run`, `artifacts`, `publish`)로 구현되어 있음을 명시. 독립 `validate`/`preview`/`artifacts`/`settings` 페이지도 함께 기술.
  - **Builder API 연동은 기본 MOCK 모드**이며 실제 호출은 `VITE_USE_REAL_BUILDER=true`로만 활성화됨(현재 데모는 demo 데이터 기반)을 분명히 함.
  - Builder/Studio 경계 원칙(검증·preview·manifest·publish 로직은 Builder 소유)을 재확인.
  - 실제 API 통합 완성도는 향후 작업이며 ROADMAP을 단일 출처로 참조.

## 검증

- 문서 전용 변경.
- 감사 근거: `src/app/router.tsx`(라우트), `src/pages/*`, `src/shared/lib/builderApi.ts`(기본 mock, `VITE_USE_REAL_BUILDER` 게이트), `demoDatasets.ts`.
