### PR TITLE
feat:  Builder API 응답 런타임 타입 검증 추가

### DIFF
--- a/__tests__/builderApi.test.ts
+++ b/__tests__/builderApi.test.ts
@@ -35,7 +35,11 @@ describe("builderApi client (#29)", () => {
 
   it("preview() POSTs spec to /preview (#75)", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      mockResponse(200, { status: "ok", preview: [], api_version: "1.0.0" }),
+      mockResponse(200, {
+        dataset_id: "test-dataset",
+        previews: [],
+        api_version: "1.0.0",
+      }),
     );
     vi.stubGlobal("fetch", fetchMock);
 

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -13,6 +13,7 @@
  * Studio BuildSpec(camelCase) → Builder 스펙 매핑(#37)이 선행되어야 완전히 연결된다.
  * 이 모듈은 그 매핑이 끝난 스펙 텍스트를 받는 저수준 계약 계층이다.
  */
+import { z } from "zod";
 import { API_BASE } from "@/shared/config/env";
 
 /** Builder API 계약 버전. builder #209의 API_CONTRACT_VERSION과 일치해야 한다. */
@@ -206,6 +207,93 @@ export function extractErrorMessage(parsed: unknown): string | undefined {
   return undefined;
 }
 
+// --- Zod 런타임 스키마 검증 (#103) ---
+
+/** Builder API 응답의 api_version을 검증하고 협상한다. */
+function validateApiVersion(responseApiVersion: string | undefined): void {
+  if (!responseApiVersion) {
+    console.warn("Builder 응답에 api_version이 없습니다. 계약 불일치 가능성이 있습니다.");
+    return;
+  }
+
+  if (responseApiVersion !== API_CONTRACT_VERSION) {
+    console.warn(
+      `API 계약 버전 불일치: Studio=${API_CONTRACT_VERSION}, Builder=${responseApiVersion}. ` +
+        "일부 기능이 예상대로 동작하지 않을 수 있습니다."
+    );
+  }
+}
+
+/** GET /version 응답 스키마 */
+export const VersionResponseSchema = z.object({
+  service: z.string(),
+  api_version: z.string(),
+});
+
+/** POST /validate 응답 스키마 */
+export const ValidateResponseSchema = z.discriminatedUnion("status", [
+  z.object({
+    status: z.literal("valid"),
+    dataset_id: z.string(),
+    api_version: z.string(),
+  }),
+  z.object({
+    status: z.literal("invalid"),
+    problems: z.array(z.string()),
+  }),
+  z.object({
+    status: z.literal("error"),
+    error: z.string(),
+  }),
+]);
+
+/** /build 응답의 outcome 항목 스키마 */
+const BuildOutcomeSchema = z.object({
+  source_key: z.string(),
+  status: z.string(),
+  stages_completed: z.array(z.string()),
+  error: z.string().nullable(),
+});
+
+/** POST /build 응답 스키마 */
+export const BuildResponseSchema = z.object({
+  status: z.string(),
+  run_id: z.string(),
+  outcomes: z.array(BuildOutcomeSchema),
+  manifest: z.string(),
+  api_version: z.string(),
+});
+
+/** GET /artifacts/{runId} 응답 스키마 */
+export const ArtifactsResponseSchema = z.object({
+  run_id: z.string(),
+  files: z.array(z.string()),
+});
+
+/** /preview 응답의 컬럼 스키마 항목 */
+const PreviewColumnSchema = z.object({
+  name: z.string(),
+  dtype: z.string(),
+  nullable: z.boolean(),
+  unique_count: z.number(),
+});
+
+/** /preview 응답의 소스별 미리보기 항목 */
+const PreviewSourceSchema = z.object({
+  source_key: z.string(),
+  status: z.string(),
+  error: z.string().nullable(),
+  schema: z.array(PreviewColumnSchema),
+  sample: z.array(z.record(z.string(), z.unknown())),
+  total_rows: z.number(),
+});
+
+/** POST /preview 응답 스키마 */
+export const PreviewResponseSchema = z.object({
+  dataset_id: z.string(),
+  previews: z.array(PreviewSourceSchema),
+});
+
 // --- 응답 와이어 타입 (Builder service 실제 구현 기준) ---
 
 export interface VersionResponse {
@@ -269,26 +357,56 @@ export interface PreviewResponse {
 /** Builder service 엔드포인트를 감싼 클라이언트. */
 export const builderApi = {
   /** GET /version — 계약 버전 확인(메타). */
-  version: (signal?: AbortSignal) => apiFetch<VersionResponse>("/version", { signal }),
+  version: async (signal?: AbortSignal) => {
+    const response = await apiFetch<VersionResponse>("/version", { signal });
+    const validated = VersionResponseSchema.parse(response);
+    validateApiVersion(validated.api_version);
+    return validated;
+  },
 
   /** POST /validate — BuildSpec YAML 검증. */
-  validate: (specYaml: string, signal?: AbortSignal) =>
-    apiFetch<ValidateResponse>("/validate", { method: "POST", body: { spec: specYaml }, signal }),
+  validate: async (specYaml: string, signal?: AbortSignal) => {
+    const response = await apiFetch<ValidateResponse>("/validate", {
+      method: "POST",
+      body: { spec: specYaml },
+      signal,
+    });
+    const validated = ValidateResponseSchema.parse(response);
+    if (validated.status === "valid") {
+      validateApiVersion(validated.api_version);
+    }
+    return validated;
+  },
 
   /** POST /preview — BuildSpec 기반 샘플 미리보기. */
-  preview: (specYaml: string, signal?: AbortSignal) =>
-    apiFetch<PreviewResponse>("/preview", { method: "POST", body: { spec: specYaml }, signal }),
+  preview: async (specYaml: string, signal?: AbortSignal) => {
+    const response = await apiFetch<PreviewResponse>("/preview", {
+      method: "POST",
+      body: { spec: specYaml },
+      signal,
+    });
+    return PreviewResponseSchema.parse(response);
+  },
 
   /** POST /build — 빌드 실행. run_id 생략 가능. 비멱등 요청이므로 재시도하지 않는다 (#117). */
-  build: (specYaml: string, runId?: string, signal?: AbortSignal) =>
-    apiFetch<BuildResponse>("/build", {
+  build: async (specYaml: string, runId?: string, signal?: AbortSignal) => {
+    const response = await apiFetch<BuildResponse>("/build", {
       method: "POST",
       body: runId ? { spec: specYaml, run_id: runId } : { spec: specYaml },
       signal,
       retries: 0,
-    }),
+    });
+    const validated = BuildResponseSchema.parse(response);
+    validateApiVersion(validated.api_version);
+    return validated;
+  },
 
   /** GET /artifacts/{runId} — 실행 산출물 파일 목록. */
-  artifacts: (runId: string, signal?: AbortSignal) =>
-    apiFetch<ArtifactsResponse>(`/artifacts/${encodeURIComponent(runId)}`, { signal }),
+  artifacts: async (runId: string, signal?: AbortSignal) => {
+    const response = await apiFetch<ArtifactsResponse>(
+      `/artifacts/${encodeURIComponent(runId)}`,
+      { signal }
+    );
+    return ArtifactsResponseSchema.parse(response);
+  },
 };


### PR DESCRIPTION
## 요약
API 응답이 타입 단언(as T)으로만 처리되어, Builder 응답이 예상 스키마와 다를 경우 UI 렌더링 시점에서 오류가 발생하던 문제 해결

## 변경 내용
### 문제
- `builderApi.ts`에서 API 응답을 타입 단언(`as T`)으로만 처리
- Builder 응답이 예상 스키마와 다를 경우 UI 렌더링 시점에서 오류 발생
- `api_version` 필드가 존재하지만 Studio에서 실제 검증하지 않음

### 해결
1. **Zod 런타임 스키마 검증 추가**
   - 모든 Builder API 응답 타입에 대한 Zod 스키마 정의
   - `VersionResponseSchema`, `ValidateResponseSchema`, `BuildResponseSchema`, `ArtifactsResponseSchema`, `PreviewResponseSchema`

2. **api_version 협상 구현**
   - Builder 응답의 `api_version`과 Studio의 `API_CONTRACT_VERSION` 비교
   - 불일치 시 콘솔에 경고 메시지 출력

3. **모든 builderApi 메서드에 런타임 검증 적용**
   - `version()`, `validate()`, `preview()`, `build()`, `artifacts()` 메서드 수정
   - API 경계에서 조기 오류 감지

### 영향
- Builder 계약 변경 시 UI 렌더링 대신 API 호출 시점에서 명확한 오류 메시지 제공
- 디버깅 효율 향상 (API 문제인지 UI 로직 문제인지 즉시 파악 가능)
- 빌드 번지 크기: 445KB → 455KB (+10KB, Zod 라이브러리 추가)

## 관련 이슈
Closes #103
- API_CONTRACT_VERSION (L19) — 실제 검증 로직 추가
- Builder service/app.py 응답에 api_version 포함됨

## 검증
- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 테스트 통과 (`npm test`)(131개 테스트 전체)

## 체크리스트
- [x] ESLint 통과
- [x] TypeScript 타입 검증 통과
- [x] 모든 테스트 통과 (131개)
- [x] 빌드 성공
- [x] Zod 스키마 검증 동작 확인
