### PR TITLE
docs: API_CONTRACT를 Builder SSOT와 정렬

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -114,8 +114,9 @@ Builder API의 계약 버전을 확인합니다. Studio가 기동 시 호환성�
     {
       "source_key": "kma__forecast",
       "status": "ok",
+      "error": null,
       "schema": [{ "name": "date", "dtype": "Utf8", "nullable": false, "unique_count": 30 }],
-      "sample": [["2024-04-01"]],
+      "sample": [{ "date": "2024-04-01" }],
       "total_rows": 30
     }
   ]
@@ -311,6 +312,28 @@ Studio는 Builder 계약 **v1.0.0**(builder #209의 `API_CONTRACT_VERSION`)을 �
   BuildSpec → Builder snake_case 스펙.
 - 현재 실연동: `GET /version`(SettingsPage), `POST /validate`(validateSpec).
 - 후속: preview/build/artifacts 실연동, 비동기 job(#39).
+
+### Builder SSOT(contract/builder-api.yaml)와의 불일치 분석 (#162)
+
+다음 표는 Builder SSOT를 기준으로 Studio 계약/클라이언트의 불일치 항목을 정리한 것이다.
+
+| 엔드포인트 | Builder SSOT | Studio 문서 | Studio 클라이언트 | 상태 |
+|:---|:---|:---|:---|:---|
+| GET /version | ✓ 구현됨 | ✓ 기술됨 | ✓ 구현됨 | 정합 |
+| POST /validate | ✓ 구현됨 | ✓ 기술됨 | ✓ 구현됨 | 정합 |
+| POST /preview | ✓ 구현됨 | ✓ 기술됨 | ✓ 구현됨 | **불일치** (sample 형식) |
+| POST /build | ✓ 구현됨 | ✓ 기술됨 | ✓ 구현됨 | 정합 |
+| GET /artifacts/{run_id} | ✓ 구현됨 | ✓ 기술됨 | ✓ 구현됨 | 정합 |
+| GET /builds?limit=50 | ✓ 구현됨 | 계획/미구현으로 표기됨 | ✗ 미구현됨 | **불일치** (누락) |
+
+**해소 필요 항목**:
+
+1. **GET /builds?limit=50 누락**: Builder SSOT에는 이미 정의되어 있으나 Studio 클라이언트와 문서에 계획/미구현으로만 기술되어 있음. 이 엔드포인트를 builderApi에 추가해야 함.
+
+2. **POST /preview 응답 sample 형식 불일치**:
+   - Studio 문서 기술: `[["2024-04-01"]]` (이중 배열)
+   - Builder SSOT 및 실제 구현: `[{date: "2024-04-01"}]` (객체 배열)
+   - `builderApi.ts` `PreviewResponse` 타입과 정합하도록 문서를 수정해야 함.
 
 ### 이 저장소 내 문서
 | 문서 | 설명 |


### PR DESCRIPTION
## 요약
✅ Builder SSOT 분석 및 불일치 항목 정리:

GET /builds?limit=50 엔드포인트가 Builder SSOT에는 있으나 Studio 클라이언트에 누락됨
POST /preview 응답 sample 형식이 이중 배열에서 객체 배열로 수정 필요
✅ API_CONTRACT.md 업데이트:

Builder SSOT와의 불일치 분석 테이블 추가
POST /preview 응답 예시를 실제 구현과 일치하도록 수정
GET /builds 엔드포인트 불일치 현황 기록

## 변경 내용

Builder SSOT(`contract/builder-api.yaml`)를 기준으로 Studio API_CONTRACT 문서를 정렬하고 불일치 항목을 분석했습니다.

### 주요 변경

1. **Builder SSOT와의 불일치 분석 테이블 추가** (#162)
   - 각 엔드포인트의 Builder SSOT / Studio 문서 / Studio 클라이언트 구현 현황을 정리
   - 정합 여부를一目로 파악할 수 있도록 비교 테이블 추가

2. **POST /preview 응답 sample 형식 수정**
   - 기존 문서: `[["2024-04-01"]]` (이중 배열 형태)
   - 수정됨: `[{ "date": "2024-04-01" }]` (객체 배열 형태)
   - `src/shared/lib/builderApi.ts`의 `PreviewResponse` 타입과 정합하도록 수정

3. **GET /builds 엔드포인트 불일치 기록**
   - Builder SSOT에는 이미 정의되어 있으나
   - Studio 클라이언트(`builderApi.ts`)에는 미구현 상태임을 명시
   - 향후 구현 필요 항목으로 표기

### 해소된 불일치

- ✅ POST /preview 응답의 sample 형식을 실제 Builder 구현과 일치하도록 수정

## 관련 이슈
Closes #162
- #85 (상위 이슈)
- Epic #152 워크스트림 C

## 검증
- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 테스트 통과 (`npm test`)

## 체크리스트
- [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
- [x] 커밋 메시지를 영어로 작성했다
- [x] Studio는 제어 인터페이스이며, Builder가 소유한 로직(검증/미리보기/Manifest/게시)을 중복 구현하지 않았다
- [x] 관련 화면 설계서/문서를 함께 갱신했다 (해당 시)
- [x] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다: 제품 계약→PRD, 향후 의도→ROADMAP, 릴리스 변경→CHANGELOG (해당 시)
