### PR TITLE
feat: 빌드 목록 로딩 UI 개선 - 스켈레톤 테이블 적용 (#154)

### DIFF
--- a/src/pages/BuildsPage.tsx
+++ b/src/pages/BuildsPage.tsx
@@ -6,6 +6,7 @@
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { listBuilds } from "@/features/runs/api";
+import { SkeletonTable } from "@/shared/ui";
 import type { BuildRun } from "@/shared/lib/types";
 import {
   Button,
@@ -114,9 +115,7 @@ export function BuildsPage() {
         </div>
 
         {state.status === "loading" ? (
-          <div className="px-6 py-10 text-center text-sm text-muted-foreground">
-            불러오는 중입니다…
-          </div>
+          <SkeletonTable rows={5} className="w-full" />
         ) : state.status === "error" ? (
           <ErrorState
             title="빌드 목록을 불러오지 못했습니다"


### PR DESCRIPTION
## 변경 사항

- SkeletonTable 컴포넌트 import 추가
- 로딩 상태 UI를 단순 텍스트에서 스켈레톤 테이블로 개선
- 빈 목록 vs 에러 상태 구분 유지 (state.status 기반)

## 완료 조건

- ✅ 로딩/빈/에러 3상태 UI
- ✅ 빈 목록 vs 에러 구분

Closes #154