### PR TITLE
feat: Build Edit/Detail 화면 실제 데이터 연동 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# local tooling
+.claude/
+.npmrc

--- a/__tests__/buildRoutes.test.tsx
+++ b/__tests__/buildRoutes.test.tsx
@@ -20,16 +20,26 @@ function renderAt(path: string, element: React.ReactNode) {
 }
 
 describe("build-centric routes", () => {
-  it("renders the build detail page with the buildId from the route", async () => {
-    renderAt("/builds/air-quality", <BuildDetailPage />);
+  it("renders the build detail page with data for the buildId from the route", async () => {
+    // 라우트 파라미터가 실제 조회에 쓰이는지 확인하기 위해 mock 이력에 존재하는 id를 쓴다.
+    renderAt("/builds/air-quality-20260621", <BuildDetailPage />);
     // BuildDetailPage는 비동기로 데이터를 로드하므로 로딩이 완료될 때까지 기다린다.
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Mock Build" })).toBeInTheDocument();
-      expect(screen.getByRole("link", { name: /편집/ })).toHaveAttribute(
-        "href",
-        "/builds/air-quality/edit",
-      );
+      // 조회된 스펙의 제목이 표시되고,
+      expect(screen.getByRole("heading", { name: "대기오염 정보" })).toBeInTheDocument();
     });
+    // 어떤 실행인지 식별할 수 있도록 run id도 함께 노출된다.
+    expect(screen.getByText(/air-quality-20260621/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /편집/ })).toHaveAttribute(
+      "href",
+      "/builds/air-quality-20260621/edit",
+    );
+  });
+
+  it("shows an error instead of placeholder data for an unknown buildId", async () => {
+    renderAt("/builds/does-not-exist", <BuildDetailPage />);
+    // 존재하지 않는 빌드를 실제 데이터처럼 보여주면 안 된다 (#119, #120).
+    expect(await screen.findByText(/빌드를 찾을 수 없습니다/)).toBeInTheDocument();
   });
 
   it("renders the run page with progress steps", () => {

--- a/__tests__/buildRoutes.test.tsx
+++ b/__tests__/buildRoutes.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import { BuildArtifactsPage } from "@/pages/BuildArtifactsPage";
@@ -20,13 +20,16 @@ function renderAt(path: string, element: React.ReactNode) {
 }
 
 describe("build-centric routes", () => {
-  it("renders the build detail page with the buildId from the route", () => {
+  it("renders the build detail page with the buildId from the route", async () => {
     renderAt("/builds/air-quality", <BuildDetailPage />);
-    expect(screen.getByRole("heading", { name: "air-quality" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /편집/ })).toHaveAttribute(
-      "href",
-      "/builds/air-quality/edit",
-    );
+    // BuildDetailPage는 비동기로 데이터를 로드하므로 로딩이 완료될 때까지 기다린다.
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Mock Build" })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /편집/ })).toHaveAttribute(
+        "href",
+        "/builds/air-quality/edit",
+      );
+    });
   });
 
   it("renders the run page with progress steps", () => {

--- a/src/features/build-spec/specStore.test.ts
+++ b/src/features/build-spec/specStore.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  SPEC_STORE_LIMIT,
+  clearBuildSpecs,
+  hasBuildSpec,
+  loadBuildSpec,
+  saveBuildSpec,
+} from "./specStore";
+import type { BuildSpec } from "@/shared/lib/types";
+
+function makeSpec(overrides: Partial<BuildSpec> = {}): BuildSpec {
+  return {
+    datasetId: "air-quality",
+    title: "대기오염 정보",
+    description: "시도별 실시간 대기오염 측정값",
+    sources: [{ provider: "datago", dataset: "air", params: { sidoName: "서울" } }],
+    exports: [{ format: "jsonl" }],
+    metadata: { outputPath: "artifacts/builds/air", source_url: "https://example.test" },
+    ...overrides,
+  };
+}
+
+describe("specStore", () => {
+  beforeEach(() => {
+    clearBuildSpecs();
+  });
+
+  it("저장한 스펙을 run id로 되돌려준다", () => {
+    const spec = makeSpec();
+    saveBuildSpec("run-1", spec);
+
+    expect(loadBuildSpec("run-1")).toEqual(spec);
+    expect(hasBuildSpec("run-1")).toBe(true);
+  });
+
+  it("여러 소스와 폼에 없는 메타데이터를 그대로 보존한다", () => {
+    const spec = makeSpec({
+      sources: [
+        { provider: "datago", dataset: "air", params: {} },
+        { provider: "datago", dataset: "water", params: { region: "busan" } },
+      ],
+      metadata: { outputPath: "out", hf_repo: "org/dataset", source_url: "https://example.test" },
+    });
+    saveBuildSpec("run-multi", spec);
+
+    const loaded = loadBuildSpec("run-multi");
+    expect(loaded?.sources).toHaveLength(2);
+    expect(loaded?.metadata.hf_repo).toBe("org/dataset");
+  });
+
+  it("저장된 적 없는 run id는 null을 반환한다", () => {
+    expect(loadBuildSpec("unknown")).toBeNull();
+    expect(hasBuildSpec("unknown")).toBe(false);
+  });
+
+  it("빈 run id는 저장하지도 조회하지도 않는다", () => {
+    saveBuildSpec("", makeSpec());
+    expect(loadBuildSpec("")).toBeNull();
+  });
+
+  it("스키마를 통과하지 못하는 손상된 값은 버린다", () => {
+    saveBuildSpec("run-broken", makeSpec());
+    // 저장 이후 스펙 형태가 바뀌었거나 값이 손상된 상황을 흉내낸다.
+    const raw = JSON.parse(localStorage.getItem("kpubdata-studio:build-specs") as string) as {
+      entries: Record<string, { spec: unknown }>;
+    };
+    raw.entries["run-broken"].spec = { datasetId: 123 };
+    localStorage.setItem("kpubdata-studio:build-specs", JSON.stringify(raw));
+
+    expect(loadBuildSpec("run-broken")).toBeNull();
+  });
+
+  it("봉투 버전이 다르면 조용히 정리한다", () => {
+    localStorage.setItem(
+      "kpubdata-studio:build-specs",
+      JSON.stringify({ version: 999, entries: { "run-1": { spec: makeSpec(), savedAt: "x" } } }),
+    );
+
+    expect(loadBuildSpec("run-1")).toBeNull();
+    expect(localStorage.getItem("kpubdata-studio:build-specs")).toBeNull();
+  });
+
+  it("상한을 넘으면 오래된 항목부터 버린다", () => {
+    for (let i = 0; i < SPEC_STORE_LIMIT + 5; i++) {
+      saveBuildSpec(`run-${String(i).padStart(3, "0")}`, makeSpec({ datasetId: `ds-${i}` }));
+    }
+
+    // 가장 먼저 저장한 항목은 밀려나고, 마지막 항목은 남아 있어야 한다.
+    expect(loadBuildSpec("run-000")).toBeNull();
+    expect(loadBuildSpec(`run-${String(SPEC_STORE_LIMIT + 4).padStart(3, "0")}`)).not.toBeNull();
+  });
+});

--- a/src/features/build-spec/specStore.ts
+++ b/src/features/build-spec/specStore.ts
@@ -1,0 +1,161 @@
+/**
+ * 실행된 빌드의 BuildSpec을 run_id 기준으로 보관하는 로컬 저장소 (#120).
+ *
+ * Builder는 BuildSpec을 영속화하지 않는다. `/build`는 매 호출마다 spec YAML을 받아
+ * 실행하고 버리며, manifest.json에도 spec은 남지 않는다. `GET /builds`가 돌려주는
+ * 것도 `{run_id, status, started_at, finished_at}`뿐이다. 따라서 "기존 빌드를 불러와
+ * 편집"하려면 Studio가 실행 시점의 spec을 스스로 기억해 두는 수밖에 없다.
+ *
+ * 한계를 분명히 해 둔다: 이 저장소는 브라우저 로컬이므로 다른 기기·브라우저에서 만든
+ * 빌드나 CLI로 실행한 빌드는 편집할 수 없다. Builder에 spec 영속화와 개별 조회
+ * 엔드포인트가 생기면 `loadBuildSpec`의 구현만 원격 호출로 교체하면 되도록,
+ * 호출부는 이 모듈의 함수 시그니처에만 의존하게 한다.
+ *
+ * 저장 형태는 draftStorage와 같은 `{version, data, savedAt}` 봉투 규약을 따른다.
+ */
+import { buildSpecSchema } from "@/shared/lib/schemas";
+import type { BuildSpec } from "@/shared/lib/types";
+
+const SPEC_STORE_KEY = "kpubdata-studio:build-specs";
+
+/** 저장 봉투 스키마 버전. 호환되지 않게 형태가 바뀌면 올린다. */
+export const SPEC_STORE_VERSION = 1;
+
+/**
+ * 보관할 최대 항목 수.
+ *
+ * localStorage는 오리진당 수 MB 수준이라 무한정 쌓으면 다른 기능(초안 저장 등)의
+ * 쓰기까지 QuotaExceededError로 막을 수 있다. 오래된 항목부터 버린다.
+ */
+export const SPEC_STORE_LIMIT = 50;
+
+/** run_id별 저장 항목. */
+interface SpecEntry {
+  /** 실행에 사용된 빌드 스펙 */
+  spec: unknown;
+  /** 저장 시각 ISO 문자열 (오래된 항목 정리 기준) */
+  savedAt: string;
+}
+
+/** localStorage에 저장되는 봉투 구조. */
+interface SpecStoreEnvelope {
+  version: number;
+  entries: Record<string, SpecEntry>;
+}
+
+/**
+ * 저장된 봉투를 읽는다. 없거나 버전이 다르거나 손상되면 빈 봉투를 반환한다.
+ *
+ * @returns 항상 사용 가능한 봉투(실패 시 빈 상태).
+ */
+function readEnvelope(): SpecStoreEnvelope {
+  const empty: SpecStoreEnvelope = { version: SPEC_STORE_VERSION, entries: {} };
+  try {
+    const raw = localStorage.getItem(SPEC_STORE_KEY);
+    if (!raw) return empty;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      (parsed as SpecStoreEnvelope).version !== SPEC_STORE_VERSION ||
+      typeof (parsed as SpecStoreEnvelope).entries !== "object" ||
+      (parsed as SpecStoreEnvelope).entries === null
+    ) {
+      // 버전 불일치/봉투 아님: 손상된 값이 계속 남지 않도록 정리한다.
+      clearBuildSpecs();
+      return empty;
+    }
+    return parsed as SpecStoreEnvelope;
+  } catch {
+    // localStorage 사용 불가(SSR/프라이빗 모드) 또는 JSON 파싱 실패.
+    return empty;
+  }
+}
+
+/**
+ * 봉투를 저장한다. 실패 시 조용히 무시한다(저장 실패가 빌드 실행을 막으면 안 된다).
+ *
+ * @param envelope - 저장할 봉투.
+ */
+function writeEnvelope(envelope: SpecStoreEnvelope): void {
+  try {
+    localStorage.setItem(SPEC_STORE_KEY, JSON.stringify(envelope));
+  } catch {
+    // 용량 초과/사용 불가 시 무시.
+  }
+}
+
+/**
+ * 실행된 빌드의 스펙을 run_id에 묶어 저장한다.
+ *
+ * 같은 run_id로 다시 저장하면 덮어쓴다. 항목 수가 상한을 넘으면 `savedAt` 기준으로
+ * 오래된 것부터 버린다.
+ *
+ * @param runId - 빌드 실행 식별자.
+ * @param spec - 실행에 사용된 빌드 스펙.
+ */
+export function saveBuildSpec(runId: string, spec: BuildSpec): void {
+  if (!runId) return;
+
+  const envelope = readEnvelope();
+  envelope.entries[runId] = { spec, savedAt: new Date().toISOString() };
+
+  const keys = Object.keys(envelope.entries);
+  if (keys.length > SPEC_STORE_LIMIT) {
+    // savedAt 오름차순으로 정렬해 오래된 항목부터 제거한다.
+    const ordered = keys.sort(
+      (a, b) => envelope.entries[a].savedAt.localeCompare(envelope.entries[b].savedAt),
+    );
+    for (const key of ordered.slice(0, keys.length - SPEC_STORE_LIMIT)) {
+      delete envelope.entries[key];
+    }
+  }
+
+  writeEnvelope(envelope);
+}
+
+/**
+ * run_id로 저장된 스펙을 불러온다.
+ *
+ * 저장 이후 스펙 스키마가 바뀌었을 수 있으므로 zod로 재검증한다. 통과하지 못한
+ * 항목은 편집 폼을 깨뜨리기 전에 버린다.
+ *
+ * @param runId - 빌드 실행 식별자.
+ * @returns 저장된 스펙, 없거나 더 이상 유효하지 않으면 null.
+ */
+export function loadBuildSpec(runId: string): BuildSpec | null {
+  if (!runId) return null;
+
+  const envelope = readEnvelope();
+  const entry = envelope.entries[runId];
+  if (!entry) return null;
+
+  const result = buildSpecSchema.safeParse(entry.spec);
+  if (!result.success) {
+    delete envelope.entries[runId];
+    writeEnvelope(envelope);
+    return null;
+  }
+  return result.data;
+}
+
+/**
+ * 저장된 스펙이 있는지 확인한다.
+ *
+ * @param runId - 빌드 실행 식별자.
+ * @returns 편집 가능한 스펙 보유 여부.
+ */
+export function hasBuildSpec(runId: string): boolean {
+  return loadBuildSpec(runId) !== null;
+}
+
+/**
+ * 저장소 전체를 비운다.
+ */
+export function clearBuildSpecs(): void {
+  try {
+    localStorage.removeItem(SPEC_STORE_KEY);
+  } catch {
+    // 무시.
+  }
+}

--- a/src/features/publish/api/index.ts
+++ b/src/features/publish/api/index.ts
@@ -5,9 +5,17 @@
  * 아직 publish 엔드포인트를 노출하지 않으므로 현재는 결정적 mock 결과를 반환한다.
  * Builder publish 엔드포인트가 생기면 이 함수만 실제 호출로 교체한다.
  */
+import { isRealBuilderEnabled } from "@/shared/lib/builderApi";
 import type { BuildSpec } from "@/shared/lib/types";
 
-export type PublishDestination = "local" | "huggingface" | "github";
+/**
+ * 게시 대상. Builder의 `PUBLISHER_REGISTRY` 키와 일치해야 한다.
+ *
+ * Builder가 실제로 제공하는 publisher는 local / huggingface / kaggle 세 가지다.
+ * 이전에는 여기에 "github"가 있었지만 Builder에 대응 publisher가 없어, 사용자가 고를 수
+ * 있는데 실행은 불가능한 선택지였다 (#120).
+ */
+export type PublishDestination = "local" | "huggingface" | "kaggle";
 
 export interface PublishResult {
   /** 게시 결과 상태 */
@@ -19,7 +27,15 @@ export interface PublishResult {
 }
 
 /**
- * 빌드 결과를 선택한 대상에 게시한다(현재 mock).
+ * 빌드 결과를 선택한 대상에 게시한다.
+ *
+ * Builder service(`service/app.py`)는 `/version`, `/validate`, `/preview`, `/build`,
+ * `/artifacts/{run_id}`, `/builds`만 노출하며 publish 엔드포인트가 없다. 게시 로직 자체는
+ * Builder CLI(`kpubdata publish`)와 `PUBLISHER_REGISTRY`에 존재하지만 HTTP로는 닿을 수 없다.
+ *
+ * 따라서 실연동 모드에서 성공을 반환하면 아무 일도 일어나지 않았는데 게시된 것처럼 보인다.
+ * 이는 이슈 #120이 지적한 문제이므로, 여기서는 성공을 가장하지 않고 실패 사유를 그대로
+ * 돌려준다. Builder에 `POST /publish`가 추가되면 이 분기를 실제 호출로 교체한다.
  *
  * @param buildId - 게시할 빌드 실행 ID.
  * @param destination - 배포 대상.
@@ -33,10 +49,20 @@ export async function publishBuild(
 ): Promise<PublishResult> {
   // 이미 취소된 신호로 호출되면 취소 흐름이 일관되게 동작하도록 AbortError를 던진다.
   if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+
+  if (isRealBuilderEnabled()) {
+    return {
+      status: "failed",
+      error:
+        "Builder에 게시 엔드포인트가 없어 실제 게시를 수행할 수 없습니다. " +
+        "현재는 Builder CLI(kpubdata publish)로만 게시할 수 있습니다.",
+    };
+  }
+
+  // mock 모드에서는 게시 흐름 UI(진행/성공/취소)를 개발·검증할 수 있도록 성공을 반환한다.
+  // 실제 결과 URL이 없으므로 url은 비워 둔다(깨진 링크 방지).
   void buildId;
   void destination;
-  // Builder publish 엔드포인트 전까지는 실제 결과 URL이 없으므로 url을 비워 둔다(깨진 링크 방지).
-  // Builder가 게시 결과 URL을 반환하면 이 함수에서 result.url에 채운다.
   return { status: "published" };
 }
 

--- a/src/features/runs/api/getBuild.ts
+++ b/src/features/runs/api/getBuild.ts
@@ -1,0 +1,49 @@
+/**
+ * 개별 빌드 실행 정보 조회 API.
+ *
+ * buildId로 빌드 상세 정보를 가져온다.
+ */
+import { isRealBuilderEnabled } from "@/shared/lib/builderApi";
+import type { BuildRun } from "@/shared/lib/types";
+
+/** mock 모드에서 사용할 가짜 빌드 데이터 */
+function mockBuild(buildId: string): BuildRun {
+  return {
+    id: buildId,
+    spec: {
+      datasetId: "mock-dataset",
+      title: "Mock Build",
+      description: "Mock build for development",
+      sources: [],
+      exports: [],
+      metadata: {},
+    },
+    status: "succeeded",
+    startedAt: "1970-01-01T00:00:00.000Z",
+    finishedAt: "1970-01-01T00:00:01.000Z",
+  };
+}
+
+/**
+ * buildId로 빌드 실행 정보를 조회한다.
+ *
+ * @param buildId - 조회할 빌드 ID.
+ * @returns 빌드 실행 정보.
+ */
+export async function getBuild(buildId: string): Promise<BuildRun> {
+  if (!isRealBuilderEnabled()) {
+    return mockBuild(buildId);
+  }
+
+  // 실연동 모드에서는 listBuilds() 결과에서 찾는다.
+  // Builder에 개별 조회 엔드포인트가 없으므로 전체 목록을 가져와서 필터링한다.
+  const { listBuilds } = await import("./index");
+  const builds = await listBuilds();
+  const build = builds.find((b) => b.id === buildId);
+
+  if (!build) {
+    throw new Error(`빌드를 찾을 수 없습니다: ${buildId}`);
+  }
+
+  return build;
+}

--- a/src/features/runs/api/getBuild.ts
+++ b/src/features/runs/api/getBuild.ts
@@ -1,49 +1,51 @@
 /**
- * 개별 빌드 실행 정보 조회 API.
+ * 개별 빌드 실행 정보 조회 API (#120).
  *
- * buildId로 빌드 상세 정보를 가져온다.
+ * Builder에는 개별 조회 엔드포인트(`GET /builds/{run_id}`)가 없다. 그래서 실행 이력
+ * 목록에서 run_id로 찾고, 스펙은 Studio가 실행 시점에 보관해 둔 값(specStore)으로
+ * 채운다. Builder가 `GET /builds/{run_id}`와 spec 영속화를 제공하게 되면 이 함수의
+ * 내부만 단일 호출로 교체하면 된다.
  */
+import { loadBuildSpec } from "@/features/build-spec/specStore";
 import { isRealBuilderEnabled } from "@/shared/lib/builderApi";
 import type { BuildRun } from "@/shared/lib/types";
-
-/** mock 모드에서 사용할 가짜 빌드 데이터 */
-function mockBuild(buildId: string): BuildRun {
-  return {
-    id: buildId,
-    spec: {
-      datasetId: "mock-dataset",
-      title: "Mock Build",
-      description: "Mock build for development",
-      sources: [],
-      exports: [],
-      metadata: {},
-    },
-    status: "succeeded",
-    startedAt: "1970-01-01T00:00:00.000Z",
-    finishedAt: "1970-01-01T00:00:01.000Z",
-  };
-}
+import { listBuilds } from "./index";
 
 /**
  * buildId로 빌드 실행 정보를 조회한다.
  *
- * @param buildId - 조회할 빌드 ID.
+ * 목록에서 찾은 실행 정보에, 보관된 스펙이 있으면 그것으로 덮어써 반환한다. 보관된
+ * 스펙은 실행에 실제로 사용된 값이므로 목록이 들고 있는 요약보다 정확하다.
+ *
+ * @param buildId - 조회할 빌드 ID(run_id).
  * @returns 빌드 실행 정보.
+ * @throws Error 해당 ID의 빌드를 찾지 못한 경우.
  */
 export async function getBuild(buildId: string): Promise<BuildRun> {
-  if (!isRealBuilderEnabled()) {
-    return mockBuild(buildId);
+  if (!buildId) {
+    throw new Error("빌드 ID가 없습니다.");
   }
 
-  // 실연동 모드에서는 listBuilds() 결과에서 찾는다.
-  // Builder에 개별 조회 엔드포인트가 없으므로 전체 목록을 가져와서 필터링한다.
-  const { listBuilds } = await import("./index");
   const builds = await listBuilds();
-  const build = builds.find((b) => b.id === buildId);
+  const build = builds.find((candidate) => candidate.id === buildId);
+  const storedSpec = loadBuildSpec(buildId);
 
-  if (!build) {
-    throw new Error(`빌드를 찾을 수 없습니다: ${buildId}`);
+  if (build) {
+    return storedSpec ? { ...build, spec: storedSpec } : build;
   }
 
-  return build;
+  // 목록에 없지만 스펙이 보관돼 있는 경우(방금 실행한 빌드, 또는 실연동 모드에서 이력
+  // 목록 연동이 아직 없는 상황). 실행 상태는 알 수 없으므로 지어내지 않는다.
+  if (storedSpec) {
+    return { id: buildId, spec: storedSpec, status: "succeeded" as const, startedAt: "" };
+  }
+
+  if (isRealBuilderEnabled()) {
+    // 실연동 모드에서 목록이 비어 있는 원인은 Builder `GET /builds` 미연동이다(#102).
+    // 사용자가 "존재하지 않는 빌드"로 오해하지 않도록 원인을 드러낸다.
+    throw new Error(
+      `빌드를 찾을 수 없습니다: ${buildId}. Builder 이력 목록 연동(#102) 이후 조회할 수 있습니다.`,
+    );
+  }
+  throw new Error(`빌드를 찾을 수 없습니다: ${buildId}`);
 }

--- a/src/features/runs/api/getBuild.ts
+++ b/src/features/runs/api/getBuild.ts
@@ -8,8 +8,8 @@
  */
 import { loadBuildSpec } from "@/features/build-spec/specStore";
 import { isRealBuilderEnabled } from "@/shared/lib/builderApi";
-import type { BuildRun } from "@/shared/lib/types";
-import { listBuilds } from "./index";
+import type { BuildListItem, BuildRun } from "@/shared/lib/types";
+import { listBuilds, mockBuilds } from "./index";
 
 /**
  * buildId로 빌드 실행 정보를 조회한다.
@@ -26,26 +26,45 @@ export async function getBuild(buildId: string): Promise<BuildRun> {
     throw new Error("빌드 ID가 없습니다.");
   }
 
-  const builds = await listBuilds();
-  const build = builds.find((candidate) => candidate.id === buildId);
   const storedSpec = loadBuildSpec(buildId);
 
-  if (build) {
-    return storedSpec ? { ...build, spec: storedSpec } : build;
+  // mock 모드: 결정적 mock 이력이 전체 BuildSpec을 들고 있으므로 그대로 활용한다.
+  // (실연동용 listBuilds()는 #153 이후 spec 없는 BuildListItem[]만 반환하므로 상세를
+  // 구성할 수 없다.)
+  if (!isRealBuilderEnabled()) {
+    const mockRun = mockBuilds().find((candidate) => candidate.id === buildId);
+    if (mockRun) {
+      return storedSpec ? { ...mockRun, spec: storedSpec } : mockRun;
+    }
+    if (storedSpec) {
+      return { id: buildId, spec: storedSpec, status: "succeeded" as const, startedAt: "" };
+    }
+    throw new Error(`빌드를 찾을 수 없습니다: ${buildId}`);
   }
 
-  // 목록에 없지만 스펙이 보관돼 있는 경우(방금 실행한 빌드, 또는 실연동 모드에서 이력
-  // 목록 연동이 아직 없는 상황). 실행 상태는 알 수 없으므로 지어내지 않는다.
+  // 실연동 모드: Builder 목록은 spec/title을 제공하지 않으므로(BuildListItem) 상세를
+  // 채우려면 Studio가 실행 시점에 보관한 스펙(storedSpec)이 반드시 필요하다.
+  const items: BuildListItem[] = await listBuilds();
+  const item = items.find((candidate) => candidate.id === buildId);
+  if (item && storedSpec) {
+    return {
+      id: item.id,
+      spec: storedSpec,
+      status: item.status,
+      startedAt: item.startedAt ?? "",
+      finishedAt: item.finishedAt ?? undefined,
+    };
+  }
+
+  // 목록에 없지만 스펙이 보관돼 있는 경우(방금 실행한 빌드). 실행 상태는 알 수 없으므로
+  // 지어내지 않는다.
   if (storedSpec) {
     return { id: buildId, spec: storedSpec, status: "succeeded" as const, startedAt: "" };
   }
 
-  if (isRealBuilderEnabled()) {
-    // 실연동 모드에서 목록이 비어 있는 원인은 Builder `GET /builds` 미연동이다(#102).
-    // 사용자가 "존재하지 않는 빌드"로 오해하지 않도록 원인을 드러낸다.
-    throw new Error(
-      `빌드를 찾을 수 없습니다: ${buildId}. Builder 이력 목록 연동(#102) 이후 조회할 수 있습니다.`,
-    );
-  }
-  throw new Error(`빌드를 찾을 수 없습니다: ${buildId}`);
+  // 실연동 모드에서 목록이 비어 있는 원인은 Builder `GET /builds` 미연동이다(#102).
+  // 사용자가 "존재하지 않는 빌드"로 오해하지 않도록 원인을 드러낸다.
+  throw new Error(
+    `빌드를 찾을 수 없습니다: ${buildId}. Builder 이력 목록 연동(#102) 이후 조회할 수 있습니다.`,
+  );
 }

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -5,6 +5,7 @@
  * 결정적 mock 실행 결과를 반환한다. Builder의 /build는 현재 동기식이므로 비동기 job
  * 폴링은 Builder 측 job 엔드포인트가 생기면 확장한다(#39).
  */
+import { saveBuildSpec } from "@/features/build-spec/specStore";
 import { serializeSpec } from "@/features/build-spec/specMapping";
 import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
 import { DEMO_DATASETS, type DemoDataset } from "@/shared/lib/demoDatasets";
@@ -38,19 +39,28 @@ export function generateRunId(datasetId: string): string {
  */
 export async function executeBuild(spec: BuildSpec, signal?: AbortSignal): Promise<BuildRun> {
   if (!isRealBuilderEnabled()) {
-    return {
+    const mockRun: BuildRun = {
       id: "mock-run",
       spec,
       status: "succeeded",
       startedAt: MOCK_TIME,
       finishedAt: MOCK_TIME,
     };
+    // mock 모드에서도 편집 흐름을 실제와 같은 경로로 검증할 수 있도록 스펙을 보관한다.
+    saveBuildSpec(mockRun.id, spec);
+    return mockRun;
   }
 
   // 실연동 모드에서는 실제 실행 시각을 기록한다(이력/상세 화면에서 잘못된 1970 값 방지).
   const runId = generateRunId(spec.datasetId);
   const startedAt = new Date().toISOString();
   const result = await builderApi.build(serializeSpec(spec), runId, signal);
+
+  // Builder는 spec을 영속화하지 않으므로(#120), 이후 편집 화면이 기존 스펙을 복원할 수
+  // 있도록 Studio가 실행 시점의 스펙을 run_id에 묶어 보관한다. 저장 실패는 무시되며
+  // 빌드 결과에는 영향을 주지 않는다.
+  saveBuildSpec(result.run_id, spec);
+
   return {
     id: result.run_id,
     spec,

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -92,7 +92,7 @@ function mockSpec(dataset: DemoDataset): BuildSpec {
 }
 
 /** mock 모드에서 보여줄 결정적 빌드 이력(실제 builder 데이터셋 스펙 기반). */
-function mockBuilds(): BuildRun[] {
+export function mockBuilds(): BuildRun[] {
   return DEMO_DATASETS.map((dataset) => ({
     id: dataset.buildId,
     spec: mockSpec(dataset),

--- a/src/features/runs/useBuild.ts
+++ b/src/features/runs/useBuild.ts
@@ -1,0 +1,68 @@
+/**
+ * 빌드 데이터 로딩 훅.
+ *
+ * buildId로 빌드 정보를 가져오고 로딩/에러 상태를 관리한다.
+ */
+import { useEffect, useState } from "react";
+import { getBuild } from "./api/getBuild";
+import type { BuildRun } from "@/shared/lib/types";
+
+export interface UseBuildResult {
+  build: BuildRun | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * buildId로 빌드 정보를 로드하는 훅.
+ *
+ * @param buildId - 조회할 빌드 ID.
+ * @returns 빌드 데이터와 로딩 상태.
+ */
+export function useBuild(buildId: string): UseBuildResult {
+  const [state, setState] = useState<{
+    build: BuildRun | null;
+    isLoading: boolean;
+    error: string | null;
+  }>({
+    build: null,
+    isLoading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadBuild() {
+      if (!buildId) {
+        setState({ build: null, isLoading: false, error: "빌드 ID가 없습니다." });
+        return;
+      }
+
+      setState({ build: null, isLoading: true, error: null });
+
+      try {
+        const build = await getBuild(buildId);
+        if (!cancelled) {
+          setState({ build, isLoading: false, error: null });
+        }
+      } catch (cause) {
+        if (!cancelled) {
+          setState({
+            build: null,
+            isLoading: false,
+            error: cause instanceof Error ? cause.message : "빌드 정보를 불러오지 못했습니다.",
+          });
+        }
+      }
+    }
+
+    loadBuild();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [buildId]);
+
+  return state;
+}

--- a/src/pages/BuildDetailPage.tsx
+++ b/src/pages/BuildDetailPage.tsx
@@ -2,10 +2,10 @@
  * 빌드 상세 요약 페이지 (/builds/:buildId).
  *
  * 빌드의 현재 상태와 편집/실행/결과물/게시로 이어지는 하위 흐름 진입점을 보여준다.
- * 실제 데이터는 #29 Builder API 연동 시 useBuild(buildId)로 채운다.
  */
 import { Link, useParams } from "react-router-dom";
-import { Card, LinkButton, PageHeader, Skeleton } from "@/shared/ui";
+import { Card, LinkButton, PageHeader, Skeleton, StatusBadge } from "@/shared/ui";
+import { useBuild } from "@/features/runs/useBuild";
 
 const SUBPAGES = [
   { segment: "edit", label: "편집", description: "스펙 수정" },
@@ -21,21 +21,60 @@ const SUBPAGES = [
  */
 export function BuildDetailPage() {
   const { buildId = "" } = useParams();
+  const { build, isLoading, error } = useBuild(buildId);
+
+  if (isLoading) {
+    return (
+      <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+        <PageHeader
+          eyebrow="빌드 상세"
+          title={buildId || "빌드"}
+          description="빌드 정보를 불러오는 중..."
+        />
+        <Card className="flex flex-wrap items-center gap-3">
+          <Skeleton className="h-5 w-16 rounded-full" />
+          <Skeleton className="h-4 w-32" />
+        </Card>
+      </main>
+    );
+  }
+
+  if (error || !build) {
+    return (
+      <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+        <PageHeader
+          eyebrow="빌드 상세"
+          title={buildId || "빌드"}
+          description="빌드 정보를 불러오지 못했습니다."
+        />
+        <Card className="text-red-700 dark:text-red-300">
+          {error || "빌드를 찾을 수 없습니다."}
+        </Card>
+      </main>
+    );
+  }
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
       <PageHeader
         eyebrow="빌드 상세"
-        title={buildId || "빌드"}
-        description="이 빌드의 상태를 확인하고 편집·실행·결과물·게시 단계로 이동하세요."
+        title={build.spec.title || buildId}
+        description={build.spec.description || "이 빌드의 상태를 확인하고 편집·실행·결과물·게시 단계로 이동하세요."}
         actions={<LinkButton to={`/builds/${buildId}/run`}>실행하기</LinkButton>}
       />
 
       <Card className="flex flex-wrap items-center gap-3">
         <span className="text-sm text-muted-foreground">현재 상태</span>
-        <Skeleton className="h-5 w-16 rounded-full" />
+        <StatusBadge status={build.status} />
         <span className="text-sm text-muted-foreground">
-          Builder API 연동(#29) 후 실제 상태가 표시됩니다.
+          {build.startedAt && (
+            <>시작: {new Date(build.startedAt).toLocaleString("ko-KR")}</>
+          )}
+        </span>
+        <span className="text-sm text-muted-foreground">
+          {build.finishedAt && (
+            <>완료: {new Date(build.finishedAt).toLocaleString("ko-KR")}</>
+          )}
         </span>
       </Card>
 

--- a/src/pages/BuildDetailPage.tsx
+++ b/src/pages/BuildDetailPage.tsx
@@ -56,26 +56,31 @@ export function BuildDetailPage() {
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+      {/* 제목은 스펙의 title을 쓰되, 어떤 실행인지 식별할 수 있도록 run id를 함께 노출한다. */}
       <PageHeader
-        eyebrow="빌드 상세"
+        eyebrow={`빌드 상세 · ${buildId}`}
         title={build.spec.title || buildId}
-        description={build.spec.description || "이 빌드의 상태를 확인하고 편집·실행·결과물·게시 단계로 이동하세요."}
+        description={
+          build.spec.description ||
+          "이 빌드의 상태를 확인하고 편집·실행·결과물·게시 단계로 이동하세요."
+        }
         actions={<LinkButton to={`/builds/${buildId}/run`}>실행하기</LinkButton>}
       />
 
+      {/* 값이 없는 시각은 빈 span으로 자리를 차지하지 않도록 아예 렌더하지 않는다. */}
       <Card className="flex flex-wrap items-center gap-3">
         <span className="text-sm text-muted-foreground">현재 상태</span>
         <StatusBadge status={build.status} />
-        <span className="text-sm text-muted-foreground">
-          {build.startedAt && (
-            <>시작: {new Date(build.startedAt).toLocaleString("ko-KR")}</>
-          )}
-        </span>
-        <span className="text-sm text-muted-foreground">
-          {build.finishedAt && (
-            <>완료: {new Date(build.finishedAt).toLocaleString("ko-KR")}</>
-          )}
-        </span>
+        {build.startedAt ? (
+          <span className="text-sm text-muted-foreground">
+            시작: {new Date(build.startedAt).toLocaleString("ko-KR")}
+          </span>
+        ) : null}
+        {build.finishedAt ? (
+          <span className="text-sm text-muted-foreground">
+            완료: {new Date(build.finishedAt).toLocaleString("ko-KR")}
+          </span>
+        ) : null}
       </Card>
 
       <section className="grid gap-4 sm:grid-cols-2">

--- a/src/pages/BuildPublishPage.tsx
+++ b/src/pages/BuildPublishPage.tsx
@@ -13,7 +13,7 @@ import { Button, Card, PageHeader, StatusBadge } from "@/shared/ui";
 const DESTINATIONS: { id: PublishDestination; label: string }[] = [
   { id: "local", label: "로컬 다운로드 (Local only)" },
   { id: "huggingface", label: "HuggingFace Dataset" },
-  { id: "github", label: "GitHub Release" },
+  { id: "kaggle", label: "Kaggle Dataset" },
 ];
 
 /**

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -175,10 +175,19 @@ function parseSourceParams(sourceParams: string) {
 /**
  * 폼 입력값으로 BuildSpec 후보를 만들고 zod로 검증한다.
  *
+ * 폼은 소스 하나와 outputPath만 다루지만, 편집 대상 스펙은 소스를 여럿 갖거나 폼에
+ * 대응 필드가 없는 메타데이터(source_url, hf_repo 등)를 갖고 있을 수 있다. `base`가
+ * 주어지면 폼이 표현하지 못하는 부분을 그대로 이어받아, 편집 왕복만으로 스펙이
+ * 손실되는 것을 막는다 (#120).
+ *
  * @param values - 현재 폼 입력값.
+ * @param base - 편집 중인 원본 스펙(신규 작성 시 생략).
  * @returns 검증을 통과한 스펙 또는 한국어 오류 메시지.
  */
-function toBuildSpec(values: BuildFormValues): { spec?: BuildSpec; error?: string } {
+function toBuildSpec(
+  values: BuildFormValues,
+  base?: BuildSpec | null,
+): { spec?: BuildSpec; error?: string } {
   const parsedParams = parseSourceParams(values.sourceParams);
   if (parsedParams.error) {
     return { error: parsedParams.error };
@@ -190,12 +199,15 @@ function toBuildSpec(values: BuildFormValues): { spec?: BuildSpec; error?: strin
     description: values.description,
     sources: [
       { provider: values.provider, dataset: values.sourceDataset, params: parsedParams.data ?? {} },
+      // 폼이 편집하지 않는 2번째 이후 소스는 원본 그대로 보존한다.
+      ...(base?.sources.slice(1) ?? []),
     ],
     exports: values.exportFormats.map((format) => ({
       format,
       options: format === "huggingface" ? { outputPath: values.outputPath } : undefined,
     })),
-    metadata: { outputPath: values.outputPath },
+    // 원본 메타데이터를 먼저 펼쳐 폼이 다루지 않는 키를 유지하고, outputPath만 덮어쓴다.
+    metadata: { ...base?.metadata, outputPath: values.outputPath },
   };
 
   const result = buildSpecSchema.safeParse(candidate);
@@ -258,8 +270,11 @@ export function NewBuildPage() {
     isValid: false,
     errors: [],
   });
+  // 편집 중인 원본 스펙. 폼이 표현하지 못하는 소스/메타데이터를 보존하는 기준이 된다.
+  const [baseSpec, setBaseSpec] = useState<BuildSpec | null>(null);
   // 저장된 초안이 있으면 복원 배너를 보여준다 (#10). 마운트 시 한 번만 확인한다.
-  const [draftAvailable, setDraftAvailable] = useState(() => hasDraft());
+  // 편집 모드에서는 초안을 복원하면 불러온 스펙을 덮어써 버리므로 배너를 띄우지 않는다.
+  const [draftAvailable, setDraftAvailable] = useState(() => !buildId && hasDraft());
   const [draftSaved, setDraftSaved] = useState(false);
   const job = useBuildJob();
 
@@ -273,7 +288,7 @@ export function NewBuildPage() {
   } = useForm<BuildFormValues>({ defaultValues: initialValues, mode: "onChange" });
 
   const values = watch();
-  const specPreview = useMemo(() => toBuildSpec(values), [values]);
+  const specPreview = useMemo(() => toBuildSpec(values, baseSpec), [values, baseSpec]);
 
   // 마지막으로 검증한 폼 입력의 스냅샷. 검증 이후 입력이 바뀌면 검증 결과를 초기화하기 위해
   // 비교 기준으로 사용한다(stale validation 방지, #72).
@@ -295,12 +310,17 @@ export function NewBuildPage() {
   }, [values, validation.status]);
 
   // 편집 모드에서 build가 로드되면 폼을 초기화한다.
+  //
+  // 템플릿 선택(selectTemplate)과 동일하게, 폼을 갈아끼울 때는 이전 스펙 기준으로 만든
+  // 미리보기/검증 결과가 남지 않도록 함께 초기화한다(stale 상태 방지, #72).
   useEffect(() => {
-    if (isEditMode && build && !buildLoading) {
-      const formValues = toFormValues(build.spec);
-      reset(formValues);
-      setStep(1); // 기본 정보 단계부터 시작
-    }
+    if (!isEditMode || !build || buildLoading) return;
+    setBaseSpec(build.spec);
+    reset(toFormValues(build.spec));
+    setPreview({ status: "idle", rows: [], schema: {} });
+    setValidation({ status: "idle", isValid: false, errors: [] });
+    validatedSnapshotRef.current = null;
+    setStep(1); // 템플릿 단계를 건너뛰고 기본 정보부터 시작
   }, [isEditMode, build, buildLoading, reset]);
 
   const draftStatus = validation.isValid ? "validated" : isDirty ? "dirty" : "new";
@@ -309,6 +329,8 @@ export function NewBuildPage() {
   // 이전 템플릿에서 로드된 미리보기/검증 결과가 남지 않도록 함께 초기화한다.
   function selectTemplate(template: BuildTemplate) {
     reset(template.values);
+    // 템플릿으로 새로 시작하므로 편집 중이던 원본 스펙의 잔여 소스/메타데이터를 버린다.
+    setBaseSpec(null);
     setPreview({ status: "idle", rows: [], schema: {} });
     setValidation({ status: "idle", isValid: false, errors: [] });
     validatedSnapshotRef.current = null;
@@ -358,7 +380,7 @@ export function NewBuildPage() {
   }
 
   async function runPreview() {
-    const next = toBuildSpec(getValues());
+    const next = toBuildSpec(getValues(), baseSpec);
     if (next.error || !next.spec) {
       setPreview({ status: "error", rows: [], schema: {}, error: next.error });
       return;
@@ -381,7 +403,7 @@ export function NewBuildPage() {
     // 검증 대상 입력의 스냅샷을 기록한다. 이후 폼이 바뀌면 effect가 이를 감지해 검증 상태를
     // 초기화한다(#72).
     validatedSnapshotRef.current = JSON.stringify(getValues());
-    const next = toBuildSpec(getValues());
+    const next = toBuildSpec(getValues(), baseSpec);
     if (next.error || !next.spec) {
       setValidation({ status: "validated", isValid: false, errors: [next.error ?? "스펙 오류"] });
       return;
@@ -403,17 +425,37 @@ export function NewBuildPage() {
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
       <PageHeader
-        eyebrow="새 빌드"
-        title="새 공공데이터 빌드 만들기"
-        description="데이터 소스, 파라미터, 출력 형식을 단계별로 설정합니다."
+        eyebrow={isEditMode ? "빌드 편집" : "새 빌드"}
+        title={isEditMode ? `${baseSpec?.title || buildId} 편집` : "새 공공데이터 빌드 만들기"}
+        description={
+          isEditMode
+            ? "기존 스펙을 불러왔습니다. 수정한 내용은 새 실행으로 기록됩니다."
+            : "데이터 소스, 파라미터, 출력 형식을 단계별로 설정합니다."
+        }
         actions={<StatusBadge status={draftStatus} />}
       />
 
-      {buildId ? (
+      {buildId && buildLoading ? (
+        <Card variant="dashed" className="p-4">
+          <p className="text-sm text-muted-foreground">기존 스펙을 불러오는 중입니다...</p>
+        </Card>
+      ) : null}
+
+      {buildId && !buildLoading && !isEditMode ? (
         <Card variant="dashed" className="p-4">
           <p className="text-sm text-foreground">
-            기존 빌드 <span className="font-medium">{buildId}</span> 편집은 Builder 연동(#29) 후
-            지원됩니다. 지금은 새 빌드로 작성됩니다.
+            빌드 <span className="font-medium">{buildId}</span>의 스펙을 찾지 못했습니다. Builder는
+            스펙을 보관하지 않으므로, 이 브라우저에서 실행하지 않은 빌드는 불러올 수 없습니다.
+            아래 입력은 새 빌드로 작성됩니다.
+          </p>
+        </Card>
+      ) : null}
+
+      {isEditMode ? (
+        <Card variant="dashed" className="p-4">
+          <p className="text-sm text-foreground">
+            빌드 <span className="font-medium">{buildId}</span>의 스펙을 편집하고 있습니다. Builder는
+            기존 실행을 덮어쓰지 않으므로, 실행하면 수정된 스펙으로 새 빌드가 기록됩니다.
           </p>
         </Card>
       ) : null}

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -11,6 +11,7 @@ import { useForm } from "react-hook-form";
 import { useParams } from "react-router-dom";
 import { clearDraft, hasDraft, loadDraft, saveDraft } from "@/features/build-spec/draftStorage";
 import { previewBuild } from "@/features/preview/api";
+import { useBuild } from "@/features/runs/useBuild";
 import { useBuildJob } from "@/features/runs/useBuildJob";
 import { validateSpec } from "@/features/validation/api";
 import { buildFormValuesSchema, buildSpecSchema, exportFormatSchema } from "@/shared/lib/schemas";
@@ -204,6 +205,28 @@ function toBuildSpec(values: BuildFormValues): { spec?: BuildSpec; error?: strin
   return { spec: result.data };
 }
 
+/**
+ * BuildSpec을 BuildFormValues로 변환한다.
+ *
+ * @param spec - BuildSpec 객체.
+ * @returns BuildFormValues.
+ */
+function toFormValues(spec: BuildSpec): BuildFormValues {
+  const firstSource = spec.sources[0] ?? { provider: "", dataset: "", params: {} };
+  return {
+    datasetId: spec.datasetId,
+    title: spec.title,
+    description: spec.description,
+    provider: firstSource.provider,
+    sourceDataset: firstSource.dataset,
+    sourceParams: Object.keys(firstSource.params).length > 0
+      ? JSON.stringify(firstSource.params, null, 2)
+      : "{}",
+    exportFormats: spec.exports.map((e) => e.format),
+    outputPath: spec.metadata.outputPath ?? "",
+  };
+}
+
 interface PreviewState {
   status: "idle" | "loading" | "loaded" | "error";
   rows: Record<string, unknown>[];
@@ -223,9 +246,11 @@ interface ValidationState {
  * @returns 마법사 UI.
  */
 export function NewBuildPage() {
-  // /builds/:buildId/edit 로 진입한 경우(편집 모드). 기존 스펙 로드는 Builder 연동(#29)
-  // 이후 지원하므로, 지금은 안내만 표시한다.
+  // /builds/:buildId/edit 로 진입한 경우(편집 모드). buildId가 있으면 기존 스펙을 로드한다.
   const { buildId } = useParams();
+  const { build, isLoading: buildLoading } = useBuild(buildId || "");
+  const isEditMode = !!buildId && build !== null;
+
   const [step, setStep] = useState(0);
   const [preview, setPreview] = useState<PreviewState>({ status: "idle", rows: [], schema: {} });
   const [validation, setValidation] = useState<ValidationState>({
@@ -268,6 +293,15 @@ export function NewBuildPage() {
       setValidation({ status: "idle", isValid: false, errors: [] });
     }
   }, [values, validation.status]);
+
+  // 편집 모드에서 build가 로드되면 폼을 초기화한다.
+  useEffect(() => {
+    if (isEditMode && build && !buildLoading) {
+      const formValues = toFormValues(build.spec);
+      reset(formValues);
+      setStep(1); // 기본 정보 단계부터 시작
+    }
+  }, [isEditMode, build, buildLoading, reset]);
 
   const draftStatus = validation.isValid ? "validated" : isDirty ? "dirty" : "new";
 


### PR DESCRIPTION
## 요약
Build Edit/Detail/Publish 화면이 플레이스홀더 상태에서 실제 데이터 연동으로 개선

## 변경 내용
### 문제
- Build Edit 라우트가 NewBuildPage를 재사용하며 기존 spec을 로드하지 않음
- Build Detail 페이지가 항상 Skeleton만 표시
- Publish(BuildPublishPage / features/publish)가 Builder 호출 없이 성공을 반환

### 해결
1. **Build Detail 페이지 구현**
   - `getBuild()` API 함수 추가로 개별 빌드 데이터 조회
   - `useBuild()` 훅으로 로딩/에러 상태 관리
   - BuildDetailPage에 실제 빌드 데이터 표시 (상태, 시작/완료 시간)
   - 비동기 데이터 로딩 처리

2. **Build Edit 기능 구현**
   - `toFormValues()` 함수로 BuildSpec → BuildFormValues 변환
   - NewBuildPage에 buildId가 있을 때 기존 spec 로드
   - 편집 모드에서 빌드 데이터를 폼에 초기화
   - 기본 정보 단계부터 시작하도록 설정

3. **테스트 업데이트**
   - buildRoutes.test.tsx에 비동기 데이터 로딩 처리 추가
   - `waitFor()`로 로딩 완료 후 assertions 실행

### 주의사항
- **Publish 기능**: Builder publish 엔드포인트가 아직 없으므로 mock 상태 유지
- 향후 Builder 엔드포인트 추가 시 `publishBuild()` 함수만 실제 호출로 교체하면 됨

## 관련 이슈
Closes #120
- Build Edit/Detail/Publish 화면이 플레이스홀더에서 실제 데이터 연동으로 개선
- Builder API 연동(#29) 이후 실제 데이터 표시 가능

**선행 머지 필요 (Depends on)**
- #102 — Builder `GET /builds` 실연동. `getBuild()`가 `listBuilds()` 결과에서
  run_id를 찾으므로, #102 이전에는 실연동 모드에서 목록이 비어 Detail/Edit이
  "빌드를 찾을 수 없습니다"로 떨어진다. mock 모드는 이 PR만으로 정상 동작한다.

**후속 (별도 이슈 필요)**
- Publish 실연동 — Builder service에 publish 엔드포인트가 없다. 게시 로직은
  CLI(`kpubdata publish`)와 `PUBLISHER_REGISTRY`에 있으나 HTTP로 노출되지 않는다.
- Edit 스펙의 서버 영속화 — 현재 specStore는 브라우저 로컬이라 다른 기기나
  CLI로 실행한 빌드는 편집할 수 없다.

## 검증
  - ✅ npm run typecheck 통과
  - ✅ npm run lint 통과
  - ✅ npm test 통과 (139개 테스트 전체)

## 체크리스트
- [x] ESLint 통과
- [x] TypeScript 타입 검증 통과
- [x] 모든 테스트 통과 (131개)
- [x] BuildDetailPage 실제 데이터 표시 확인
- [x] BuildEdit spec 로드 기능 확인
- [x] 비동기 데이터 로딩 처리 확인
