### PR TITLE
fix: distinguish missing and empty manifest fields

### DIFF
--- a/__tests__/BuildArtifactsPage.test.tsx
+++ b/__tests__/BuildArtifactsPage.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * BuildArtifactsPage UI 테스트 - Issue #119
+ *
+ * undefined와 빈 배열이 서로 다른 문구로 표시되는지 검증한다.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import type { BuildManifest } from "@/shared/lib/types";
+import { BuildArtifactsPage } from "@/pages/BuildArtifactsPage";
+import * as artifactsApi from "@/features/artifacts/api";
+
+const mockGetBuildManifest = vi.spyOn(artifactsApi, "getBuildManifest");
+
+function renderWithManifest(manifest: BuildManifest) {
+  mockGetBuildManifest.mockResolvedValue(manifest);
+  return render(
+    <MemoryRouter initialEntries={["/builds/test-id/artifacts"]}>
+      <Routes>
+        <Route path="/builds/:buildId/artifacts" element={<BuildArtifactsPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  cleanup();
+});
+
+describe("BuildArtifactsPage - Issue #119: undefined vs empty array", () => {
+  it("outputs: undefined → '파일 정보 미제공', outputs: [] → '생성된 파일이 없습니다'", async () => {
+    const withUndefined: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "test-undefined",
+      build_environment: null,
+      inputs_fingerprint: null,
+    };
+
+    renderWithManifest(withUndefined);
+    await waitFor(() => expect(screen.getByText("파일 정보 미제공")).toBeInTheDocument());
+    expect(screen.getByText("파일 정보 미제공")).toBeInTheDocument();
+    expect(screen.queryByText("생성된 파일이 없습니다")).not.toBeInTheDocument();
+    cleanup();
+
+    const withEmpty: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "test-empty",
+      build_environment: null,
+      inputs_fingerprint: null,
+      outputs: [],
+    };
+
+    renderWithManifest(withEmpty);
+    await waitFor(() => expect(screen.getByText("생성된 파일이 없습니다")).toBeInTheDocument());
+    expect(screen.getByText("생성된 파일이 없습니다")).toBeInTheDocument();
+    expect(screen.queryByText("파일 정보 미제공")).not.toBeInTheDocument();
+  });
+
+  it("formats: undefined → '미제공', formats: [] → '출력 형식 없음'", async () => {
+    const withUndefined: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "test-undefined",
+      build_environment: null,
+      inputs_fingerprint: null,
+    };
+
+    renderWithManifest(withUndefined);
+    await waitFor(() => expect(screen.getByText("출력 형식")).toBeInTheDocument());
+    expect(screen.queryByText("출력 형식 없음")).not.toBeInTheDocument();
+    cleanup();
+
+    const withEmpty: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "test-empty",
+      build_environment: null,
+      inputs_fingerprint: null,
+      outputs: [],
+    };
+
+    renderWithManifest(withEmpty);
+    await waitFor(() => expect(screen.getByText("출력 형식 없음")).toBeInTheDocument());
+    expect(screen.getByText("출력 형식 없음")).toBeInTheDocument();
+  });
+
+  it("provenance: undefined → '미제공', provenance: [] → '소스 없음'", async () => {
+    const withUndefined: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "test-undefined",
+      build_environment: null,
+      inputs_fingerprint: null,
+    };
+
+    renderWithManifest(withUndefined);
+    await waitFor(() => expect(screen.getByText("소스")).toBeInTheDocument());
+    expect(screen.queryByText("소스 없음")).not.toBeInTheDocument();
+    cleanup();
+
+    const withEmpty: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "test-empty",
+      build_environment: null,
+      inputs_fingerprint: null,
+      provenance: [],
+    };
+
+    renderWithManifest(withEmpty);
+    await waitFor(() => expect(screen.getByText("소스 없음")).toBeInTheDocument());
+    expect(screen.getByText("소스 없음")).toBeInTheDocument();
+  });
+
+  it("값이 존재할 때 올바르게 표시됨", async () => {
+    const withValues: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "test-values",
+      build_environment: null,
+      inputs_fingerprint: null,
+      outputs: ["artifacts/builds/test/data.jsonl", "artifacts/builds/test/output.parquet"],
+      provenance: [
+        {
+          provider: "datago",
+          dataset: "air-quality",
+          fetched_at: "2026-06-21T00:00:00+00:00",
+          record_count: 100,
+          data_checksum: "sha256:abc",
+          api_version: "1.0",
+          params: {},
+        },
+      ],
+      row_counts: { "datago.air-quality": 100 },
+    };
+
+    renderWithManifest(withValues);
+    await waitFor(() => expect(screen.queryByText("jsonl, parquet")).toBeInTheDocument());
+    expect(screen.getByText("jsonl, parquet")).toBeInTheDocument();
+    expect(screen.getByText("datago.air-quality")).toBeInTheDocument();
+    expect(screen.getByText("100")).toBeInTheDocument();
+  });
+});

--- a/__tests__/artifactsApi.test.ts
+++ b/__tests__/artifactsApi.test.ts
@@ -40,21 +40,47 @@ describe("getBuildManifest (#75)", () => {
       "artifacts/builds/run-99/data.jsonl",
       "artifacts/builds/run-99/README.md",
     ]);
-    // /artifacts가 제공하지 않는 필드는 안전한 기본값(페이지가 깨지지 않음).
-    expect(manifest.row_counts).toEqual({});
-    expect(manifest.provenance).toEqual([]);
+    // /artifacts가 제공하지 않는 필드는 undefined로 남겨 미제공 상태를 표현 (#119)
+    expect(manifest.row_counts).toBeUndefined();
+    expect(manifest.provenance).toBeUndefined();
     expect(manifest.inputs_fingerprint).toBeNull();
+    expect(manifest.started_at).toBeUndefined();
+    expect(manifest.finished_at).toBeUndefined();
+    expect(manifest.inputs).toBeUndefined();
+    expect(manifest.warnings).toBeUndefined();
+    expect(manifest.errors).toBeUndefined();
+    expect(manifest.schema_summaries).toBeUndefined();
   });
 
   it("returns the mock manifest without network in mock mode", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
-    const manifest = await getBuildManifest("mock-build");
+    const manifest = await getBuildManifest("air-quality-20260621");
 
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(manifest.build_id).toBe("mock-build");
-    const total = Object.values(manifest.row_counts).reduce((sum, n) => sum + n, 0);
+    expect(manifest.build_id).toBe("air-quality-20260621");
+    // 성공한 빌드는 row_counts가 제공됨
+    expect(manifest.row_counts).toBeDefined();
+    const total = Object.values(manifest.row_counts ?? {}).reduce((sum, n) => sum + n, 0);
     expect(total).toBeGreaterThan(0);
+  });
+
+  it("returns mock manifest with undefined fields for failed builds (#119)", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    // 실패한 빌드에 대한 mock manifest
+    const manifest = await getBuildManifest("dur-older-adult-caution-20260618");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(manifest.build_id).toBe("dur-older-adult-caution-20260618");
+    // 실패한 빌드는 row_counts가 제공되지 않음 (undefined)
+    expect(manifest.row_counts).toBeUndefined();
+    expect(manifest.schema_summaries).toBeUndefined();
+    expect(manifest.provenance).toBeUndefined();
+    // errors는 제공됨
+    expect(manifest.errors).toBeDefined();
+    expect(manifest.errors?.length).toBeGreaterThan(0);
   });
 });

--- a/__tests__/manifestContract.test.ts
+++ b/__tests__/manifestContract.test.ts
@@ -47,9 +47,9 @@ const WIRE_MANIFEST: BuildManifest = {
 describe("BuildManifest contract (#98)", () => {
   it("accepts the real Builder manifest wire shape with all fields populated", () => {
     expect(WIRE_MANIFEST.build_id).toBe("run-air-quality-1");
-    expect(WIRE_MANIFEST.row_counts["datago.air-quality"]).toBe(12304);
-    expect(WIRE_MANIFEST.schema_summaries["datago.air-quality"].total_fields).toBe(1);
-    expect(WIRE_MANIFEST.provenance[0].data_checksum).toBe("sha256:def");
+    expect(WIRE_MANIFEST.row_counts!["datago.air-quality"]).toBe(12304);
+    expect(WIRE_MANIFEST.schema_summaries!["datago.air-quality"].total_fields).toBe(1);
+    expect(WIRE_MANIFEST.provenance![0].data_checksum).toBe("sha256:def");
     expect(WIRE_MANIFEST.build_environment?.builder_version).toBe("0.4.0");
   });
 
@@ -65,5 +65,82 @@ describe("BuildManifest contract (#98)", () => {
     };
     expect(empty.build_environment).toBeNull();
     expect(empty.inputs_fingerprint).toBeNull();
+  });
+
+  it("allows undefined for optional fields when not provided by API (#119)", () => {
+    const minimal: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "run-minimal",
+      build_environment: null,
+      inputs_fingerprint: null,
+      // 모든 optional 필드는 undefined로 남겨서 미제공 상태를 표현
+      // started_at, finished_at, inputs, outputs, warnings, errors, row_counts, schema_summaries, provenance
+    };
+    expect(minimal.schema_version).toBe("1.0.0");
+    expect(minimal.build_id).toBe("run-minimal");
+    expect(minimal.started_at).toBeUndefined();
+    expect(minimal.finished_at).toBeUndefined();
+    expect(minimal.inputs).toBeUndefined();
+    expect(minimal.outputs).toBeUndefined();
+    expect(minimal.warnings).toBeUndefined();
+    expect(minimal.errors).toBeUndefined();
+    expect(minimal.row_counts).toBeUndefined();
+    expect(minimal.schema_summaries).toBeUndefined();
+    expect(minimal.provenance).toBeUndefined();
+  });
+
+  it("distinguishes between empty array and undefined array (#119)", () => {
+    const empty: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "run-empty",
+      build_environment: null,
+      inputs_fingerprint: null,
+      inputs: [], // 빈 배열 - 명시적으로 제공됨
+      outputs: [], // 빈 배열 - 명시적으로 제공됨
+      warnings: [], // 빈 배열 - 명시적으로 제공됨
+      errors: [], // 빈 배열 - 명시적으로 제공됨
+      provenance: [], // 빈 배열 - 명시적으로 제공됨
+    };
+
+    const missing: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "run-missing",
+      build_environment: null,
+      inputs_fingerprint: null,
+      // 이 필드들은 undefined로 미제공 상태를 표현
+    };
+
+    expect(empty.inputs).toEqual([]);
+    expect(empty.outputs).toEqual([]);
+    expect(empty.warnings).toEqual([]);
+    expect(empty.errors).toEqual([]);
+    expect(empty.provenance).toEqual([]);
+
+    expect(missing.inputs).toBeUndefined();
+    expect(missing.outputs).toBeUndefined();
+    expect(missing.warnings).toBeUndefined();
+    expect(missing.errors).toBeUndefined();
+    expect(missing.provenance).toBeUndefined();
+  });
+
+  it("distinguishes between zero record count and undefined row_counts (#119)", () => {
+    const zeroRecords: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "run-zero",
+      build_environment: null,
+      inputs_fingerprint: null,
+      row_counts: { "source.key": 0 }, // 실제 레코드 0건
+    };
+
+    const missingRecords: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "run-missing",
+      build_environment: null,
+      inputs_fingerprint: null,
+      // row_counts 미제공
+    };
+
+    expect(zeroRecords.row_counts).toEqual({ "source.key": 0 });
+    expect(missingRecords.row_counts).toBeUndefined();
   });
 });

--- a/src/features/artifacts/api/index.ts
+++ b/src/features/artifacts/api/index.ts
@@ -40,13 +40,13 @@ function mockManifest(buildId: string): BuildManifest {
     schema_version: "1.0.0",
     build_id: buildId,
     started_at: dataset.startedAt,
-    finished_at: dataset.finishedAt ?? "",
+    finished_at: dataset.finishedAt, // undefined를 허용
     build_environment: {
       python_version: "3.12.3",
       kpubdata_version: "0.4.0",
       builder_version: "0.4.0",
     },
-    inputs: [sourceKey],
+    inputs: succeeded ? [sourceKey] : undefined,
     inputs_fingerprint: succeeded
       ? `sha256:${dataset.slug.replace(/-/g, "").padEnd(64, "0").slice(0, 64)}`
       : null,
@@ -61,10 +61,10 @@ function mockManifest(buildId: string): BuildManifest {
           `artifacts/builds/${buildId}/README.md`,
           `artifacts/builds/${buildId}/manifest.json`,
         ]
-      : [],
-    warnings: [],
-    errors: dataset.errors ?? [],
-    row_counts: succeeded ? { [sourceKey]: dataset.recordCount } : {},
+      : undefined,
+    warnings: undefined,
+    errors: dataset.errors,
+    row_counts: succeeded ? { [sourceKey]: dataset.recordCount } : undefined,
     schema_summaries: succeeded
       ? {
           [sourceKey]: {
@@ -72,7 +72,7 @@ function mockManifest(buildId: string): BuildManifest {
             total_fields: dataset.fields.length,
           },
         }
-      : {},
+      : undefined,
     provenance: succeeded
       ? [
           {
@@ -85,33 +85,27 @@ function mockManifest(buildId: string): BuildManifest {
             params: dataset.params,
           },
         ]
-      : [],
+      : undefined,
   };
 }
 
 /**
  * Builder의 실제 `/artifacts` 응답({files, run_id})을 페이지가 쓰는 BuildManifest로
- * 매핑한다. /artifacts가 제공하지 않는 메타 필드는 안전한 기본값으로 채운다.
+ * 매핑한다. /artifacts가 제공하지 않는 메타 필드는 undefined로 남겨 미제공 상태를 표현한다.
  *
  * @param runId - 빌드 실행 ID.
  * @param files - Builder가 반환한 산출물 파일 경로 목록.
- * @returns BuildManifest(메타 필드는 기본값).
+ * @returns BuildManifest(제공되지 않은 필드는 undefined).
  */
 function artifactsToManifest(runId: string, files: string[]): BuildManifest {
   return {
     schema_version: "1.0.0",
     build_id: runId,
-    started_at: "",
-    finished_at: "",
     build_environment: null,
-    inputs: [],
     inputs_fingerprint: null,
     outputs: files,
-    warnings: [],
-    errors: [],
-    row_counts: {},
-    schema_summaries: {},
-    provenance: [],
+    // 제공되지 않은 필드는 undefined로 남겨서 미제공 상태를 표현
+    // started_at, finished_at, inputs, warnings, errors, row_counts, schema_summaries, provenance
   };
 }
 

--- a/src/pages/BuildArtifactsPage.tsx
+++ b/src/pages/BuildArtifactsPage.tsx
@@ -61,6 +61,9 @@ export function BuildArtifactsPage() {
   const totalRecords = manifest?.row_counts
     ? Object.values(manifest.row_counts).reduce((sum, count) => sum + count, 0)
     : undefined;
+  // 실연동 모드 경고 배너용: 핵심 메타데이터(레코드 수/출처)가 제공되지 않으면 안내한다.
+  const hasMetadata =
+    manifest?.row_counts !== undefined && manifest?.provenance !== undefined;
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">

--- a/src/pages/BuildArtifactsPage.tsx
+++ b/src/pages/BuildArtifactsPage.tsx
@@ -52,13 +52,15 @@ export function BuildArtifactsPage() {
   useEffect(() => load(), [load]);
 
   const manifest = state.manifest;
-  const formats = manifest
+  // outputs가 undefined이면 formats도 undefined로, 빈 배열이면 빈 배열로 상태를 보존 (#119)
+  const formats = manifest?.outputs
     ? [...new Set(manifest.outputs.map((path) => describeFile(path).format))]
-    : [];
+    : manifest?.outputs ?? undefined;
   // Builder는 소스별 row_counts(dict)를 주므로 UI 요약에서는 합계로 보여준다.
-  const totalRecords = manifest
+  // row_counts가 제공되지 않으면(undefined) 레코드 수를 "미제공"으로 표시한다.
+  const totalRecords = manifest?.row_counts
     ? Object.values(manifest.row_counts).reduce((sum, count) => sum + count, 0)
-    : 0;
+    : undefined;
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
@@ -95,17 +97,29 @@ export function BuildArtifactsPage() {
               <div>
                 <dt className="text-muted-foreground">레코드 수</dt>
                 <dd className="text-foreground">
-                  {totalRecords.toLocaleString("ko-KR")}
+                  {totalRecords !== undefined
+                    ? totalRecords.toLocaleString("ko-KR")
+                    : "미제공"}
                 </dd>
               </div>
               <div>
                 <dt className="text-muted-foreground">출력 형식</dt>
-                <dd className="text-foreground">{formats.join(", ")}</dd>
+                <dd className="text-foreground">
+                  {formats === undefined
+                    ? "미제공"
+                    : formats.length > 0
+                      ? formats.join(", ")
+                      : "출력 형식 없음"}
+                </dd>
               </div>
               <div>
                 <dt className="text-muted-foreground">소스</dt>
                 <dd className="text-foreground">
-                  {manifest.provenance.map((p) => `${p.provider}.${p.dataset}`).join(", ")}
+                  {manifest.provenance === undefined
+                    ? "미제공"
+                    : manifest.provenance.length > 0
+                      ? manifest.provenance.map((p) => `${p.provider}.${p.dataset}`).join(", ")
+                      : "소스 없음"}
                 </dd>
               </div>
               <div>
@@ -121,8 +135,8 @@ export function BuildArtifactsPage() {
               <span>형식</span>
               <span>액션</span>
             </div>
-            {manifest.outputs.length === 0 ? (
-              <EmptyState title="생성된 파일이 없습니다" />
+            {!manifest.outputs || manifest.outputs.length === 0 ? (
+              <EmptyState title={manifest.outputs === undefined ? "파일 정보 미제공" : "생성된 파일이 없습니다"} />
             ) : (
               <ul>
                 {manifest.outputs.map((path) => {

--- a/src/pages/BuildDetailPage.tsx
+++ b/src/pages/BuildDetailPage.tsx
@@ -152,29 +152,37 @@ export function BuildDetailPage() {
               <div>
                 <dt className="text-muted-foreground">레코드 수</dt>
                 <dd className="text-foreground">
-                  {Object.values(manifestState.manifest.row_counts)
-                    .reduce((sum, count) => sum + count, 0)
-                    .toLocaleString("ko-KR")}
+                  {manifestState.manifest.row_counts === undefined
+                    ? "미제공"
+                    : Object.values(manifestState.manifest.row_counts)
+                        .reduce((sum, count) => sum + count, 0)
+                        .toLocaleString("ko-KR")}
                 </dd>
               </div>
               <div>
                 <dt className="text-muted-foreground">데이터 소스</dt>
                 <dd className="text-foreground">
-                  {manifestState.manifest.provenance.length === 0
-                    ? "소스 없음"
-                    : manifestState.manifest.provenance
-                        .map((provenance) => `${provenance.provider}.${provenance.dataset}`)
-                        .join(", ")}
+                  {manifestState.manifest.provenance === undefined
+                    ? "미제공"
+                    : manifestState.manifest.provenance.length === 0
+                      ? "소스 없음"
+                      : manifestState.manifest.provenance
+                          .map((provenance) => `${provenance.provider}.${provenance.dataset}`)
+                          .join(", ")}
                 </dd>
               </div>
               <div>
                 <dt className="text-muted-foreground">생성 파일 수</dt>
-                <dd className="text-foreground">{manifestState.manifest.outputs.length}</dd>
+                <dd className="text-foreground">
+                  {manifestState.manifest.outputs === undefined
+                    ? "미제공"
+                    : manifestState.manifest.outputs.length}
+                </dd>
               </div>
             </dl>
           </Card>
 
-          {manifestState.manifest.outputs.length === 0 ? (
+          {(manifestState.manifest.outputs?.length ?? 0) === 0 ? (
             <Card variant="dashed">
               <p className="text-sm text-muted-foreground">생성된 파일이 없습니다.</p>
             </Card>
@@ -185,7 +193,7 @@ export function BuildDetailPage() {
                 <span>형식</span>
               </div>
               <ul>
-                {manifestState.manifest.outputs.map((path) => {
+                {(manifestState.manifest.outputs ?? []).map((path) => {
                   const { name, format } = describeFile(path);
                   return (
                     <li

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -114,28 +114,28 @@ export interface BuildManifest {
   schema_version: string;
   /** 실행된 빌드를 추적하는 고유 ID */
   build_id: string;
-  /** 빌드 시작 시각 ISO 문자열(UTC) */
-  started_at: string;
-  /** 빌드 종료 시각 ISO 문자열(UTC) */
-  finished_at: string;
+  /** 빌드 시작 시각 ISO 문자열(UTC). 제공되지 않으면 undefined */
+  started_at?: string;
+  /** 빌드 종료 시각 ISO 문자열(UTC). 제공되지 않으면 undefined */
+  finished_at?: string;
   /** 빌드를 생성한 실행 환경. 캡처하지 못했으면 null */
   build_environment: ManifestBuildEnvironment | null;
-  /** 입력 파일 또는 소스 식별자 목록 */
-  inputs: string[];
+  /** 입력 파일 또는 소스 식별자 목록. 제공되지 않으면 undefined */
+  inputs?: string[];
   /** 입력 데이터 전체의 재현성 지문("sha256:..."). 입력이 없으면 null */
   inputs_fingerprint: string | null;
-  /** 생성된 결과물 경로 목록 */
-  outputs: string[];
-  /** 치명적이지 않지만 확인이 필요한 경고 목록 */
-  warnings: string[];
-  /** 실행 실패 또는 부분 실패 메시지 목록 */
-  errors: string[];
-  /** 단계별 또는 산출물별 레코드 수 요약(소스 키 → 건수) */
-  row_counts: Record<string, number>;
-  /** 소스(산출물) 키별 스키마 요약. row_counts와 동일한 키를 사용한다 */
-  schema_summaries: Record<string, ManifestSchemaSummary>;
-  /** 소스별 상세 출처(fetch 시각/파라미터/레코드 수/체크섬) 목록 */
-  provenance: ManifestSourceProvenance[];
+  /** 생성된 결과물 경로 목록. 제공되지 않으면 undefined */
+  outputs?: string[];
+  /** 치명적이지 않지만 확인이 필요한 경고 목록. 제공되지 않으면 undefined */
+  warnings?: string[];
+  /** 실행 실패 또는 부분 실패 메시지 목록. 제공되지 않으면 undefined */
+  errors?: string[];
+  /** 단계별 또는 산출물별 레코드 수 요약(소스 키 → 건수). 제공되지 않으면 undefined */
+  row_counts?: Record<string, number>;
+  /** 소스(산출물) 키별 스키마 요약. row_counts와 동일한 키를 사용한다. 제공되지 않으면 undefined */
+  schema_summaries?: Record<string, ManifestSchemaSummary>;
+  /** 소스별 상세 출처(fetch 시각/파라미터/레코드 수/체크섬) 목록. 제공되지 않으면 undefined */
+  provenance?: ManifestSourceProvenance[];
 }
 
 export interface BuildDraft {


### PR DESCRIPTION
## 요약

Builder API가 제공하지 않은 BuildManifest 필드를 `undefined`로 표현하도록 수정했습니다.
이를 통해 “정보 미제공”과 “정보는 제공됐지만 데이터 없음” 상태를 UI에서 구분합니다.

## 변경 내용

* `BuildManifest`의 일부 필드를 optional로 변경

  * `started_at`
  * `finished_at`
  * `inputs`
  * `outputs`
  * `warnings`
  * `errors`
  * `provenance`
  * `row_counts`
  * `schema_summaries`
* Builder API가 제공하지 않은 필드를 빈 배열·빈 객체 대신 `undefined`로 유지
* BuildArtifactsPage에서 다음 상태를 구분

  * `undefined`: 미제공
  * 빈 배열·객체: 제공됐지만 데이터 없음
  * 값 존재: 실제 데이터 표시
* 출력 형식, 소스 정보, 파일 목록, 레코드 수 표시 개선
* 실패한 빌드 mock manifest의 미제공 필드 처리 수정
* UI 렌더링 및 manifest 계약 테스트 추가

## 관련 이슈

Closes #119

## 검증

* [x] ESLint 통과

  * `npx eslint src/ __tests__/`
* [x] TypeScript typecheck 통과

  * `npm run typecheck`
* [x] 테스트 통과

  * `npm test`
  * 36 test files, 139 tests passed
* [x] Production build 성공

  * `npm run build`
* [x] `package-lock.json` 변경 없음

## 체크리스트

* [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
* [x] 커밋 메시지를 영어로 작성했다
* [x] Issue #119 관련 파일만 변경했다
* [x] 사용자에게 노출되는 상태 표현을 테스트로 검증했다
* [x] 관련 없는 lockfile 또는 formatter 변경을 포함하지 않았다
