### PR TITLE
chore(deps): bump react와 react-dom을 19.2.8로 함께 올림

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "kpubdata-studio",
       "version": "0.1.0",
       "dependencies": {
-        "react": "19.2.7",
-        "react-dom": "19.2.7",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
         "react-hook-form": "^7.82.0",
         "react-router-dom": "^7.18.1",
         "zod": "^4.4.3",
@@ -3347,24 +3347,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "screenshots": "node scripts/capture-screenshots.mjs"
   },
   "dependencies": {
-    "react": "19.2.7",
-    "react-dom": "19.2.7",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "react-hook-form": "^7.82.0",
     "react-router-dom": "^7.18.1",
     "zod": "^4.4.3",


### PR DESCRIPTION
## 개요

dependabot PR #150(react)과 #147(react-dom)을 하나로 합쳐, `react`와 `react-dom`을 **동일한 버전 19.2.8**로 함께 올립니다.

## 배경

- #150은 `react`만 19.2.8로 올려 `react-dom`(19.2.7)과 어긋남
- #147은 `react-dom`만 19.2.8로 올려 `react`(19.2.7)와 어긋남
- 각각 단독으로는 Vitest에서 다음 오류로 실패:
  > Incompatible React versions: The "react" and "react-dom" packages must have the exact same version.

## 변경

- `react` 19.2.7 → 19.2.8
- `react-dom` 19.2.7 → 19.2.8
- `package-lock.json` 재생성

## 검증 (로컬)

- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm test` ✅ (35 files / 131 tests)
- `npm run build` ✅

머지되면 dependabot #150, #147은 자동으로 닫힙니다.