### PR TITLE
feat: 오류 응답 Zod 검증 및 사용자 친화적 에러 메시지 구현

### DIFF
--- a/__tests__/builderApi.test.ts
+++ b/__tests__/builderApi.test.ts
@@ -35,7 +35,11 @@ describe("builderApi client (#29)", () => {
 
   it("preview() POSTs spec to /preview (#75)", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      mockResponse(200, { status: "ok", preview: [], api_version: "1.0.0" }),
+      mockResponse(200, {
+        dataset_id: "test_dataset",
+        previews: [],
+        api_version: "1.0.0",
+      }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -126,5 +130,134 @@ describe("extractErrorMessage (#75)", () => {
     expect(extractErrorMessage({ status: "failed", outcomes: [] })).toBeUndefined();
     expect(extractErrorMessage(undefined)).toBeUndefined();
     expect(extractErrorMessage("oops")).toBeUndefined();
+  });
+});
+
+describe("Zod 스키마 런타임 검증 (#158, #103)", () => {
+  it("version() 스키마 검증 - 올바른 응답 통과", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { service: "kpubdata-builder", api_version: "1.0.0" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await builderApi.version();
+
+    expect(result.service).toBe("kpubdata-builder");
+    expect(result.api_version).toBe("1.0.0");
+  });
+
+  it("version() 스키마 검증 - 필드 누락 시 실패", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { service: "kpubdata-builder" }), // api_version 누락
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(builderApi.version()).rejects.toThrow("응답 스키마 검증 실패");
+  });
+
+  it("validate() 스키마 검증 - valid 응답 통과", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, {
+        status: "valid",
+        dataset_id: "test_dataset",
+        api_version: "1.0.0",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await builderApi.validate("dataset_id: x");
+
+    expect(result.status).toBe("valid");
+    if (result.status === "valid") {
+      expect(result.dataset_id).toBe("test_dataset");
+    }
+  });
+
+  it("validate() 스키마 검증 - invalid 응답 통과", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(400, {
+        status: "invalid",
+        problems: ["필수 파라미터 누락"],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      await builderApi.validate("invalid");
+      expect.fail("ApiError가 발생해야 합니다.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).status).toBe(400);
+    }
+  });
+
+  it("build() 스키마 검증 - ok 응답 통과", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, {
+        status: "ok",
+        run_id: "run_123",
+        outcomes: [
+          {
+            source_key: "kma__forecast",
+            status: "ok",
+            stages_completed: ["bronze", "silver"],
+            error: null,
+          },
+        ],
+        manifest: "output/run_123/manifest.json",
+        api_version: "1.0.0",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await builderApi.build("dataset_id: x");
+
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.run_id).toBe("run_123");
+      expect(result.outcomes).toHaveLength(1);
+    }
+  });
+
+  it("preview() 스키마 검증 - 올바른 응답 통과", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, {
+        dataset_id: "weather_report",
+        previews: [
+          {
+            source_key: "kma__forecast",
+            status: "ok",
+            error: null,
+            schema: [
+              { name: "date", dtype: "Utf8", nullable: false, unique_count: 30 },
+            ],
+            sample: [{ date: "2024-04-01" }],
+            total_rows: 30,
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await builderApi.preview("dataset_id: x");
+
+    expect(result.dataset_id).toBe("weather_report");
+    expect(result.previews).toHaveLength(1);
+    expect(result.previews[0].schema).toBeDefined();
+  });
+
+  it("artifacts() 스키마 검증 - 올바른 응답 통과", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, {
+        run_id: "run_123",
+        files: ["manifest.json", "data.parquet"],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await builderApi.artifacts("run_123");
+
+    expect(result.run_id).toBe("run_123");
+    expect(result.files).toContain("manifest.json");
   });
 });

--- a/__tests__/builderApi.test.ts
+++ b/__tests__/builderApi.test.ts
@@ -4,6 +4,7 @@ import {
   apiFetch,
   builderApi,
   extractErrorMessage,
+  formatApiErrorMessage,
 } from "@/shared/lib/builderApi";
 
 function mockResponse(status: number, body: unknown): Response {
@@ -133,6 +134,49 @@ describe("extractErrorMessage (#75)", () => {
   });
 });
 
+describe("formatApiErrorMessage (#159)", () => {
+  it("400 - 기본 메시지 반환", () => {
+    expect(formatApiErrorMessage(400, undefined)).toBe("요청 형식이 올바르지 않습니다.");
+  });
+
+  it("404 - 기본 메시지 반환", () => {
+    expect(formatApiErrorMessage(404, undefined)).toBe("요청한 리소스를 찾을 수 없습니다.");
+  });
+
+  it("404 - run_id 포함 응답 시 메시지에 run_id 추가", () => {
+    const message = formatApiErrorMessage(404, { run_id: "run_123" });
+    expect(message).toContain("run_123");
+  });
+
+  it("502 - 기본 메시지 반환", () => {
+    expect(formatApiErrorMessage(502, undefined)).toBe("데이터 소스에서 오류가 발생했습니다.");
+  });
+
+  it("extractErrorMessage가 있으면 해당 메시지 우선", () => {
+    const message = formatApiErrorMessage(400, { error: "구체적 에러" });
+    expect(message).toContain("구체적 에러");
+  });
+
+  it("404 - 리소스 없음 응답 스키마 검증", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(404, {
+        error: "run not found: run_999",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      await apiFetch("/artifacts/run_999");
+      expect.fail("ApiError가 발생해야 합니다.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      const apiError = error as ApiError;
+      expect(apiError.status).toBe(404);
+      expect(apiError.message).toContain("run_999");
+    }
+  });
+});
+
 describe("Zod 스키마 런타임 검증 (#158, #103)", () => {
   it("version() 스키마 검증 - 올바른 응답 통과", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
@@ -152,7 +196,7 @@ describe("Zod 스키마 런타임 검증 (#158, #103)", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(builderApi.version()).rejects.toThrow("응답 스키마 검증 실패");
+    await expect(builderApi.version()).rejects.toThrow("Builder API 응답이 예상된 형식과 일치하지 않습니다");
   });
 
   it("validate() 스키마 검증 - valid 응답 통과", async () => {

--- a/src/shared/lib/builderApi.schema.ts
+++ b/src/shared/lib/builderApi.schema.ts
@@ -1,5 +1,5 @@
 /**
- * Builder API 응답 Zod 스키마 (#158, #103)
+ * Builder API 응답 Zod 스키마 (#158, #103, #159)
  *
  * Builder HTTP API 응답의 런타임 타입 검증을 위한 Zod 스키마입니다.
  * Builder SSOT(contract/builder-api.yaml)와 정합하도록 작성되었습니다.
@@ -7,6 +7,7 @@
  * 사용 방법:
  * - apiFetch()에서 응답 파싱 후 zod.parse()로 런타임 검증
  * - TypeScript 타입 안정성 보장 + 런타임 데이터 정합성 검증
+ * - 오류 응답도 스키마로 검증하여 사용자에게 명시적인 피드백 제공 (#159)
  */
 
 import { z } from "zod";
@@ -131,6 +132,65 @@ export const previewResponseSchema = z.object({
   previews: z.array(previewSourceSchema),
 });
 
+/**
+ * ============================================
+ * 오류 응답 스키마 (#159)
+ * ============================================
+ */
+
+/**
+ * 400 - 스펙 로딩 실패 (SpecLoadError)
+ */
+export const specLoadErrorSchema = z.object({
+  status: z.literal("error"),
+  error: z.string(),
+});
+
+/**
+ * 400 - 요청 본문 누락/형식 오류
+ */
+export const badRequestSchema = z.object({
+  error: z.string(),
+});
+
+/**
+ * 404 - 리소스 없음
+ */
+export const notFoundSchema = z.object({
+  error: z.string(),
+});
+
+/**
+ * 502 - 소스 fetch/stage 실패 (일부 성공, 최소 하나 실패)
+ *
+ * 참고: outcomes 배열에는 성공/실패 소스가 섞여 있으며,
+ * 하나라도 실패한 소스가 있으면 전체 상태는 "failed"가 됩니다.
+ */
+export const buildPartialFailureSchema = z.object({
+  status: z.literal("failed"),
+  run_id: z.string(),
+  outcomes: z.array(buildOutcomeSchema),
+  manifest: z.string(),
+  api_version: z.string(),
+});
+
+/**
+ * 통합 오류 응답 스키마
+ *
+ * Builder API의 다양한 오류 응답 형태를 검증합니다.
+ * discriminatedUnion 대신 일반적인 z.union() 사용.
+ */
+export const errorResponseSchema = z.union([
+  // 400 - 스펙 로딩 실패 (이미 validateResponseSchema에 있음)
+  validateErrorSchema,
+  // 400 - 요청 본문 오류
+  badRequestSchema,
+  // 404 - 리소스 없음
+  notFoundSchema,
+  // 502 - 빌드 부분 실패 (이미 buildResponseSchema의 failed에 있음)
+  buildPartialFailureSchema,
+]);
+
 // 타입 추출 (TypeScript 타입과 일치하도록 Zod 스키마에서 추출)
 export type VersionResponse = z.infer<typeof versionResponseSchema>;
 export type ValidateValid = z.infer<typeof validateValidSchema>;
@@ -145,3 +205,9 @@ export type ArtifactsResponse = z.infer<typeof artifactsResponseSchema>;
 export type PreviewColumn = z.infer<typeof previewColumnSchema>;
 export type PreviewSource = z.infer<typeof previewSourceSchema>;
 export type PreviewResponse = z.infer<typeof previewResponseSchema>;
+
+// 오류 응답 타입 (#159)
+export type SpecLoadError = z.infer<typeof specLoadErrorSchema>;
+export type BadRequest = z.infer<typeof badRequestSchema>;
+export type NotFound = z.infer<typeof notFoundSchema>;
+export type BuildPartialFailure = z.infer<typeof buildPartialFailureSchema>;

--- a/src/shared/lib/builderApi.schema.ts
+++ b/src/shared/lib/builderApi.schema.ts
@@ -1,0 +1,147 @@
+/**
+ * Builder API 응답 Zod 스키마 (#158, #103)
+ *
+ * Builder HTTP API 응답의 런타임 타입 검증을 위한 Zod 스키마입니다.
+ * Builder SSOT(contract/builder-api.yaml)와 정합하도록 작성되었습니다.
+ *
+ * 사용 방법:
+ * - apiFetch()에서 응답 파싱 후 zod.parse()로 런타임 검증
+ * - TypeScript 타입 안정성 보장 + 런타임 데이터 정합성 검증
+ */
+
+import { z } from "zod";
+
+/**
+ * GET /version 응답 스키마
+ */
+export const versionResponseSchema = z.object({
+  service: z.string(),
+  api_version: z.string(),
+});
+
+/**
+ * POST /validate 응답 스키마 (검증 성공)
+ */
+export const validateValidSchema = z.object({
+  status: z.literal("valid"),
+  dataset_id: z.string(),
+  api_version: z.string(),
+});
+
+/**
+ * POST /validate 응답 스키마 (검증 실패 - 문제 목록)
+ */
+export const validateInvalidSchema = z.object({
+  status: z.literal("invalid"),
+  problems: z.array(z.string()),
+});
+
+/**
+ * POST /validate 응답 스키마 (스펙 로딩 오류)
+ */
+export const validateErrorSchema = z.object({
+  status: z.literal("error"),
+  error: z.string(),
+});
+
+/**
+ * POST /validate 통합 응답 스키마
+ */
+export const validateResponseSchema = z.discriminatedUnion("status", [
+  validateValidSchema,
+  validateInvalidSchema,
+  validateErrorSchema,
+]);
+
+/**
+ * 빌드 아웃컴 (BuildOutcome) 스키마
+ */
+export const buildOutcomeSchema = z.object({
+  source_key: z.string(),
+  status: z.string(),
+  stages_completed: z.array(z.string()),
+  error: z.string().nullable(),
+});
+
+/**
+ * POST /build 응답 스키마 (빌드 성공)
+ */
+export const buildOkSchema = z.object({
+  status: z.literal("ok"),
+  run_id: z.string(),
+  outcomes: z.array(buildOutcomeSchema),
+  manifest: z.string(),
+  api_version: z.string(),
+});
+
+/**
+ * POST /build 응답 스키마 (빌드 실패 - 하나 이상 소스 실패)
+ */
+export const buildFailedSchema = z.object({
+  status: z.literal("failed"),
+  run_id: z.string(),
+  outcomes: z.array(buildOutcomeSchema),
+  manifest: z.string(),
+  api_version: z.string(),
+});
+
+/**
+ * POST /build 통합 응답 스키마
+ */
+export const buildResponseSchema = z.discriminatedUnion("status", [
+  buildOkSchema,
+  buildFailedSchema,
+]);
+
+/**
+ * GET /artifacts/{run_id} 응답 스키마
+ */
+export const artifactsResponseSchema = z.object({
+  run_id: z.string(),
+  files: z.array(z.string()),
+});
+
+/**
+ * Preview 컬럼 스키마 항목
+ */
+export const previewColumnSchema = z.object({
+  name: z.string(),
+  dtype: z.string(),
+  nullable: z.boolean(),
+  unique_count: z.number(),
+});
+
+/**
+ * Preview 소스별 미리보기 항목
+ */
+export const previewSourceSchema = z.object({
+  source_key: z.string(),
+  status: z.string(),
+  error: z.string().nullable(),
+  schema: z.array(previewColumnSchema),
+  sample: z.array(z.record(z.string(), z.unknown())),
+  total_rows: z.number(),
+});
+
+/**
+ * POST /preview 응답 스키마
+ */
+export const previewResponseSchema = z.object({
+  dataset_id: z.string(),
+  previews: z.array(previewSourceSchema),
+});
+
+// 타입 추출 (TypeScript 타입과 일치하도록 Zod 스키마에서 추출)
+export type VersionResponse = z.infer<typeof versionResponseSchema>;
+export type ValidateValid = z.infer<typeof validateValidSchema>;
+export type ValidateInvalid = z.infer<typeof validateInvalidSchema>;
+export type ValidateError = z.infer<typeof validateErrorSchema>;
+export type ValidateResponse = z.infer<typeof validateResponseSchema>;
+export type BuildOutcome = z.infer<typeof buildOutcomeSchema>;
+export type BuildOk = z.infer<typeof buildOkSchema>;
+export type BuildFailed = z.infer<typeof buildFailedSchema>;
+export type BuildResponse = z.infer<typeof buildResponseSchema>;
+export type ArtifactsResponse = z.infer<typeof artifactsResponseSchema>;
+export type PreviewColumn = z.infer<typeof previewColumnSchema>;
+export type PreviewSource = z.infer<typeof previewSourceSchema>;
+export type PreviewResponse = z.infer<typeof previewResponseSchema>;

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -181,8 +181,8 @@ export async function apiFetch<T>(
   }
 
   if (!response.ok) {
-    const message =
-      extractErrorMessage(parsed) ?? `Builder API 오류 (HTTP ${response.status})`;
+    // 사용자에게 명시적인 에러 메시지 제공 (#159)
+    const message = formatApiErrorMessage(response.status, parsed);
     throw new ApiError(response.status, message, parsed);
   }
 
@@ -190,9 +190,16 @@ export async function apiFetch<T>(
   if (schema) {
     const result = schema.safeParse(parsed);
     if (!result.success) {
+      // 스키마 불일치 시 사용자에게 표시 가능한 명시적 에러 (#159)
+      const errorDetails = result.error.issues.map((issue) => {
+        const path = issue.path.length > 0 ? `\`${issue.path.join(".")}\`` : "응답 구조";
+        const message = issue.message || "형식 불일치";
+        return `${path}: ${message}`;
+      }).join(", ");
+
       throw new ApiError(
         500,
-        `응답 스키마 검증 실패: ${result.error.issues.map((e) => e.message).join(", ")}`,
+        `Builder API 응답이 예상된 형식과 일치하지 않습니다: ${errorDetails}`,
         parsed,
       );
     }
@@ -233,6 +240,52 @@ export function extractErrorMessage(parsed: unknown): string | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * HTTP 상태 코드와 응답 본문을 사용자에게 표시 가능한 에러 메시지로 변환합니다 (#159).
+ *
+ * @param status - HTTP 상태 코드
+ * @param parsed - 파싱된 응답 본문
+ * @returns 사용자에게 표시할 수 있는 명시적인 에러 메시지
+ */
+export function formatApiErrorMessage(status: number, parsed: unknown): string {
+  // 먼저 구조화된 에러 메시지 추출 시도
+  const extracted = extractErrorMessage(parsed);
+  if (extracted) return extracted;
+
+  // 상태 코드별 기본 메시지
+  const statusMessages: Record<number, string> = {
+    400: "요청 형식이 올바르지 않습니다.",
+    401: "인증이 필요합니다.",
+    403: "접근 권한이 없습니다.",
+    404: "요청한 리소스를 찾을 수 없습니다.",
+    405: "Method Not Allowed",
+    408: "요청 시간이 초과되었습니다.",
+    429: "너무 많은 요청을 보냈습니다. 잠시 후 다시 시도해주세요.",
+    500: "서버 내부 오류가 발생했습니다.",
+    502: "데이터 소스에서 오류가 발생했습니다.",
+    503: "서비스를 일시적으로 사용할 수 없습니다.",
+    504: "Gateway Timeout",
+  };
+
+  const baseMessage = statusMessages[status] ?? `Builder API 오류 (HTTP ${status})`;
+
+  // 응답에 추가 정보가 있는 경우 덧붙임
+  if (parsed && typeof parsed === "object") {
+    const record = parsed as Record<string, unknown>;
+    if (record.run_id) {
+      return `${baseMessage} (빌드 ID: ${record.run_id})`;
+    }
+    if (record.dataset_id) {
+      return `${baseMessage} (데이터셋 ID: ${record.dataset_id})`;
+    }
+    if (record.source_key) {
+      return `${baseMessage} (소스: ${record.source_key})`;
+    }
+  }
+
+  return baseMessage;
 }
 
 // --- 응답 타입 (Zod 스키마에서 추출) ---

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -12,8 +12,14 @@
  * 주의: validate/preview/build는 Builder가 BuildSpec YAML(snake_case)을 기대하므로,
  * Studio BuildSpec(camelCase) → Builder 스펙 매핑(#37)이 선행되어야 완전히 연결된다.
  * 이 모듈은 그 매핑이 끝난 스펙 텍스트를 받는 저수준 계약 계층이다.
+ *
+ * 런타임 타입 검증 (#158, #103):
+ * - 모든 응답은 Zod 스키마로 런타임 검증된다.
+ * - as T 캐스팅 대신 zod.parse()를 사용하여 타입 안정성을 보장한다.
  */
 import { API_BASE } from "@/shared/config/env";
+import * as schemas from "./builderApi.schema";
+import { z } from "zod";
 
 /** Builder API 계약 버전. builder #209의 API_CONTRACT_VERSION과 일치해야 한다. */
 export const API_CONTRACT_VERSION = "1.0.0";
@@ -97,12 +103,21 @@ function isTimeoutAbort(cause: unknown): boolean {
  * 네트워크 일시 장애와 5xx에는 지수 백오프로 제한 재시도하고(#94), 응답이 없을 경우
  * UI가 무한 대기에 빠지지 않도록 자동 타임아웃을 건다(#94). 호출자 취소 signal은 그대로 존중한다.
  *
+ * 런타임 타입 검증 (#158, #103):
+ * - 스키마가 제공되면 Zod로 런타임 검증을 수행한다.
+ * - 검증 실패 시 ApiError를 던진다.
+ *
  * @param path - 선행 슬래시를 포함한 엔드포인트 경로(예: "/version").
  * @param options - 메서드/바디/취소 시그널/타임아웃/재시도.
+ * @param schema - 응답을 검증할 Zod 스키마 (선택).
  * @returns 파싱된 응답 본문.
- * @throws ApiError 응답이 2xx가 아니거나 네트워크/파싱/타임아웃 오류가 발생한 경우.
+ * @throws ApiError 응답이 2xx가 아니거나 네트워크/파싱/타임아웃/스키마 검증 오류가 발생한 경우.
  */
-export async function apiFetch<T>(path: string, options: RequestOptions = {}): Promise<T> {
+export async function apiFetch<T>(
+  path: string,
+  options: RequestOptions = {},
+  schema?: z.ZodSchema<T>,
+): Promise<T> {
   const {
     method = "GET",
     body,
@@ -171,6 +186,20 @@ export async function apiFetch<T>(path: string, options: RequestOptions = {}): P
     throw new ApiError(response.status, message, parsed);
   }
 
+  // Zod 스키마로 런타임 타입 검증 (#158, #103)
+  if (schema) {
+    const result = schema.safeParse(parsed);
+    if (!result.success) {
+      throw new ApiError(
+        500,
+        `응답 스키마 검증 실패: ${result.error.issues.map((e) => e.message).join(", ")}`,
+        parsed,
+      );
+    }
+    return result.data;
+  }
+
+  // 스키마가 없는 경우 (하위 호환): as T 캐스팅만 수행
   return parsed as T;
 }
 
@@ -206,89 +235,45 @@ export function extractErrorMessage(parsed: unknown): string | undefined {
   return undefined;
 }
 
-// --- 응답 와이어 타입 (Builder service 실제 구현 기준) ---
+// --- 응답 타입 (Zod 스키마에서 추출) ---
 
-export interface VersionResponse {
-  service: string;
-  api_version: string;
-}
-
-export type ValidateResponse =
-  | { status: "valid"; dataset_id: string; api_version: string }
-  | { status: "invalid"; problems: string[] }
-  | { status: "error"; error: string };
-
-export interface BuildOutcome {
-  source_key: string;
-  status: string;
-  stages_completed: string[];
-  error: string | null;
-}
-
-export interface BuildResponse {
-  status: string;
-  run_id: string;
-  outcomes: BuildOutcome[];
-  manifest: string;
-  api_version: string;
-}
-
-export interface ArtifactsResponse {
-  run_id: string;
-  files: string[];
-}
-
-/** /preview 응답의 소스별 컬럼 스키마 항목(service app.py 기준). */
-export interface PreviewColumn {
-  name: string;
-  dtype: string;
-  nullable: boolean;
-  unique_count: number;
-}
-
-/** /preview 응답의 소스별 미리보기 항목(service app.py 기준). */
-export interface PreviewSource {
-  source_key: string;
-  status: string;
-  error: string | null;
-  schema: PreviewColumn[];
-  sample: Record<string, unknown>[];
-  total_rows: number;
-}
-
-/**
- * POST /preview 응답 와이어 형태(builder service app.py 기준).
- *
- * `{ dataset_id, previews: [...] }` — 소스별로 스키마와 샘플 행을 담는다.
- */
-export interface PreviewResponse {
-  dataset_id: string;
-  previews: PreviewSource[];
-}
+export type VersionResponse = schemas.VersionResponse;
+export type ValidateResponse = schemas.ValidateResponse;
+export type BuildOutcome = schemas.BuildOutcome;
+export type BuildResponse = schemas.BuildResponse;
+export type ArtifactsResponse = schemas.ArtifactsResponse;
+export type PreviewColumn = schemas.PreviewColumn;
+export type PreviewSource = schemas.PreviewSource;
+export type PreviewResponse = schemas.PreviewResponse;
 
 /** Builder service 엔드포인트를 감싼 클라이언트. */
 export const builderApi = {
   /** GET /version — 계약 버전 확인(메타). */
-  version: (signal?: AbortSignal) => apiFetch<VersionResponse>("/version", { signal }),
+  version: (signal?: AbortSignal) =>
+    apiFetch("/version", { signal }, schemas.versionResponseSchema),
 
   /** POST /validate — BuildSpec YAML 검증. */
   validate: (specYaml: string, signal?: AbortSignal) =>
-    apiFetch<ValidateResponse>("/validate", { method: "POST", body: { spec: specYaml }, signal }),
+    apiFetch("/validate", { method: "POST", body: { spec: specYaml }, signal }, schemas.validateResponseSchema),
 
   /** POST /preview — BuildSpec 기반 샘플 미리보기. */
   preview: (specYaml: string, signal?: AbortSignal) =>
-    apiFetch<PreviewResponse>("/preview", { method: "POST", body: { spec: specYaml }, signal }),
+    apiFetch("/preview", { method: "POST", body: { spec: specYaml }, signal }, schemas.previewResponseSchema),
 
   /** POST /build — 빌드 실행. run_id 생략 가능. 비멱등 요청이므로 재시도하지 않는다 (#117). */
   build: (specYaml: string, runId?: string, signal?: AbortSignal) =>
-    apiFetch<BuildResponse>("/build", {
-      method: "POST",
-      body: runId ? { spec: specYaml, run_id: runId } : { spec: specYaml },
-      signal,
-      retries: 0,
-    }),
+    apiFetch(
+      "/build",
+      {
+        method: "POST",
+        body: runId ? { spec: specYaml, run_id: runId } : { spec: specYaml },
+        signal,
+        retries: 0,
+      },
+      schemas.buildResponseSchema,
+    ),
 
   /** GET /artifacts/{runId} — 실행 산출물 파일 목록. */
   artifacts: (runId: string, signal?: AbortSignal) =>
-    apiFetch<ArtifactsResponse>(`/artifacts/${encodeURIComponent(runId)}`, { signal }),
+    apiFetch(`/artifacts/${encodeURIComponent(runId)}`, { signal }, schemas.artifactsResponseSchema),
 };


### PR DESCRIPTION
## 요약
Builder API의 오류 응답에 대한 Zod 스키마 검증을 추가하고, 사용자에게 명시적이고 조치가능한 에러 메시지를 제공합니다.
**#158 머지 후 충돌 해결해야합니다.**

## 변경 내용
### 주요 변경

1. **오류 응답 Zod 스키마 정의** (`src/shared/lib/builderApi.schema.ts`)
   - `specLoadErrorSchema`: 400 - 스펙 로딩 실패
   - `badRequestSchema`: 400 - 요청 본문 오류
   - `notFoundSchema`: 404 - 리소스 없음
   - `buildPartialFailureSchema`: 502 - 소스 부분 실패
   - `errorResponseSchema`: 통합 오류 응답 스키마

2. **사용자 친화적 에러 메시지 구현** (`src/shared/lib/builderApi.ts`)
   - `formatApiErrorMessage()` 함수 추가
   - HTTP 상태 코드별 사용자 친화적 기본 메시지 제공
   - 응답에 추가 정보(run_id, dataset_id, source_key) 포함 메시지
   - `extractErrorMessage` 우선 적용 (기존 검증 로직 하위 호환)

3. **Zod 검증 에러 메시지 개선**
   - 스키마 검증 실패 시 경로(\`path\`: message) 형태로 명시적 에러
   - 일반적인 \"응답 스키마 검증 실패\"에서 구체적인 필드 정보 제공

4. **오류 응답 검증 테스트** (`__tests__/builderApi.test.ts`)
   - `formatApiErrorMessage()` 테스트 (상태 코드별 메시지 검증)
   - 404 리소스 없음 응답 Zod 검증 테스트
   - 기존 테스트 업데이트 (에러 메시지 변경 사항 반영)

### 개선 전/비교

**이전 (#158만 있을 때)**:
```typescript
// 런타임 검증 없음 - 타입 불일치 가능성
return parsed as T; // ⚠️ unsafe
개선 후 (#159):


// 정상 응답 - Zod 검증
const result = schema.safeParse(parsed);
if (!result.success) {
  throw new ApiError(
    500,
    `Builder API 응답이 예상된 형식과 일치하지 않습니다: ${errorDetails}`,
    parsed,
  );
}
return result.data; // ✅ type-safe + validated

// 오류 응답 - 사용자 친화적 메시지
const message = formatApiErrorMessage(400, parsed);
// → "요청 형식이 올바르지 않습니다. (빌드 ID: xxx)"
// → "run not found: run_999"
// → "데이터 소스에서 오류가 발생했습니다. (소스: kma__forecast)"
```

## 관련 이슈
Closes #159
- #103 (상위 이슈)
- Epic #152 워크스트림 B (신뢰성)
- #158 (cherry-pick 통합)

## 검증
- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 테스트 통과 (`npm test`)

## 체크리스트
- [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
- [x] 커밋 메시지를 영어로 작성했다
- [x] Studio는 제어 인터페이스이며, Builder가 소유한 로직(검증/미리보기/Manifest/게시)을 중복 구현하지 않았다
- [x] 관련 화면 설계서/문서를 함께 갱신했다 (해당 시)