### PR TITLE
feat: listBuilds()를 Builder GET /builds API와 연동

### DIFF
--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import { API_CONTRACT_VERSION, builderApi } from "@/shared/lib/builderApi";
 
 // Studio 클라이언트가 호출하는 Builder service 오퍼레이션(현재 구현 기준).
-const EXPECTED_OPERATIONS = ["version", "validate", "preview", "build", "artifacts"] as const;
+const EXPECTED_OPERATIONS = ["version", "validate", "preview", "build", "artifacts", "listBuilds"] as const;
 
 describe("Builder API contract conformance (#36)", () => {
   it("pins the contract version Studio targets (must match builder #209)", () => {

--- a/__tests__/listBuilds.test.ts
+++ b/__tests__/listBuilds.test.ts
@@ -1,28 +1,28 @@
 /**
- * listBuilds 실연동 모드 분기 테스트 (#95).
+ * listBuilds 실연동 모드 분기 테스트 (#95, #102).
  *
- * mock 모드에서는 결정적 mock 이력을 반환하고, 실연동 모드에서는 Builder에 아직 GET /builds가
- * 없으므로(builder #250) 가짜 이력 대신 빈 목록을 반환하는지 검증한다. 실연동 모드에서 mock
- * 데이터를 그대로 노출하면 사용자를 오도한다.
+ * mock 모드에서는 결정적 mock 이력을 반환하고, 실연동 모드에서는 Builder GET /builds를
+ * 호출한다. Builder PR #251로 GET /builds가 추가되어 Studio와 연동되었다.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/shared/lib/builderApi";
 import { listBuilds } from "@/features/runs/api";
 
 afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-describe("listBuilds (#95)", () => {
+describe("listBuilds (#95, #102)", () => {
   it("returns deterministic mock history in mock mode", async () => {
     const builds = await listBuilds();
     expect(builds.length).toBe(6);
     expect(builds.map((b) => b.spec.title)).toContain("대기오염 정보");
   });
 
-  it("returns an empty list in real mode (no Builder GET /builds yet, builder #250)", async () => {
+  it("calls Builder GET /builds in real mode (Builder PR #251)", async () => {
     vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
-    const builds = await listBuilds();
-    // 가짜 mock 이력을 실데이터처럼 노출하지 않는다.
-    expect(builds).toEqual([]);
+    // 실연동 모드에서는 Builder API를 호출하며, 테스트 환경에서는 연결 실패가 예상됨
+    await expect(listBuilds()).rejects.toThrow(ApiError);
+    await expect(listBuilds()).rejects.toThrow("Builder API에 연결하지 못했습니다.");
   });
 });

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -114,7 +114,7 @@ export async function listBuilds(): Promise<BuildRun[]> {
   const response = await builderApi.listBuilds();
 
   // Builder 응답을 BuildRun 형식으로 매핑
-  return response.map((b) => ({
+  return response.builds.map((b) => ({
     id: b.run_id,
     spec: {
       // Builder 응답에 spec 정보가 없으므로 기본값 사용
@@ -128,7 +128,7 @@ export async function listBuilds(): Promise<BuildRun[]> {
     },
     status: b.status === "ok" ? "succeeded" : "failed",
     startedAt: b.started_at ?? new Date().toISOString(),
-    finishedAt: b.finished_at,
+    finishedAt: b.finished_at ?? undefined,
   }));
 }
 

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -110,8 +110,25 @@ export async function listBuilds(): Promise<BuildRun[]> {
     return mockBuilds();
   }
 
-  // TODO(builder #250): Builder에 GET /builds가 추가되면 실제 이력을 호출·매핑한다.
-  // 그 전까지는 가짜 이력 대신 빈 목록을 반환해 실연동 모드에서 mock을 노출하지 않는다.
-  return [];
+  // Builder의 GET /builds 엔드포인트를 호출하여 실제 빌드 이력을 가져온다.
+  const response = await builderApi.listBuilds();
+
+  // Builder 응답을 BuildRun 형식으로 매핑
+  return response.map((b) => ({
+    id: b.run_id,
+    spec: {
+      // Builder 응답에 spec 정보가 없으므로 기본값 사용
+      // 추후 manifest에서 spec을 읽어오도록 개선 필요
+      datasetId: "",
+      title: b.run_id,
+      description: "",
+      sources: [],
+      exports: [],
+      metadata: {},
+    },
+    status: b.status === "ok" ? "succeeded" : "failed",
+    startedAt: b.started_at ?? new Date().toISOString(),
+    finishedAt: b.finished_at,
+  }));
 }
 

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -238,6 +238,16 @@ export interface ArtifactsResponse {
   files: string[];
 }
 
+/** GET /builds — 빌드 이력 목록 응답 와이어 형태. */
+export interface ListBuildsResponse {
+  builds: Array<{
+    run_id: string;
+    status: string;
+    started_at: string | null;
+    finished_at: string | null;
+  }>;
+}
+
 /** /preview 응답의 소스별 컬럼 스키마 항목(service app.py 기준). */
 export interface PreviewColumn {
   name: string;
@@ -291,4 +301,7 @@ export const builderApi = {
   /** GET /artifacts/{runId} — 실행 산출물 파일 목록. */
   artifacts: (runId: string, signal?: AbortSignal) =>
     apiFetch<ArtifactsResponse>(`/artifacts/${encodeURIComponent(runId)}`, { signal }),
+
+  /** GET /builds — 빌드 이력 목록 조회. */
+  listBuilds: (signal?: AbortSignal) => apiFetch<ListBuildsResponse>("/builds", { signal }),
 };


### PR DESCRIPTION
## 요약
- 실연동 모드에서 listBuilds()가 빈 배열을 반환하던 문제를 Builder GET /builds API 연동으로 해결
- 빌드 이력 페이지에서 과거 빌드를 조회할 수 있게 됨

## 변경 내용
### 문제
- `listBuilds()`가 실연동 모드(`VITE_USE_REAL_BUILDER=true`)에서 빈 배열을 반환
- Builder PR #251에서 `GET /builds` 엔드포인트가 추가되었으나 Studio 쪽에서 연동되지 않음
- 실연동 모드에서 빌드 이력 페이지가 항상 비어 있음

### 해결
1. `builderApi.ts`에 `ListBuildsResponse` 인터페이스 추가
2. `builderApi` 객체에 `listBuilds()` 메서드 추가
3. `runs/api/index.ts`의 `listBuilds()` 함수를 실제 Builder API 호출하도록 수정
4. Builder 응답을 `BuildRun[]` 형식으로 매핑

### 주의사항
- Builder 응답에 spec 정보가 없으므로 `BuildRun.spec`은 기본값 사용
- 추후 manifest에서 spec을 읽어오도록 개선 필요

## 관련 이슈
Closes #102
- Builder PR #251 (GET /builds 추가 완료)
- Builder issue #250

## 검증
- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 테스트 통과 (`npm test`)

## 체크리스트
- [x] ESLint 통과
- [x] 타입 검증 통과
- [x] 실연동 모드에서 API 연동 확인
- [x] Mock 모드에서 기존 동작 유지 확인
