### PR TITLE
feat: integrate Builder build history API (#153)

### DIFF
--- a/__tests__/builderApi.test.ts
+++ b/__tests__/builderApi.test.ts
@@ -83,6 +83,73 @@ describe("builderApi client (#29)", () => {
     expect((error as ApiError).status).toBe(0);
   });
 
+  it("listBuilds() calls GET /builds without limit parameter (#153)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { builds: [] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await builderApi.listBuilds();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/builds");
+    expect(String(url)).not.toContain("?limit=");
+    expect(init.method).toBe("GET");
+  });
+
+  it("listBuilds() calls GET /builds?limit=N with limit parameter (#153)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { builds: [] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await builderApi.listBuilds(25);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/builds?limit=25");
+    expect(init.method).toBe("GET");
+  });
+
+  it("listBuilds() parses Builder wire response correctly (#153)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, {
+        builds: [
+          {
+            run_id: "run_123",
+            status: "ok",
+            started_at: "2024-01-15T10:30:00Z",
+            finished_at: "2024-01-15T11:45:00Z",
+          },
+          {
+            run_id: "run_456",
+            status: "failed",
+            started_at: "2024-01-16T14:20:00Z",
+            finished_at: null,
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await builderApi.listBuilds();
+
+    expect(result.builds).toHaveLength(2);
+    expect(result.builds[0]).toMatchObject({
+      run_id: "run_123",
+      status: "ok",
+      started_at: "2024-01-15T10:30:00Z",
+      finished_at: "2024-01-15T11:45:00Z",
+    });
+    expect(result.builds[1]).toMatchObject({
+      run_id: "run_456",
+      status: "failed",
+      started_at: "2024-01-16T14:20:00Z",
+      finished_at: null,
+    });
+  });
+
   it("surfaces outcomes[].error on a 502 with no top-level error (#75)", async () => {
     vi.stubGlobal(
       "fetch",

--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import { API_CONTRACT_VERSION, builderApi } from "@/shared/lib/builderApi";
 
 // Studio 클라이언트가 호출하는 Builder service 오퍼레이션(현재 구현 기준).
-const EXPECTED_OPERATIONS = ["version", "validate", "preview", "build", "artifacts"] as const;
+const EXPECTED_OPERATIONS = ["version", "validate", "preview", "build", "artifacts", "listBuilds"] as const;
 
 describe("Builder API contract conformance (#36)", () => {
   it("pins the contract version Studio targets (must match builder #209)", () => {

--- a/__tests__/listBuilds.test.ts
+++ b/__tests__/listBuilds.test.ts
@@ -1,28 +1,228 @@
 /**
- * listBuilds 실연동 모드 분기 테스트 (#95).
+ * listBuilds 실연동 모드 분기 테스트 (#95, #153).
  *
- * mock 모드에서는 결정적 mock 이력을 반환하고, 실연동 모드에서는 Builder에 아직 GET /builds가
- * 없으므로(builder #250) 가짜 이력 대신 빈 목록을 반환하는지 검증한다. 실연동 모드에서 mock
- * 데이터를 그대로 노출하면 사용자를 오도한다.
+ * mock 모드에서는 결정적 mock 이력을 반환하고, 실연동 모드에서는 Builder GET /builds를
+ * 호출하여 BuildListItem[]으로 매핑하는지 검증한다(#153, builder #250).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { listBuilds } from "@/features/runs/api";
 
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
 afterEach(() => {
   vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
 });
 
-describe("listBuilds (#95)", () => {
-  it("returns deterministic mock history in mock mode", async () => {
-    const builds = await listBuilds();
-    expect(builds.length).toBe(6);
-    expect(builds.map((b) => b.spec.title)).toContain("대기오염 정보");
+describe("listBuilds (#95, #153)", () => {
+  describe("mock mode", () => {
+    it("returns deterministic mock history with BuildListItem structure", async () => {
+      const builds = await listBuilds();
+      expect(builds.length).toBe(6);
+      // mock 데이터는 실제 title을 가짐
+      expect(builds.map((b) => b.title)).toContain("대기오염 정보");
+      // 모든 항목이 필수 필드를 가짐
+      builds.forEach((item) => {
+        expect(item).toHaveProperty("id");
+        expect(item).toHaveProperty("title");
+        expect(item).toHaveProperty("status");
+        expect(item).toHaveProperty("startedAt");
+        expect(item).toHaveProperty("finishedAt");
+      });
+    });
+
+    it("does not make network calls in mock mode", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      await listBuilds();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 
-  it("returns an empty list in real mode (no Builder GET /builds yet, builder #250)", async () => {
-    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
-    const builds = await listBuilds();
-    // 가짜 mock 이력을 실데이터처럼 노출하지 않는다.
-    expect(builds).toEqual([]);
+  describe("real integration mode", () => {
+    it("calls Builder GET /builds without limit parameter", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, { builds: [] }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await listBuilds();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url] = fetchMock.mock.calls[0];
+      expect(String(url)).toContain("/builds");
+      expect(String(url)).not.toContain("?limit=");
+    });
+
+    it("calls Builder GET /builds?limit=N with limit parameter", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, { builds: [] }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await listBuilds(25);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url] = fetchMock.mock.calls[0];
+      expect(String(url)).toContain("/builds?limit=25");
+    });
+
+    it("maps Builder response to BuildListItem[] correctly", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, {
+          builds: [
+            {
+              run_id: "run_123",
+              status: "ok",
+              started_at: "2024-01-15T10:30:00Z",
+              finished_at: "2024-01-15T11:45:00Z",
+            },
+            {
+              run_id: "run_456",
+              status: "failed",
+              started_at: "2024-01-16T14:20:00Z",
+              finished_at: null,
+            },
+          ],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await listBuilds();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        id: "run_123",
+        title: null, // Builder provides no title
+        status: "succeeded", // "ok" -> "succeeded"
+        startedAt: "2024-01-15T10:30:00Z",
+        finishedAt: "2024-01-15T11:45:00Z",
+      });
+      expect(result[1]).toMatchObject({
+        id: "run_456",
+        title: null, // Builder provides no title
+        status: "failed", // "failed" -> "failed"
+        startedAt: "2024-01-16T14:20:00Z",
+        finishedAt: null, // null preserved
+      });
+    });
+
+    it("correctly maps Builder status to BuildRunStatus", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, {
+          builds: [
+            { run_id: "ok_build", status: "ok", started_at: "2024-01-15T10:00:00Z", finished_at: null },
+            { run_id: "failed_build", status: "failed", started_at: "2024-01-15T11:00:00Z", finished_at: null },
+          ],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await listBuilds();
+
+      expect(result[0].status).toBe("succeeded");
+      expect(result[1].status).toBe("failed");
+    });
+
+    it("preserves null timestamps from Builder response", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, {
+          builds: [
+            {
+              run_id: "run_null_times",
+              status: "ok",
+              started_at: null,
+              finished_at: null,
+            },
+          ],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await listBuilds();
+
+      expect(result[0].startedAt).toBeNull();
+      expect(result[0].finishedAt).toBeNull();
+    });
+
+    it("handles omitted timestamps in Builder response", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, {
+          builds: [
+            {
+              run_id: "run_without_times",
+              status: "ok",
+            },
+          ],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await listBuilds();
+
+      expect(result[0].startedAt).toBeNull();
+      expect(result[0].finishedAt).toBeNull();
+    });
+
+    it("returns empty array when Builder returns empty builds array", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, { builds: [] }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await listBuilds();
+
+      expect(result).toEqual([]);
+    });
+
+    it("propagates HTTP errors without converting to empty array", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(500, { error: "Internal server error" }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(listBuilds()).rejects.toThrow();
+    });
+
+    it("propagates network errors without converting to empty array", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockRejectedValue(
+        new Error("Network connection failed"),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(listBuilds()).rejects.toThrow("Builder API에 연결하지 못했습니다.");
+    });
+
+    it("maintains backward compatibility with no-argument calls", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, { builds: [] }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await listBuilds(); // No argument
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url] = fetchMock.mock.calls[0];
+      expect(String(url)).toContain("/builds");
+      expect(String(url)).not.toContain("?limit=");
+    });
   });
 });

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -8,7 +8,7 @@
 import { serializeSpec } from "@/features/build-spec/specMapping";
 import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
 import { DEMO_DATASETS, type DemoDataset } from "@/shared/lib/demoDatasets";
-import type { BuildRun, BuildSpec } from "@/shared/lib/types";
+import type { BuildListItem, BuildRun, BuildSpec } from "@/shared/lib/types";
 
 const MOCK_TIME = "1970-01-01T00:00:00.000Z";
 
@@ -93,25 +93,35 @@ function mockBuilds(): BuildRun[] {
 }
 
 /**
- * 빌드 실행 이력 목록을 조회한다 (#12, #95).
+ * 빌드 실행 이력 목록을 조회한다 (#12, #95, #153).
  *
  * mock 모드(`VITE_USE_REAL_BUILDER` 미설정)에서는 이력 표/검색/정렬 UI를 개발·검증할 수
  * 있도록 결정적 mock 목록을 반환한다.
  *
- * 실연동 모드에서는 Builder에 이력 목록 엔드포인트(`GET /builds`)가 아직 없다(builder #250).
- * 그 전까지 mock 데이터를 실데이터처럼 보여주면 사용자를 오도하므로, 실연동 모드에서는
- * 가짜 이력을 만들지 않고 빈 목록을 반환한다. Builder에 `GET /builds`가 추가되면 이 분기에서
- * 해당 API를 호출하고 응답을 BuildRun[]으로 매핑하도록 확장한다(executeBuild의 실연동 패턴과 동일).
+ * 실연동 모드에서는 Builder `GET /builds`를 호출하고 응답을 BuildListItem[]으로 매핑한다(#153, builder #250).
+ * Builder 응답에 spec/title이 없으므로 title은 null이 되고, UI는 run ID를 대신 표시한다.
  *
- * @returns 빌드 실행 목록(mock 모드: 결정적 mock, 실연동 모드: 현재는 빈 목록).
+ * @param limit - 선택적 limit 파라미터. Builder의 기본값(50)을 사용하려면 생략한다.
+ * @returns 빌드 실행 목록(mock 모드: 결정적 mock, 실연동 모드: Builder 응답 매핑).
  */
-export async function listBuilds(): Promise<BuildRun[]> {
+export async function listBuilds(limit?: number): Promise<BuildListItem[]> {
   if (!isRealBuilderEnabled()) {
-    return mockBuilds();
+    return mockBuilds().map((run) => ({
+      id: run.id,
+      title: run.spec.title,
+      status: run.status,
+      startedAt: run.startedAt,
+      finishedAt: run.finishedAt ?? null,
+    }));
   }
 
-  // TODO(builder #250): Builder에 GET /builds가 추가되면 실제 이력을 호출·매핑한다.
-  // 그 전까지는 가짜 이력 대신 빈 목록을 반환해 실연동 모드에서 mock을 노출하지 않는다.
-  return [];
+  const response = await builderApi.listBuilds(limit);
+  return response.builds.map((summary) => ({
+    id: summary.run_id,
+    title: null, // Builder GET /builds는 title을 제공하지 않음
+    status: summary.status === "ok" ? "succeeded" : "failed",
+    startedAt: summary.started_at ?? null, // 누락 또는 null을 명시적 null로 정규화
+    finishedAt: summary.finished_at ?? null, // 누락 또는 null을 명시적 null로 정규화
+  }));
 }
 

--- a/src/pages/BuildsPage.tsx
+++ b/src/pages/BuildsPage.tsx
@@ -6,8 +6,7 @@
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { listBuilds } from "@/features/runs/api";
-import { SkeletonTable } from "@/shared/ui";
-import type { BuildRun } from "@/shared/lib/types";
+import type { BuildListItem } from "@/shared/lib/types";
 import {
   Button,
   Card,
@@ -15,24 +14,26 @@ import {
   ErrorState,
   LinkButton,
   PageHeader,
+  SkeletonTable,
   StatusBadge,
   TextInput,
 } from "@/shared/ui";
 
 interface BuildsState {
   status: "loading" | "loaded" | "error";
-  runs?: BuildRun[];
+  runs?: BuildListItem[];
   error?: string;
 }
 
-function formatTime(iso?: string): string {
+function formatTime(iso: string | null | undefined): string {
   if (!iso) return "—";
   const date = new Date(iso);
   return Number.isNaN(date.getTime()) ? iso : date.toLocaleString("ko-KR");
 }
 
-/** ISO 시작 시각을 timestamp로 정렬하기 위한 안전한 변환(파싱 실패 시 0). */
-function startedAtMillis(iso: string): number {
+/** ISO 시작 시각을 timestamp로 정렬하기 위한 안전한 변환(null이면 0으로 처리하여 나중에 정렬). */
+function startedAtMillis(iso: string | null): number {
+  if (!iso) return 0; // null인 경우 목록 끝으로 보냄
   const ms = new Date(iso).getTime();
   return Number.isNaN(ms) ? 0 : ms;
 }
@@ -71,9 +72,10 @@ export function BuildsPage() {
   const runs = state.runs;
   const visible = useMemo(() => {
     if (!runs) return [];
-    const filtered = runs.filter((run) =>
-      run.spec.title.toLowerCase().includes(query.trim().toLowerCase()),
-    );
+    const filtered = runs.filter((run) => {
+      const titleOrId = run.title ?? run.id; // title이 null이면 run ID로 검색
+      return titleOrId.toLowerCase().includes(query.trim().toLowerCase());
+    });
     return [...filtered].sort((a, b) => {
       const diff = startedAtMillis(a.startedAt) - startedAtMillis(b.startedAt);
       return newestFirst ? -diff : diff;
@@ -140,7 +142,7 @@ export function BuildsPage() {
                 key={run.id}
                 className="grid grid-cols-[1.4fr_0.7fr_0.9fr_0.7fr] items-center gap-4 border-b border-border px-6 py-3 text-sm last:border-0 "
               >
-                <span className="font-medium">{run.spec.title}</span>
+                <span className="font-medium">{run.title ?? run.id}</span>
                 <span>
                   <StatusBadge status={run.status} />
                 </span>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -8,7 +8,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { listBuilds } from "@/features/runs/api";
-import type { BuildRun, BuildRunStatus } from "@/shared/lib/types";
+import type { BuildListItem, BuildRunStatus } from "@/shared/lib/types";
 import {
   Card,
   EmptyState,
@@ -44,14 +44,15 @@ const QUICK_ACTIONS = [
   },
 ];
 
-/** ISO 시작 시각을 timestamp로 안전하게 변환한다(파싱 실패 시 0). */
-function startedAtMillis(iso: string): number {
+/** ISO 시작 시각을 timestamp로 안전하게 변환한다(null이면 0으로 처리하여 나중에 정렬). */
+function startedAtMillis(iso: string | null): number {
+  if (!iso) return 0; // null인 경우 목록 끝으로 보냄
   const ms = new Date(iso).getTime();
   return Number.isNaN(ms) ? 0 : ms;
 }
 
 /** ISO 시각을 한국어 로케일 문자열로 표시한다. */
-function formatTime(iso?: string): string {
+function formatTime(iso: string | null | undefined): string {
   if (!iso) return "—";
   const date = new Date(iso);
   return Number.isNaN(date.getTime()) ? iso : date.toLocaleString("ko-KR");
@@ -63,7 +64,7 @@ function formatTime(iso?: string): string {
  * @returns Studio 대시보드 메인 화면.
  */
 export function HomePage() {
-  const [builds, setBuilds] = useState<BuildRun[]>([]);
+  const [builds, setBuilds] = useState<BuildListItem[]>([]);
 
   useEffect(() => {
     let active = true;
@@ -127,7 +128,7 @@ export function HomePage() {
                   key={run.id}
                   className="grid grid-cols-[1.4fr_0.7fr_0.9fr_0.6fr] items-center gap-4 border-b border-border px-6 py-3 text-sm last:border-0"
                 >
-                  <span className="font-medium">{run.spec.title}</span>
+                  <span className="font-medium">{run.title ?? run.id}</span>
                   <span>
                     <StatusBadge status={run.status} />
                   </span>

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -266,6 +266,23 @@ export interface PreviewResponse {
   previews: PreviewSource[];
 }
 
+/** GET /builds 응답의 단일 빌드 요약(builder contract BuildSummary 기준). */
+export interface BuildSummary {
+  /** 빌드 실행 식별자 */
+  run_id: string;
+  /** 빌드 상태("ok" | "failed") */
+  status: "ok" | "failed";
+  /** 빌드 시작 시각(ISO 8601, null, 또는 생략됨) */
+  started_at?: string | null;
+  /** 빌드 완료 시각(ISO 8601, null, 또는 생략됨) */
+  finished_at?: string | null;
+}
+
+/** GET /builds 응답 와이어 형태(builder contract BuildsResponse 기준). */
+export interface BuildsResponse {
+  builds: BuildSummary[];
+}
+
 /** Builder service 엔드포인트를 감싼 클라이언트. */
 export const builderApi = {
   /** GET /version — 계약 버전 확인(메타). */
@@ -291,4 +308,10 @@ export const builderApi = {
   /** GET /artifacts/{runId} — 실행 산출물 파일 목록. */
   artifacts: (runId: string, signal?: AbortSignal) =>
     apiFetch<ArtifactsResponse>(`/artifacts/${encodeURIComponent(runId)}`, { signal }),
+
+  /** GET /builds — 빌드 이력 목록(#153, builder #250). */
+  listBuilds: (limit?: number, signal?: AbortSignal) => {
+    const query = limit !== undefined ? `?limit=${limit}` : "";
+    return apiFetch<BuildsResponse>(`/builds${query}`, { signal });
+  },
 };

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -161,3 +161,23 @@ export interface BuildRun {
   /** 실행 종료 시각 ISO 문자열 */
   finishedAt?: string;
 }
+
+/**
+ * 빌드 이력 목록용 최소 표현 타입(#153).
+ *
+ * Builder GET /builds가 spec/title을 제공하지 않으므로, 이들을 null로 가지고
+ * UI에서는 run ID를 대신 표시한다. 실제 BuildSpec이 필요한 상세 화면으로 진입하면
+ * 그때 개별 조회로 전체 스펙을 가져온다.
+ */
+export interface BuildListItem {
+  /** 실행 이력 항목 고유 ID */
+  id: string;
+  /** 빌드 제목(Builder에서 제공하지 않으므로 실연동 시 null, mock 시 실제 title) */
+  title: string | null;
+  /** 현재 실행 상태 */
+  status: BuildRunStatus;
+  /** 실행 시작 시각 ISO 문자열(Builder에서 null이면 null 유지) */
+  startedAt: string | null;
+  /** 실행 종료 시각 ISO 문자열(Builder에서 null이거나 누락이면 null) */
+  finishedAt: string | null;
+}


### PR DESCRIPTION
## 요약

실연동 모드에서 빈 배열을 반환하던 `listBuilds()`를 Builder의 `GET /builds` 엔드포인트와 연결합니다.

Builder 목록 응답에는 전체 BuildSpec과 제목이 포함되지 않으므로 목록 전용 `BuildListItem` 타입을 사용합니다. Builder가 제공하지 않은 값을 임의로 생성하지 않고, 누락되거나 null인 timestamp도 명시적인 `null`로 처리합니다.

## 선행 변경과의 정합성

최신 `main`으로 rebase하면서 PR #173의 `SkeletonTable` 기반 로딩 UI를 유지하고,
이 PR의 `BuildListItem` 기반 실연동 목록 처리를 함께 적용했습니다.

- 로딩 상태: `SkeletonTable` 유지
- 목록 데이터: `BuildListItem` 사용
- 제목 미제공 시 run ID 표시
- nullable 및 생략된 timestamp 처리 유지

## 변경 내용

* 기존 공용 `apiFetch()`를 재사용하는 `builderApi.listBuilds()` 추가
* 선택적 `limit` 파라미터 지원

  * 미지정: `GET /builds`
  * 지정: `GET /builds?limit=<value>`
* Builder `BuildSummary`를 Studio `BuildListItem`으로 매핑

  * `run_id` → `id`
  * `ok` → `succeeded`
  * `failed` → `failed`
  * 누락되거나 null인 timestamp → `null`
* Builder가 제공하지 않는 title/spec을 생성하지 않고 run ID를 대체 표시
* Builds 및 Home 화면을 목록 전용 타입에 맞게 조정
* mock 모드에서는 기존 결정적 목록을 유지하고 네트워크 요청을 수행하지 않음
* HTTP 및 네트워크 오류를 빈 배열로 변환하지 않고 호출자에게 전파
* Builder API 계약 적합성 operation 목록에 `listBuilds` 추가

## 관련 이슈

Closes #153
Refs #102
Refs #152

## 검증

* [x] `npm run lint` 통과
* [x] `npm run build` 통과
* [x] 테스트 통과 (`npm test`: 35 files, 144 tests)
* [x] `npx tsc --noEmit` 통과
* [x] `git diff --check` 통과
* [ ] UI 변경 시 스크린샷 첨부 (해당 없음)

주요 회귀 테스트:

* mock 모드에서 기존 목록 반환
* mock 모드에서 네트워크 호출 0회
* 무인자 호출 시 `GET /builds`
* limit 지정 시 `GET /builds?limit=N`
* `{ builds: [...] }` 응답 매핑
* Builder 상태값 변환
* null timestamp 보존
* 생략된 timestamp를 `null`로 정규화
* 빈 목록 정상 처리
* HTTP·네트워크 오류 전파
* 기존 무인자 `listBuilds()` 호출 호환성

## 체크리스트

* [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
* [x] 커밋 메시지를 영어로 작성했다
* [x] Studio는 제어 인터페이스이며, Builder가 소유한 로직을 중복 구현하지 않았다
* [x] 관련 화면 설계서/문서 갱신은 필요하지 않음
* [x] 사용자 노출 계약 문서 정렬은 별도 이슈에서 처리
