### PR TITLE
feat: validate Builder responses with zod (#158)

### DIFF
--- a/__tests__/builderApi.test.ts
+++ b/__tests__/builderApi.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import {
   ApiError,
   apiFetch,
@@ -33,9 +34,18 @@ describe("builderApi client (#29)", () => {
     expect(init.method).toBe("GET");
   });
 
+  it("version() rejects when api_version is missing (Zod validation)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { service: "kpubdata-builder" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(builderApi.version()).rejects.toBeInstanceOf(z.ZodError);
+  });
+
   it("preview() POSTs spec to /preview (#75)", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      mockResponse(200, { status: "ok", preview: [], api_version: "1.0.0" }),
+      mockResponse(200, { dataset_id: "x", previews: [] }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -45,6 +55,24 @@ describe("builderApi client (#29)", () => {
     expect(String(url)).toContain("/preview");
     expect(init.method).toBe("POST");
     expect(JSON.parse(init.body)).toEqual({ spec: "dataset_id: x" });
+  });
+
+  it("preview() rejects when previews is missing (Zod validation)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { dataset_id: "x", preview: [] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(builderApi.preview("spec")).rejects.toBeInstanceOf(z.ZodError);
+  });
+
+  it("preview() rejects when previews is not an array (Zod validation)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { dataset_id: "x", previews: "not-an-array" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(builderApi.preview("spec")).rejects.toBeInstanceOf(z.ZodError);
   });
 
   it("build() POSTs spec + run_id as JSON", async () => {
@@ -65,6 +93,73 @@ describe("builderApi client (#29)", () => {
     const init = fetchMock.mock.calls[0][1];
     expect(init.method).toBe("POST");
     expect(JSON.parse(init.body)).toEqual({ spec: "dataset_id: x", run_id: "run1" });
+  });
+
+  it("build() rejects when run_id is missing (Zod validation)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, {
+        status: "ok",
+        outcomes: [],
+        manifest: "m.json",
+        api_version: "1.0.0",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(builderApi.build("spec")).rejects.toBeInstanceOf(z.ZodError);
+  });
+
+  it("build() rejects when status is 'failed' in 200 response (Zod validation)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, {
+        status: "failed",
+        run_id: "run1",
+        outcomes: [],
+        manifest: "m.json",
+        api_version: "1.0.0",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(builderApi.build("spec")).rejects.toBeInstanceOf(z.ZodError);
+  });
+
+  it("artifacts() rejects when files is not an array (Zod validation)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { run_id: "run1", files: "not-an-array" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(builderApi.artifacts("run1")).rejects.toBeInstanceOf(z.ZodError);
+  });
+
+  it("artifacts() rejects when files is an object (Zod validation)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { run_id: "run1", files: { key: "value" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(builderApi.artifacts("run1")).rejects.toBeInstanceOf(z.ZodError);
+  });
+
+  it("listBuilds() rejects when builds is missing (Zod validation)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { buildList: [] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(builderApi.listBuilds()).rejects.toBeInstanceOf(z.ZodError);
+  });
+
+  it("listBuilds() rejects when build status is not 'ok' or 'failed' (Zod validation)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, {
+        builds: [{ run_id: "run1", status: "running" }],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(builderApi.listBuilds()).rejects.toBeInstanceOf(z.ZodError);
   });
 
   it("throws ApiError with the server message on a non-2xx response", async () => {
@@ -147,6 +242,40 @@ describe("builderApi client (#29)", () => {
       status: "failed",
       started_at: "2024-01-16T14:20:00Z",
       finished_at: null,
+    });
+  });
+
+  it("listBuilds() parses builds without optional timestamp fields (PR #174 regression)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, {
+        builds: [
+          {
+            run_id: "run1",
+            status: "ok",
+            started_at: null,
+            finished_at: null,
+          },
+          {
+            run_id: "run2",
+            status: "failed",
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await builderApi.listBuilds();
+
+    expect(result.builds).toHaveLength(2);
+    expect(result.builds[0]).toMatchObject({
+      run_id: "run1",
+      status: "ok",
+      started_at: null,
+      finished_at: null,
+    });
+    expect(result.builds[1]).toMatchObject({
+      run_id: "run2",
+      status: "failed",
     });
   });
 

--- a/__tests__/builderApi.test.ts
+++ b/__tests__/builderApi.test.ts
@@ -83,6 +83,73 @@ describe("builderApi client (#29)", () => {
     expect((error as ApiError).status).toBe(0);
   });
 
+  it("listBuilds() calls GET /builds without limit parameter (#153)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { builds: [] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await builderApi.listBuilds();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/builds");
+    expect(String(url)).not.toContain("?limit=");
+    expect(init.method).toBe("GET");
+  });
+
+  it("listBuilds() calls GET /builds?limit=N with limit parameter (#153)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { builds: [] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await builderApi.listBuilds(25);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/builds?limit=25");
+    expect(init.method).toBe("GET");
+  });
+
+  it("listBuilds() parses Builder wire response correctly (#153)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, {
+        builds: [
+          {
+            run_id: "run_123",
+            status: "ok",
+            started_at: "2024-01-15T10:30:00Z",
+            finished_at: "2024-01-15T11:45:00Z",
+          },
+          {
+            run_id: "run_456",
+            status: "failed",
+            started_at: "2024-01-16T14:20:00Z",
+            finished_at: null,
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await builderApi.listBuilds();
+
+    expect(result.builds).toHaveLength(2);
+    expect(result.builds[0]).toMatchObject({
+      run_id: "run_123",
+      status: "ok",
+      started_at: "2024-01-15T10:30:00Z",
+      finished_at: "2024-01-15T11:45:00Z",
+    });
+    expect(result.builds[1]).toMatchObject({
+      run_id: "run_456",
+      status: "failed",
+      started_at: "2024-01-16T14:20:00Z",
+      finished_at: null,
+    });
+  });
+
   it("surfaces outcomes[].error on a 502 with no top-level error (#75)", async () => {
     vi.stubGlobal(
       "fetch",

--- a/__tests__/builderApiTimeout.test.ts
+++ b/__tests__/builderApiTimeout.test.ts
@@ -36,7 +36,7 @@ describe("apiFetch retry (#94)", () => {
       .mockResolvedValueOnce(okResponse({ service: "kpubdata-builder" }));
     vi.stubGlobal("fetch", fetchMock);
 
-    const result = await apiFetch<{ service: string }>("/version", { retries: 1, timeoutMs: 0 });
+    const result = await apiFetch("/version", { retries: 1, timeoutMs: 0 }) as { service: string };
 
     expect(result.service).toBe("kpubdata-builder");
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -49,7 +49,7 @@ describe("apiFetch retry (#94)", () => {
       .mockResolvedValueOnce(okResponse({ service: "ok" }));
     vi.stubGlobal("fetch", fetchMock);
 
-    const result = await apiFetch<{ service: string }>("/version", { retries: 1, timeoutMs: 0 });
+    const result = await apiFetch("/version", { retries: 1, timeoutMs: 0 }) as { service: string };
 
     expect(result.service).toBe("ok");
     expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import { API_CONTRACT_VERSION, builderApi } from "@/shared/lib/builderApi";
 
 // Studio 클라이언트가 호출하는 Builder service 오퍼레이션(현재 구현 기준).
-const EXPECTED_OPERATIONS = ["version", "validate", "preview", "build", "artifacts"] as const;
+const EXPECTED_OPERATIONS = ["version", "validate", "preview", "build", "artifacts", "listBuilds"] as const;
 
 describe("Builder API contract conformance (#36)", () => {
   it("pins the contract version Studio targets (must match builder #209)", () => {

--- a/__tests__/listBuilds.test.ts
+++ b/__tests__/listBuilds.test.ts
@@ -1,28 +1,228 @@
 /**
- * listBuilds 실연동 모드 분기 테스트 (#95).
+ * listBuilds 실연동 모드 분기 테스트 (#95, #153).
  *
- * mock 모드에서는 결정적 mock 이력을 반환하고, 실연동 모드에서는 Builder에 아직 GET /builds가
- * 없으므로(builder #250) 가짜 이력 대신 빈 목록을 반환하는지 검증한다. 실연동 모드에서 mock
- * 데이터를 그대로 노출하면 사용자를 오도한다.
+ * mock 모드에서는 결정적 mock 이력을 반환하고, 실연동 모드에서는 Builder GET /builds를
+ * 호출하여 BuildListItem[]으로 매핑하는지 검증한다(#153, builder #250).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { listBuilds } from "@/features/runs/api";
 
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
 afterEach(() => {
   vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
 });
 
-describe("listBuilds (#95)", () => {
-  it("returns deterministic mock history in mock mode", async () => {
-    const builds = await listBuilds();
-    expect(builds.length).toBe(6);
-    expect(builds.map((b) => b.spec.title)).toContain("대기오염 정보");
+describe("listBuilds (#95, #153)", () => {
+  describe("mock mode", () => {
+    it("returns deterministic mock history with BuildListItem structure", async () => {
+      const builds = await listBuilds();
+      expect(builds.length).toBe(6);
+      // mock 데이터는 실제 title을 가짐
+      expect(builds.map((b) => b.title)).toContain("대기오염 정보");
+      // 모든 항목이 필수 필드를 가짐
+      builds.forEach((item) => {
+        expect(item).toHaveProperty("id");
+        expect(item).toHaveProperty("title");
+        expect(item).toHaveProperty("status");
+        expect(item).toHaveProperty("startedAt");
+        expect(item).toHaveProperty("finishedAt");
+      });
+    });
+
+    it("does not make network calls in mock mode", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      await listBuilds();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 
-  it("returns an empty list in real mode (no Builder GET /builds yet, builder #250)", async () => {
-    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
-    const builds = await listBuilds();
-    // 가짜 mock 이력을 실데이터처럼 노출하지 않는다.
-    expect(builds).toEqual([]);
+  describe("real integration mode", () => {
+    it("calls Builder GET /builds without limit parameter", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, { builds: [] }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await listBuilds();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url] = fetchMock.mock.calls[0];
+      expect(String(url)).toContain("/builds");
+      expect(String(url)).not.toContain("?limit=");
+    });
+
+    it("calls Builder GET /builds?limit=N with limit parameter", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, { builds: [] }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await listBuilds(25);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url] = fetchMock.mock.calls[0];
+      expect(String(url)).toContain("/builds?limit=25");
+    });
+
+    it("maps Builder response to BuildListItem[] correctly", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, {
+          builds: [
+            {
+              run_id: "run_123",
+              status: "ok",
+              started_at: "2024-01-15T10:30:00Z",
+              finished_at: "2024-01-15T11:45:00Z",
+            },
+            {
+              run_id: "run_456",
+              status: "failed",
+              started_at: "2024-01-16T14:20:00Z",
+              finished_at: null,
+            },
+          ],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await listBuilds();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        id: "run_123",
+        title: null, // Builder provides no title
+        status: "succeeded", // "ok" -> "succeeded"
+        startedAt: "2024-01-15T10:30:00Z",
+        finishedAt: "2024-01-15T11:45:00Z",
+      });
+      expect(result[1]).toMatchObject({
+        id: "run_456",
+        title: null, // Builder provides no title
+        status: "failed", // "failed" -> "failed"
+        startedAt: "2024-01-16T14:20:00Z",
+        finishedAt: null, // null preserved
+      });
+    });
+
+    it("correctly maps Builder status to BuildRunStatus", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, {
+          builds: [
+            { run_id: "ok_build", status: "ok", started_at: "2024-01-15T10:00:00Z", finished_at: null },
+            { run_id: "failed_build", status: "failed", started_at: "2024-01-15T11:00:00Z", finished_at: null },
+          ],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await listBuilds();
+
+      expect(result[0].status).toBe("succeeded");
+      expect(result[1].status).toBe("failed");
+    });
+
+    it("preserves null timestamps from Builder response", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, {
+          builds: [
+            {
+              run_id: "run_null_times",
+              status: "ok",
+              started_at: null,
+              finished_at: null,
+            },
+          ],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await listBuilds();
+
+      expect(result[0].startedAt).toBeNull();
+      expect(result[0].finishedAt).toBeNull();
+    });
+
+    it("handles omitted timestamps in Builder response", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, {
+          builds: [
+            {
+              run_id: "run_without_times",
+              status: "ok",
+            },
+          ],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await listBuilds();
+
+      expect(result[0].startedAt).toBeNull();
+      expect(result[0].finishedAt).toBeNull();
+    });
+
+    it("returns empty array when Builder returns empty builds array", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, { builds: [] }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await listBuilds();
+
+      expect(result).toEqual([]);
+    });
+
+    it("propagates HTTP errors without converting to empty array", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(500, { error: "Internal server error" }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(listBuilds()).rejects.toThrow();
+    });
+
+    it("propagates network errors without converting to empty array", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockRejectedValue(
+        new Error("Network connection failed"),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(listBuilds()).rejects.toThrow("Builder API에 연결하지 못했습니다.");
+    });
+
+    it("maintains backward compatibility with no-argument calls", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, { builds: [] }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await listBuilds(); // No argument
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url] = fetchMock.mock.calls[0];
+      expect(String(url)).toContain("/builds");
+      expect(String(url)).not.toContain("?limit=");
+    });
   });
 });

--- a/__tests__/validationApi.test.ts
+++ b/__tests__/validationApi.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { validateSpec } from "@/features/validation/api";
 import type { BuildSpec } from "@/shared/lib/types";
 
@@ -48,31 +49,6 @@ describe("validateSpec wiring (#29/#37)", () => {
     expect(result).toEqual({ valid: true, errors: [] });
   });
 
-  it("maps a 2xx invalid response to valid=false with problems", async () => {
-    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        mockResponse(200, { status: "invalid", problems: ["소스를 최소 1개 추가해주세요."] }),
-      ),
-    );
-
-    const result = await validateSpec(spec);
-    expect(result.valid).toBe(false);
-    expect(result.errors).toEqual(["소스를 최소 1개 추가해주세요."]);
-  });
-
-  it("maps a 2xx error response to valid=false with the error message", async () => {
-    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(mockResponse(200, { status: "error", error: "스펙 로드 실패" })),
-    );
-
-    const result = await validateSpec(spec);
-    expect(result).toEqual({ valid: false, errors: ["스펙 로드 실패"] });
-  });
-
   it("maps a 400 invalid response to valid=false with problems", async () => {
     vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
     vi.stubGlobal(
@@ -85,5 +61,27 @@ describe("validateSpec wiring (#29/#37)", () => {
     const result = await validateSpec(spec);
     expect(result.valid).toBe(false);
     expect(result.errors).toEqual(["제목을 입력해주세요."]);
+  });
+
+  it("rejects with ZodError on 200 invalid response (contract violation)", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse(200, { status: "invalid", problems: ["소스를 최소 1개 추가해주세요."] }),
+      ),
+    );
+
+    await expect(validateSpec(spec)).rejects.toBeInstanceOf(z.ZodError);
+  });
+
+  it("rejects with ZodError on 200 error response (contract violation)", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockResponse(200, { status: "error", error: "스펙 로드 실패" })),
+    );
+
+    await expect(validateSpec(spec)).rejects.toBeInstanceOf(z.ZodError);
   });
 });

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -8,7 +8,7 @@
 import { serializeSpec } from "@/features/build-spec/specMapping";
 import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
 import { DEMO_DATASETS, type DemoDataset } from "@/shared/lib/demoDatasets";
-import type { BuildRun, BuildSpec } from "@/shared/lib/types";
+import type { BuildListItem, BuildRun, BuildSpec } from "@/shared/lib/types";
 
 const MOCK_TIME = "1970-01-01T00:00:00.000Z";
 
@@ -93,25 +93,35 @@ function mockBuilds(): BuildRun[] {
 }
 
 /**
- * 빌드 실행 이력 목록을 조회한다 (#12, #95).
+ * 빌드 실행 이력 목록을 조회한다 (#12, #95, #153).
  *
  * mock 모드(`VITE_USE_REAL_BUILDER` 미설정)에서는 이력 표/검색/정렬 UI를 개발·검증할 수
  * 있도록 결정적 mock 목록을 반환한다.
  *
- * 실연동 모드에서는 Builder에 이력 목록 엔드포인트(`GET /builds`)가 아직 없다(builder #250).
- * 그 전까지 mock 데이터를 실데이터처럼 보여주면 사용자를 오도하므로, 실연동 모드에서는
- * 가짜 이력을 만들지 않고 빈 목록을 반환한다. Builder에 `GET /builds`가 추가되면 이 분기에서
- * 해당 API를 호출하고 응답을 BuildRun[]으로 매핑하도록 확장한다(executeBuild의 실연동 패턴과 동일).
+ * 실연동 모드에서는 Builder `GET /builds`를 호출하고 응답을 BuildListItem[]으로 매핑한다(#153, builder #250).
+ * Builder 응답에 spec/title이 없으므로 title은 null이 되고, UI는 run ID를 대신 표시한다.
  *
- * @returns 빌드 실행 목록(mock 모드: 결정적 mock, 실연동 모드: 현재는 빈 목록).
+ * @param limit - 선택적 limit 파라미터. Builder의 기본값(50)을 사용하려면 생략한다.
+ * @returns 빌드 실행 목록(mock 모드: 결정적 mock, 실연동 모드: Builder 응답 매핑).
  */
-export async function listBuilds(): Promise<BuildRun[]> {
+export async function listBuilds(limit?: number): Promise<BuildListItem[]> {
   if (!isRealBuilderEnabled()) {
-    return mockBuilds();
+    return mockBuilds().map((run) => ({
+      id: run.id,
+      title: run.spec.title,
+      status: run.status,
+      startedAt: run.startedAt,
+      finishedAt: run.finishedAt ?? null,
+    }));
   }
 
-  // TODO(builder #250): Builder에 GET /builds가 추가되면 실제 이력을 호출·매핑한다.
-  // 그 전까지는 가짜 이력 대신 빈 목록을 반환해 실연동 모드에서 mock을 노출하지 않는다.
-  return [];
+  const response = await builderApi.listBuilds(limit);
+  return response.builds.map((summary) => ({
+    id: summary.run_id,
+    title: null, // Builder GET /builds는 title을 제공하지 않음
+    status: summary.status === "ok" ? "succeeded" : "failed",
+    startedAt: summary.started_at ?? null, // 누락 또는 null을 명시적 null로 정규화
+    finishedAt: summary.finished_at ?? null, // 누락 또는 null을 명시적 null로 정규화
+  }));
 }
 

--- a/src/features/validation/api/index.ts
+++ b/src/features/validation/api/index.ts
@@ -3,6 +3,9 @@
  *
  * 실제 Builder 연동이 켜져 있으면(`VITE_USE_REAL_BUILDER=true`) Builder `/validate`를
  * 호출하고, 아니면 mock(항상 valid)을 반환해 Studio가 독립 동작하도록 한다(#29/#37).
+ *
+ * Builder 계약상 200 정상 응답은 status="valid"만 허용된다.
+ * status="invalid"/"error"는 400 오류 응답으로 처리한다.
  */
 import { serializeSpec } from "@/features/build-spec/specMapping";
 import { ApiError, builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
@@ -33,15 +36,10 @@ export async function validateSpec(
   }
 
   try {
-    const result = await builderApi.validate(serializeSpec(spec));
-    // 2xx로 invalid/error가 올 수도 있으므로 status별로 사유를 매핑한다.
-    if (result.status === "valid") return { valid: true, errors: [] };
-    if (result.status === "invalid") {
-      return { valid: false, errors: result.problems.map(String) };
-    }
-    return { valid: false, errors: [result.error] };
+    await builderApi.validate(serializeSpec(spec));
+    return { valid: true, errors: [] };
   } catch (cause) {
-    // Builder가 검증 실패를 400 + {status:"invalid", problems}으로 돌려주는 경우도 처리한다.
+    // Builder가 검증 실패를 400 + {status:"invalid", problems}으로 돌려주는 경우를 처리한다.
     if (cause instanceof ApiError) {
       const invalid = asInvalidDetails(cause.details);
       if (invalid) return { valid: false, errors: invalid.problems };

--- a/src/pages/BuildsPage.tsx
+++ b/src/pages/BuildsPage.tsx
@@ -6,8 +6,7 @@
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { listBuilds } from "@/features/runs/api";
-import { SkeletonTable } from "@/shared/ui";
-import type { BuildRun } from "@/shared/lib/types";
+import type { BuildListItem } from "@/shared/lib/types";
 import {
   Button,
   Card,
@@ -15,24 +14,26 @@ import {
   ErrorState,
   LinkButton,
   PageHeader,
+  SkeletonTable,
   StatusBadge,
   TextInput,
 } from "@/shared/ui";
 
 interface BuildsState {
   status: "loading" | "loaded" | "error";
-  runs?: BuildRun[];
+  runs?: BuildListItem[];
   error?: string;
 }
 
-function formatTime(iso?: string): string {
+function formatTime(iso: string | null | undefined): string {
   if (!iso) return "—";
   const date = new Date(iso);
   return Number.isNaN(date.getTime()) ? iso : date.toLocaleString("ko-KR");
 }
 
-/** ISO 시작 시각을 timestamp로 정렬하기 위한 안전한 변환(파싱 실패 시 0). */
-function startedAtMillis(iso: string): number {
+/** ISO 시작 시각을 timestamp로 정렬하기 위한 안전한 변환(null이면 0으로 처리하여 나중에 정렬). */
+function startedAtMillis(iso: string | null): number {
+  if (!iso) return 0; // null인 경우 목록 끝으로 보냄
   const ms = new Date(iso).getTime();
   return Number.isNaN(ms) ? 0 : ms;
 }
@@ -71,9 +72,10 @@ export function BuildsPage() {
   const runs = state.runs;
   const visible = useMemo(() => {
     if (!runs) return [];
-    const filtered = runs.filter((run) =>
-      run.spec.title.toLowerCase().includes(query.trim().toLowerCase()),
-    );
+    const filtered = runs.filter((run) => {
+      const titleOrId = run.title ?? run.id; // title이 null이면 run ID로 검색
+      return titleOrId.toLowerCase().includes(query.trim().toLowerCase());
+    });
     return [...filtered].sort((a, b) => {
       const diff = startedAtMillis(a.startedAt) - startedAtMillis(b.startedAt);
       return newestFirst ? -diff : diff;
@@ -140,7 +142,7 @@ export function BuildsPage() {
                 key={run.id}
                 className="grid grid-cols-[1.4fr_0.7fr_0.9fr_0.7fr] items-center gap-4 border-b border-border px-6 py-3 text-sm last:border-0 "
               >
-                <span className="font-medium">{run.spec.title}</span>
+                <span className="font-medium">{run.title ?? run.id}</span>
                 <span>
                   <StatusBadge status={run.status} />
                 </span>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -8,7 +8,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { listBuilds } from "@/features/runs/api";
-import type { BuildRun, BuildRunStatus } from "@/shared/lib/types";
+import type { BuildListItem, BuildRunStatus } from "@/shared/lib/types";
 import {
   Card,
   EmptyState,
@@ -44,14 +44,15 @@ const QUICK_ACTIONS = [
   },
 ];
 
-/** ISO 시작 시각을 timestamp로 안전하게 변환한다(파싱 실패 시 0). */
-function startedAtMillis(iso: string): number {
+/** ISO 시작 시각을 timestamp로 안전하게 변환한다(null이면 0으로 처리하여 나중에 정렬). */
+function startedAtMillis(iso: string | null): number {
+  if (!iso) return 0; // null인 경우 목록 끝으로 보냄
   const ms = new Date(iso).getTime();
   return Number.isNaN(ms) ? 0 : ms;
 }
 
 /** ISO 시각을 한국어 로케일 문자열로 표시한다. */
-function formatTime(iso?: string): string {
+function formatTime(iso: string | null | undefined): string {
   if (!iso) return "—";
   const date = new Date(iso);
   return Number.isNaN(date.getTime()) ? iso : date.toLocaleString("ko-KR");
@@ -63,7 +64,7 @@ function formatTime(iso?: string): string {
  * @returns Studio 대시보드 메인 화면.
  */
 export function HomePage() {
-  const [builds, setBuilds] = useState<BuildRun[]>([]);
+  const [builds, setBuilds] = useState<BuildListItem[]>([]);
 
   useEffect(() => {
     let active = true;
@@ -127,7 +128,7 @@ export function HomePage() {
                   key={run.id}
                   className="grid grid-cols-[1.4fr_0.7fr_0.9fr_0.6fr] items-center gap-4 border-b border-border px-6 py-3 text-sm last:border-0"
                 >
-                  <span className="font-medium">{run.spec.title}</span>
+                  <span className="font-medium">{run.title ?? run.id}</span>
                   <span>
                     <StatusBadge status={run.status} />
                   </span>

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -13,6 +13,7 @@
  * Studio BuildSpec(camelCase) → Builder 스펙 매핑(#37)이 선행되어야 완전히 연결된다.
  * 이 모듈은 그 매핑이 끝난 스펙 텍스트를 받는 저수준 계약 계층이다.
  */
+import { z } from "zod";
 import { API_BASE } from "@/shared/config/env";
 
 /** Builder API 계약 버전. builder #209의 API_CONTRACT_VERSION과 일치해야 한다. */
@@ -102,7 +103,7 @@ function isTimeoutAbort(cause: unknown): boolean {
  * @returns 파싱된 응답 본문.
  * @throws ApiError 응답이 2xx가 아니거나 네트워크/파싱/타임아웃 오류가 발생한 경우.
  */
-export async function apiFetch<T>(path: string, options: RequestOptions = {}): Promise<T> {
+export async function apiFetch(path: string, options: RequestOptions = {}): Promise<unknown> {
   const {
     method = "GET",
     body,
@@ -171,7 +172,7 @@ export async function apiFetch<T>(path: string, options: RequestOptions = {}): P
     throw new ApiError(response.status, message, parsed);
   }
 
-  return parsed as T;
+  return parsed;
 }
 
 /**
@@ -206,99 +207,151 @@ export function extractErrorMessage(parsed: unknown): string | undefined {
   return undefined;
 }
 
-// --- 응답 와이어 타입 (Builder service 실제 구현 기준) ---
+// --- 성공 응답 스키마 (Builder contract 기준, Zod 런타임 검증용) ---
 
-export interface VersionResponse {
-  service: string;
-  api_version: string;
-}
+/** GET /version 응답 스키마. */
+export const VersionResponseSchema = z.object({
+  service: z.string(),
+  api_version: z.string(),
+});
 
-export type ValidateResponse =
-  | { status: "valid"; dataset_id: string; api_version: string }
-  | { status: "invalid"; problems: string[] }
-  | { status: "error"; error: string };
-
-export interface BuildOutcome {
-  source_key: string;
-  status: string;
-  stages_completed: string[];
-  error: string | null;
-}
-
-export interface BuildResponse {
-  status: string;
-  run_id: string;
-  outcomes: BuildOutcome[];
-  manifest: string;
-  api_version: string;
-}
-
-export interface ArtifactsResponse {
-  run_id: string;
-  files: string[];
-}
-
-/** /preview 응답의 소스별 컬럼 스키마 항목(service app.py 기준). */
-export interface PreviewColumn {
-  name: string;
-  dtype: string;
-  nullable: boolean;
-  unique_count: number;
-}
-
-/** /preview 응답의 소스별 미리보기 항목(service app.py 기준). */
-export interface PreviewSource {
-  source_key: string;
-  status: string;
-  error: string | null;
-  schema: PreviewColumn[];
-  sample: Record<string, unknown>[];
-  total_rows: number;
-}
+export type VersionResponse = z.infer<typeof VersionResponseSchema>;
 
 /**
- * POST /preview 응답 와이어 형태(builder service app.py 기준).
- *
- * `{ dataset_id, previews: [...] }` — 소스별로 스키마와 샘플 행을 담는다.
+ * POST /validate 성공(200) 응답 스키마.
+ * Builder 계약상 200은 status="valid"만 허용된다.
+ * invalid/error는 400 오류 응답이므로 여기 포함하지 않는다.
  */
-export interface PreviewResponse {
-  dataset_id: string;
-  previews: PreviewSource[];
+export const ValidateResponseSchema = z.object({
+  status: z.literal("valid"),
+  dataset_id: z.string(),
+  api_version: z.string(),
+});
+
+export type ValidateResponse = z.infer<typeof ValidateResponseSchema>;
+
+/** /preview 응답의 컬럼 스키마 항목. */
+export const PreviewColumnSchema = z.object({
+  name: z.string(),
+  dtype: z.string(),
+  nullable: z.boolean(),
+  unique_count: z.number().int(),
+});
+
+export type PreviewColumn = z.infer<typeof PreviewColumnSchema>;
+
+/** /preview 응답의 소스별 미리보기 항목. */
+export const PreviewSourceSchema = z.object({
+  source_key: z.string(),
+  status: z.string(),
+  error: z.string().nullable().optional(),
+  schema: PreviewColumnSchema.array(),
+  sample: z.record(z.string(), z.unknown()).array(),
+  total_rows: z.number().int(),
+});
+
+export type PreviewSource = z.infer<typeof PreviewSourceSchema>;
+
+/** POST /preview 응답 스키마. */
+export const PreviewResponseSchema = z.object({
+  dataset_id: z.string(),
+  previews: PreviewSourceSchema.array(),
+});
+
+export type PreviewResponse = z.infer<typeof PreviewResponseSchema>;
+
+/** /build 응답의 단일 소스 결과. */
+export const BuildOutcomeSchema = z.object({
+  source_key: z.string(),
+  status: z.enum(["ok", "failed"]),
+  stages_completed: z.string().array(),
+  error: z.string().nullable(),
+});
+
+export type BuildOutcome = z.infer<typeof BuildOutcomeSchema>;
+
+/**
+ * POST /build 성공(200) 응답 스키마.
+ * Builder 계약상 200은 status="ok"만 허용된다.
+ * status="failed"는 502 오류 응답이므로 여기 포함하지 않는다.
+ */
+export const BuildResponseSchema = z.object({
+  status: z.literal("ok"),
+  run_id: z.string(),
+  outcomes: BuildOutcomeSchema.array(),
+  manifest: z.string(),
+  api_version: z.string(),
+});
+
+export type BuildResponse = z.infer<typeof BuildResponseSchema>;
+
+/** GET /artifacts/{run_id} 응답 스키마. */
+export const ArtifactsResponseSchema = z.object({
+  run_id: z.string(),
+  files: z.string().array(),
+});
+
+export type ArtifactsResponse = z.infer<typeof ArtifactsResponseSchema>;
+
+/** GET /builds 응답의 단일 빌드 요약. */
+export const BuildSummarySchema = z.object({
+  run_id: z.string(),
+  status: z.enum(["ok", "failed"]),
+  started_at: z.string().nullable().optional(),
+  finished_at: z.string().nullable().optional(),
+});
+
+export type BuildSummary = z.infer<typeof BuildSummarySchema>;
+
+/** GET /builds 응답 스키마. */
+export const BuildsResponseSchema = z.object({
+  builds: BuildSummarySchema.array(),
+});
+
+export type BuildsResponse = z.infer<typeof BuildsResponseSchema>;
+
+// --- 내부 helper: 성공 응답 파싱 with Zod 검증 ---
+
+/**
+ * apiFetch를 호출하고 응답을 Zod 스키마로 파싱/검증한다.
+ * @internal (export for testing only)
+ */
+async function apiFetchParsed<T>(
+  path: string,
+  schema: z.ZodType<T>,
+  options: RequestOptions = {},
+): Promise<T> {
+  const response = await apiFetch(path, options);
+  return schema.parse(response);
 }
 
-/** GET /builds 응답의 단일 빌드 요약(builder contract BuildSummary 기준). */
-export interface BuildSummary {
-  /** 빌드 실행 식별자 */
-  run_id: string;
-  /** 빌드 상태("ok" | "failed") */
-  status: "ok" | "failed";
-  /** 빌드 시작 시각(ISO 8601, null, 또는 생략됨) */
-  started_at?: string | null;
-  /** 빌드 완료 시각(ISO 8601, null, 또는 생략됨) */
-  finished_at?: string | null;
-}
-
-/** GET /builds 응답 와이어 형태(builder contract BuildsResponse 기준). */
-export interface BuildsResponse {
-  builds: BuildSummary[];
-}
+// --- Builder service 엔드포인트 클라이언트 ---
 
 /** Builder service 엔드포인트를 감싼 클라이언트. */
 export const builderApi = {
   /** GET /version — 계약 버전 확인(메타). */
-  version: (signal?: AbortSignal) => apiFetch<VersionResponse>("/version", { signal }),
+  version: (signal?: AbortSignal) =>
+    apiFetchParsed("/version", VersionResponseSchema, { signal }),
 
   /** POST /validate — BuildSpec YAML 검증. */
   validate: (specYaml: string, signal?: AbortSignal) =>
-    apiFetch<ValidateResponse>("/validate", { method: "POST", body: { spec: specYaml }, signal }),
+    apiFetchParsed("/validate", ValidateResponseSchema, {
+      method: "POST",
+      body: { spec: specYaml },
+      signal,
+    }),
 
   /** POST /preview — BuildSpec 기반 샘플 미리보기. */
   preview: (specYaml: string, signal?: AbortSignal) =>
-    apiFetch<PreviewResponse>("/preview", { method: "POST", body: { spec: specYaml }, signal }),
+    apiFetchParsed("/preview", PreviewResponseSchema, {
+      method: "POST",
+      body: { spec: specYaml },
+      signal,
+    }),
 
   /** POST /build — 빌드 실행. run_id 생략 가능. 비멱등 요청이므로 재시도하지 않는다 (#117). */
   build: (specYaml: string, runId?: string, signal?: AbortSignal) =>
-    apiFetch<BuildResponse>("/build", {
+    apiFetchParsed("/build", BuildResponseSchema, {
       method: "POST",
       body: runId ? { spec: specYaml, run_id: runId } : { spec: specYaml },
       signal,
@@ -307,11 +360,11 @@ export const builderApi = {
 
   /** GET /artifacts/{runId} — 실행 산출물 파일 목록. */
   artifacts: (runId: string, signal?: AbortSignal) =>
-    apiFetch<ArtifactsResponse>(`/artifacts/${encodeURIComponent(runId)}`, { signal }),
+    apiFetchParsed(`/artifacts/${encodeURIComponent(runId)}`, ArtifactsResponseSchema, { signal }),
 
   /** GET /builds — 빌드 이력 목록(#153, builder #250). */
   listBuilds: (limit?: number, signal?: AbortSignal) => {
     const query = limit !== undefined ? `?limit=${limit}` : "";
-    return apiFetch<BuildsResponse>(`/builds${query}`, { signal });
+    return apiFetchParsed(`/builds${query}`, BuildsResponseSchema, { signal });
   },
 };

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -266,6 +266,23 @@ export interface PreviewResponse {
   previews: PreviewSource[];
 }
 
+/** GET /builds 응답의 단일 빌드 요약(builder contract BuildSummary 기준). */
+export interface BuildSummary {
+  /** 빌드 실행 식별자 */
+  run_id: string;
+  /** 빌드 상태("ok" | "failed") */
+  status: "ok" | "failed";
+  /** 빌드 시작 시각(ISO 8601, null, 또는 생략됨) */
+  started_at?: string | null;
+  /** 빌드 완료 시각(ISO 8601, null, 또는 생략됨) */
+  finished_at?: string | null;
+}
+
+/** GET /builds 응답 와이어 형태(builder contract BuildsResponse 기준). */
+export interface BuildsResponse {
+  builds: BuildSummary[];
+}
+
 /** Builder service 엔드포인트를 감싼 클라이언트. */
 export const builderApi = {
   /** GET /version — 계약 버전 확인(메타). */
@@ -291,4 +308,10 @@ export const builderApi = {
   /** GET /artifacts/{runId} — 실행 산출물 파일 목록. */
   artifacts: (runId: string, signal?: AbortSignal) =>
     apiFetch<ArtifactsResponse>(`/artifacts/${encodeURIComponent(runId)}`, { signal }),
+
+  /** GET /builds — 빌드 이력 목록(#153, builder #250). */
+  listBuilds: (limit?: number, signal?: AbortSignal) => {
+    const query = limit !== undefined ? `?limit=${limit}` : "";
+    return apiFetch<BuildsResponse>(`/builds${query}`, { signal });
+  },
 };

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -161,3 +161,23 @@ export interface BuildRun {
   /** 실행 종료 시각 ISO 문자열 */
   finishedAt?: string;
 }
+
+/**
+ * 빌드 이력 목록용 최소 표현 타입(#153).
+ *
+ * Builder GET /builds가 spec/title을 제공하지 않으므로, 이들을 null로 가지고
+ * UI에서는 run ID를 대신 표시한다. 실제 BuildSpec이 필요한 상세 화면으로 진입하면
+ * 그때 개별 조회로 전체 스펙을 가져온다.
+ */
+export interface BuildListItem {
+  /** 실행 이력 항목 고유 ID */
+  id: string;
+  /** 빌드 제목(Builder에서 제공하지 않으므로 실연동 시 null, mock 시 실제 title) */
+  title: string | null;
+  /** 현재 실행 상태 */
+  status: BuildRunStatus;
+  /** 실행 시작 시각 ISO 문자열(Builder에서 null이면 null 유지) */
+  startedAt: string | null;
+  /** 실행 종료 시각 ISO 문자열(Builder에서 null이거나 누락이면 null) */
+  finishedAt: string | null;
+}


### PR DESCRIPTION
## 요약

Builder API의 2xx 정상 응답을 TypeScript 타입 단언으로만 처리하던 방식을 Zod 기반 런타임 검증으로 변경합니다.

기존 `apiFetch<T>()`의 `return parsed as T`를 제거하고, 각 Builder API 메서드가 자신의 응답 스키마를 사용해 파싱하도록 구성했습니다. 응답 구조가 계약과 다르면 UI까지 잘못된 데이터가 전달되지 않고 API 경계에서 `ZodError`가 발생합니다.

## 선행 PR

* Depends on #174
* 이 PR은 #174의 `feat/issue-153-list-builds-real-api` 브랜치 위에서 작업한 stacked PR입니다.
* #174가 머지되기 전까지 PR base는 `feat/issue-153-list-builds-real-api`로 유지합니다.
* #174 머지 후 최신 `main`으로 rebase하고 PR base를 `main`으로 변경합니다.

## 변경 내용

### Zod 응답 스키마 추가

다음 Builder 정상 응답에 대한 Zod 스키마를 정의했습니다.

* `GET /version`
* `POST /validate`
* `POST /preview`
* `POST /build`
* `GET /artifacts/{run_id}`
* `GET /builds`

Zod 스키마에서 TypeScript 타입을 `z.infer`로 도출하여 런타임 스키마와 정적 타입이 별도로 드리프트하지 않도록 했습니다.

### API 응답 파싱 구조 변경

* `apiFetch()`는 HTTP 처리와 JSON 파싱 후 `unknown` 반환
* 내부 `apiFetchParsed()`가 엔드포인트별 Zod 스키마로 정상 응답 검증
* 기존 `apiFetch<T>()` generic 타입 단언 제거
* 알 수 없는 추가 필드는 허용하여 하위 호환 가능한 Builder 필드 추가를 차단하지 않음

### Builder 계약 정렬

Builder OpenAPI 계약을 기준으로 정상 응답을 정렬했습니다.

* `/validate` 200 응답은 `status: "valid"`만 허용
* `/build` 200 응답은 `status: "ok"`만 허용
* Preview의 `unique_count`, `total_rows`는 정수로 검증
* Build outcome 상태는 `ok | failed`로 제한
* Build 목록 timestamp는 기존처럼 optional 및 nullable 유지

### Validation 처리 정리

`builderApi.validate()`가 정상 반환되면 유효한 스펙으로 처리하도록 단순화했습니다.

Builder가 반환하는 400 `{ status: "invalid", problems: [...] }` 응답은 기존 `ApiError.details` 처리 방식을 유지합니다.

## 오류 응답 검증 범위

이번 PR은 Issue #158의 정상 응답 검증만 포함합니다.

다음 항목은 후속 Issue #159에서 처리합니다.

* 400·401·404·502 오류 응답 Zod 스키마
* `ApiError.details` 런타임 검증
* Zod 검증 실패를 사용자용 `ApiError`로 변환
* 오류 응답 메시지 및 표시 방식 정리
* `extractErrorMessage()` 리팩터링

## 테스트

추가하거나 정렬한 주요 테스트:

* 각 정상 응답 스키마 파싱
* `/version` 필수 필드 누락 거부
* `/validate`의 잘못된 200 `invalid/error` 응답 거부
* `/preview` 계약 불일치 응답 거부
* `/build`의 필수 필드 누락 및 잘못된 성공 상태 거부
* `/artifacts`의 잘못된 files 타입 거부
* `/builds` 필수 필드 및 상태값 검증
* Build 목록 timestamp가 null이거나 생략된 경우의 회귀 테스트
* 기존 HTTP 오류, network 오류, timeout, retry 동작 유지

## 검증

* [x] `git diff --check`
* [x] `npm test` — 35 files, 154 tests passed
* [x] `npm run typecheck`
* [x] `npm run lint`
* [x] `npm run build`

## 변경 파일

* `src/shared/lib/builderApi.ts`
* `src/features/validation/api/index.ts`
* `__tests__/builderApi.test.ts`
* `__tests__/builderApiTimeout.test.ts`
* `__tests__/validationApi.test.ts`

## 관련 이슈

Closes #158
Refs #103
Refs #152
Depends on #174
