### PR TITLE
test: add real Builder HTTP integration harness (#160)

### DIFF
--- a/.github/workflows/builder-integration.yml
+++ b/.github/workflows/builder-integration.yml
@@ -1,0 +1,71 @@
+# Builder HTTP E2E 통합 테스트 CI (#160).
+#
+# 실제 kpubdata-builder Docker 컨테이너를 기동하고
+# Studio의 builderApi와 HTTP 통신하는 통합 테스트를 실행한다.
+#
+# - workflow_dispatch로 수동 실행 가능
+# - 관련 파일이 변경된 PR에서 자동 실행
+# - Docker build/run 실제 수행
+# - 별도 secret 불필요 (KPUBDATA_BUILDER_DEV_MODE 사용)
+
+name: Builder Integration Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/shared/lib/builderApi.ts"
+      - "src/shared/config/env.ts"
+      - "__tests__/integration/**"
+      - "scripts/run-builder-integration.sh"
+      - "docker-compose.integration.yml"
+      - "vitest.integration.config.ts"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/builder-integration.yml"
+
+# 최소 권한: 코드 읽기만 필요
+permissions:
+  contents: read
+
+# 동시 실행 취소
+concurrency:
+  group: builder-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    name: Builder HTTP E2E
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Studio
+        uses: actions/checkout@v7
+        with:
+          path: studio
+
+      - name: Checkout Builder
+        uses: actions/checkout@v7
+        with:
+          repository: yeongseon/kpubdata-builder
+          ref: main
+          path: kpubdata-builder
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: studio/package-lock.json
+
+      - name: Install dependencies
+        working-directory: studio
+        run: npm ci
+
+      - name: Run Builder integration tests
+        working-directory: studio
+        run: npm run test:integration:builder:docker
+        env:
+          # Studio와 Builder가 형제 디렉터리에 있으므로 기본값 사용
+          KPUBDATA_BUILDER_CONTEXT: ../kpubdata-builder

--- a/__tests__/integration/builderHttp.e2e.ts
+++ b/__tests__/integration/builderHttp.e2e.ts
@@ -1,0 +1,112 @@
+/**
+ * Builder HTTP E2E 통합 테스트 (#160).
+ *
+ * 실제 Builder Docker 컨테이너와 HTTP 통신하는 테스트.
+ * Studio의 builderApi를 통해 실제 요청을 전송하고 응답을 검증한다.
+ *
+ * 이 테스트는 다음을 요구한다:
+ * - Builder Docker 컨테이너가 실행 중이어야 함
+ * - VITE_BUILDER_API_URL이 Builder endpoint를 가리켜야 함
+ * - VITE_USE_REAL_BUILDER=true 여야 함
+ *
+ * 실행 방법:
+ *   npm run test:integration:builder:docker
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { ApiError, builderApi, API_CONTRACT_VERSION } from "@/shared/lib/builderApi";
+
+// Builder API URL 환경변수 확인
+const BUILDER_URL = import.meta.env.VITE_BUILDER_API_URL;
+const USE_REAL_BUILDER = import.meta.env.VITE_USE_REAL_BUILDER;
+
+if (!BUILDER_URL || USE_REAL_BUILDER !== "true") {
+  throw new Error(
+    "Integration test requires VITE_BUILDER_API_URL and VITE_USE_REAL_BUILDER=true",
+  );
+}
+
+describe("Builder HTTP E2E (#160)", () => {
+  // 실패해도 결정적인 동작을 위한 고유 run ID
+  const runId = `studio-e2e-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  // 외부 의존 없이 결정적으로 실패하는 BuildSpec
+  const specYaml = `dataset_id: integration.offline
+title: Offline integration fixture
+description: Deterministic Builder HTTP integration fixture
+sources:
+  - provider: __integration_missing_provider__
+    dataset: __integration_missing_dataset__
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+`;
+
+  beforeAll(() => {
+    console.log(`E2E test run ID: ${runId}`);
+    console.log(`Builder URL: ${BUILDER_URL}`);
+  });
+
+  it("GET /version - 계약 버전 확인", async () => {
+    const version = await builderApi.version();
+
+    expect(version.service).toBe("kpubdata-builder");
+    expect(version.api_version).toBe(API_CONTRACT_VERSION);
+  });
+
+  it("POST /validate - 구조 검증 통과", async () => {
+    const validated = await builderApi.validate(specYaml);
+
+    expect(validated).toEqual({
+      status: "valid",
+      dataset_id: "integration.offline",
+      api_version: API_CONTRACT_VERSION,
+    });
+  });
+
+  it("POST /build - 존재하지 않는 source로 502 실패", async () => {
+    // Builder 계약: 실패 시 HTTP 502 + BuildFailureResponse 반환
+    // Studio는 이를 ApiError(502)로 받아야 함
+
+    const error = await builderApi.build(specYaml, runId).catch((cause) => cause);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(502);
+
+    const details = (error as ApiError).details;
+    expect(details).toBeDefined();
+    expect(typeof details).toBe("object");
+
+    // BuildFailureResponse 구조 검증
+    expect((details as { status?: string }).status).toBe("failed");
+    expect((details as { run_id?: string }).run_id).toBe(runId);
+    expect((details as { outcomes?: unknown[] }).outcomes).toBeDefined();
+    expect(Array.isArray((details as { outcomes?: unknown[] }).outcomes)).toBe(true);
+
+    // 실패한 source가 outcomes에 존재해야 함
+    const outcomes = (details as { outcomes?: Array<{ source_key?: string; status?: string }> }).outcomes || [];
+    const failedSource = outcomes.find((o) => o.source_key === "__integration_missing_provider__.__integration_missing_dataset__");
+    expect(failedSource).toBeDefined();
+    expect(failedSource?.status).toBe("failed");
+  });
+
+  it("GET /artifacts/{run_id} - partial manifest 조회", async () => {
+    // build 실패 후에도 partial manifest가 존재해야 함
+    const artifacts = await builderApi.artifacts(runId);
+
+    expect(artifacts.run_id).toBe(runId);
+    expect(Array.isArray(artifacts.files)).toBe(true);
+    // partial manifest가 있어야 함
+    expect(artifacts.files).toContain("manifest.json");
+  });
+
+  it("GET /builds - 빌드 이력 목록에 실패 run 포함", async () => {
+    const builds = await builderApi.listBuilds();
+
+    expect(Array.isArray(builds.builds)).toBe(true);
+
+    // 생성한 run_id가 목록에 존재해야 함
+    const ourBuild = builds.builds.find((b) => b.run_id === runId);
+    expect(ourBuild).toBeDefined();
+    expect(ourBuild?.status).toBe("failed");
+  });
+});

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -1,0 +1,41 @@
+# Builder HTTP E2E 통합 테스트용 Docker Compose 설정 (#160).
+#
+# Studio의 builderApi가 실제 Builder 컨테이너와 HTTP 통신하는 흐름을 검증한다.
+# 로컬 개발과 CI에서 모두 사용 가능하며, 별도의 Compose project로 격리한다.
+
+name: kpubdata-studio-e2e
+
+services:
+  builder:
+    build:
+      context: ${KPUBDATA_BUILDER_CONTEXT:-../kpubdata-builder}
+      dockerfile: Dockerfile
+    environment:
+      # 로컬 무인증 모드 (service/app.py의 _DEV_MODE_ENV)
+      # docker-entrypoint.sh에서도 KPUBDATA_BUILDER_DEV를 체크하므로 둘 다 설정
+      KPUBDATA_BUILDER_DEV: "1"
+      KPUBDATA_BUILDER_DEV_MODE: "1"
+      # 빌드 산출물 출력 디렉터리
+      KPUBDATA_BUILDER_OUTPUT_DIR: /data
+      # 서버 바인딩 (기본 0.0.0.0)
+      KPUBDATA_BUILDER_HOST: 0.0.0.0
+      # 내부 포트 (기본 8000)
+      KPUBDATA_BUILDER_PORT: "8000"
+    ports:
+      # 호스트 포트: 충돌 방지를 위해 18000 사용 (환경변수로 재정의 가능)
+      - "${KPUBDATA_BUILDER_E2E_PORT:-18000}:8000"
+    volumes:
+      # 테스트 전용 named volume (테스트 종료 시 제거)
+      - builder-e2e-data:/data
+    healthcheck:
+      # readiness 확인용 healthcheck
+      test: ["CMD", "curl", "-f", "http://localhost:8000/version"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+    container_name: kpubdata-builder-e2e
+
+volumes:
+  builder-e2e-data:
+    # 테스트별로 격리된 볼륨 (cleanup 필요 시 이름으로 제거)

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -27,14 +27,6 @@ services:
     volumes:
       # 테스트 전용 named volume (테스트 종료 시 제거)
       - builder-e2e-data:/data
-    healthcheck:
-      # readiness 확인용 healthcheck
-      test: ["CMD", "curl", "-f", "http://localhost:8000/version"]
-      interval: 2s
-      timeout: 5s
-      retries: 30
-      start_period: 10s
-    container_name: kpubdata-builder-e2e
 
 volumes:
   builder-e2e-data:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "screenshots": "node scripts/capture-screenshots.mjs"
+    "screenshots": "node scripts/capture-screenshots.mjs",
+    "test:integration:builder": "vitest run --config vitest.integration.config.ts",
+    "test:integration:builder:docker": "sh scripts/run-builder-integration.sh"
   },
   "dependencies": {
     "react": "19.2.8",

--- a/scripts/run-builder-integration.sh
+++ b/scripts/run-builder-integration.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+# Builder HTTP E2E 통합 테스트 실행 스크립트 (#160).
+#
+# Builder Docker 컨테이너를 기동하고 readiness 확인 후 Vitest 통합 테스트를 실행한다.
+# 테스트 성공·실패와 관계없이 cleanup을 수행하며, 실패 시 Builder 로그를 출력한다.
+# Ctrl+C로 중단해도 cleanup이 수행된다.
+
+set -eu
+
+# 색상 출력
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# 기본값
+BUILDER_CONTEXT="${KPUBDATA_BUILDER_CONTEXT:-../kpubdata-builder}"
+E2E_PORT="${KPUBDATA_BUILDER_E2E_PORT:-18000}"
+COMPOSE_PROJECT_NAME="kpubdata-studio-e2e"
+COMPOSE_FILE="docker-compose.integration.yml"
+
+echo "=== Builder HTTP E2E 통합 테스트 ==="
+echo "Builder context: ${BUILDER_CONTEXT}"
+echo "E2E port: ${E2E_PORT}"
+echo ""
+
+# Docker 확인
+if ! command -v docker >/dev/null 2>&1; then
+    echo "${RED}Error: Docker가 설치되지 않았습니다.${NC}" >&2
+    exit 1
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+    echo "${RED}Error: Docker Compose가 설치되지 않았습니다.${NC}" >&2
+    exit 1
+fi
+
+# Builder context 확인
+if [ ! -d "${BUILDER_CONTEXT}" ]; then
+    echo "${RED}Error: Builder context 디렉터리가 존재하지 않습니다: ${BUILDER_CONTEXT}${NC}" >&2
+    echo "KPUBDATA_BUILDER_CONTEXT 환경변수로 Builder 경로를 지정하세요." >&2
+    exit 1
+fi
+
+if [ ! -f "${BUILDER_CONTEXT}/Dockerfile" ]; then
+    echo "${RED}Error: Builder Dockerfile이 존재하지 않습니다: ${BUILDER_CONTEXT}/Dockerfile${NC}" >&2
+    exit 1
+fi
+
+# trap 설정: 항상 cleanup 수행
+cleanup() {
+    EXIT_CODE=$?
+    if [ ${EXIT_CODE} -ne 0 ]; then
+        echo "${YELLOW}테스트 실패. Builder 로그를 출력합니다...${NC}"
+        docker compose -f "${COMPOSE_FILE}" -p "${COMPOSE_PROJECT_NAME}" logs builder || true
+    fi
+    echo ""
+    echo "=== Cleanup ==="
+    docker compose -f "${COMPOSE_FILE}" -p "${COMPOSE_PROJECT_NAME}" down --remove-orphans -v
+    echo "${GREEN}Cleanup 완료${NC}"
+    exit ${EXIT_CODE}
+}
+
+trap cleanup EXIT INT TERM
+
+# 기존 컨테이너 정리
+echo "기존 컨테이너 정리 중..."
+docker compose -f "${COMPOSE_FILE}" -p "${COMPOSE_PROJECT_NAME}" down --remove-orphans -v 2>/dev/null || true
+
+# Builder 이미지 빌드 및 컨테이너 기동
+echo "Builder 이미지 빌드 및 컨테이너 기동 중..."
+docker compose -f "${COMPOSE_FILE}" -p "${COMPOSE_PROJECT_NAME}" up -d --build
+
+# readiness polling (healthcheck 대신 curl로 직접 확인)
+echo "Builder readiness 확인 중..."
+MAX_WAIT=60
+WAITED=0
+READY=0
+
+while [ ${WAITED} -lt ${MAX_WAIT} ]; do
+    if curl -s -f "http://127.0.0.1:${E2E_PORT}/version" >/dev/null 2>&1; then
+        READY=1
+        break
+    fi
+    sleep 2
+    WAITED=$((WAITED + 2))
+    echo -n "."
+done
+
+echo ""
+
+if [ ${READY} -eq 0 ]; then
+    echo "${RED}Error: Builder가 ${MAX_WAIT}초 내에 준비되지 않았습니다.${NC}" >&2
+    exit 1
+fi
+
+echo "${GREEN}Builder 준비 완료 (port ${E2E_PORT})${NC}"
+
+# 환경변수 설정하여 Vitest 실행
+echo ""
+echo "=== Vitest 통합 테스트 실행 ==="
+export VITE_BUILDER_API_URL="http://127.0.0.1:${E2E_PORT}"
+export VITE_USE_REAL_BUILDER="true"
+
+# npx를 사용하여 vitest 실행 (node_modules 없어도 동작하도록)
+npx vitest run --config vitest.integration.config.ts
+
+echo "${GREEN}=== 통합 테스트 완료 ===${NC}"

--- a/scripts/run-builder-integration.sh
+++ b/scripts/run-builder-integration.sh
@@ -84,7 +84,7 @@ while [ ${WAITED} -lt ${MAX_WAIT} ]; do
     fi
     sleep 2
     WAITED=$((WAITED + 2))
-    echo -n "."
+    printf "."
 done
 
 echo ""

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,36 @@
+/**
+ * Vitest 통합 테스트 설정 (#160).
+ *
+ * 실제 Builder Docker 컨테이너와 HTTP 통신하는 E2E 테스트를 위한 별도 설정.
+ * 일반 unit 테스트(vitest.config.ts)와 분리되어 있어 `npm test`에서 실행되지 않는다.
+ */
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  // 통합 테스트는 Node 환경에서 실행 (jsdom 불필요)
+  test: {
+    // 테스트 파일이 아닌 파일은 제외
+    exclude: ["node_modules", "dist"],
+    // 통합 테스트만 포함 (기본 Vitest와 분리)
+    include: ["__tests__/integration/**/*.e2e.ts"],
+    environment: "node",
+    // 충분한 timeout (Docker 컨테이너 기동 등)
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    // 단일 스레드 실행 (순서 보장)
+    pool: "forks",
+    fileParallelism: false,
+    // 별도의 setup 파일 불필요 (jsdom 설정 없음)
+    setupFiles: [],
+    // coverage는 integration에서 비활성화 (unit 테스트에서만)
+    coverage: { enabled: false },
+  },
+
+  // 경로 별칭 (vite.config.ts와 동일하게 유지)
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## 요약

실제 `kpubdata-builder` Docker 컨테이너를 대상으로 Studio의 HTTP 클라이언트 경로를 검증하는 통합 테스트 하네스를 추가합니다.

MSW나 fetch mock을 사용하지 않고, Studio의 `builderApi`가 실제 TCP/HTTP 요청을 전송해 Builder 응답을 처리하는 전체 경로를 검증합니다.

```text
Vitest
→ Studio builderApi
→ global fetch
→ TCP/HTTP
→ Builder Docker container
→ Builder HTTP service
→ JSON response
→ Studio builderApi
```

## 선행 PR

- Depends on #174
- 이 PR은 `feat/issue-153-list-builds-real-api`를 base로 한 stacked PR입니다.
- 현재 Files changed에는 #160 범위의 2개 커밋과 6개 파일만 표시됩니다.
- #174 머지 후 base를 `main`으로 변경할 예정입니다.

## 변경 내용

### 실제 Builder 통합 테스트 환경

* 통합 테스트 전용 Docker Compose 구성 추가
* Builder 저장소를 Docker build context로 사용
* 기본 Builder 경로: `../kpubdata-builder`
* 기본 테스트 포트: `18000`
* 무인증 개발 모드로 Builder 실행
* 테스트 전용 named volume 사용
* Compose project 기반 컨테이너 이름 자동 생성
* Builder 경로와 포트를 환경변수로 재정의 가능

지원 환경변수:

```text
KPUBDATA_BUILDER_CONTEXT
KPUBDATA_BUILDER_E2E_PORT
```

### 실행 스크립트

`scripts/run-builder-integration.sh`에서 다음 과정을 자동화합니다.

1. Docker 및 Docker Compose 확인
2. Builder context와 Dockerfile 확인
3. 기존 테스트 리소스 정리
4. Builder 이미지 빌드 및 컨테이너 기동
5. `GET /version` readiness polling
6. Vitest 통합 테스트 실행
7. 실패 시 Builder 로그 출력
8. 성공·실패·중단 여부와 관계없이 컨테이너와 볼륨 정리

### 전용 Vitest 설정

* 일반 단위 테스트와 통합 테스트 분리
* Node 환경 사용
* `__tests__/integration/**/*.e2e.ts`만 실행
* jsdom과 기존 setup 파일 미사용
* 파일 병렬 실행 비활성화
* 일반 `npm test`에는 포함되지 않음

추가 명령:

```bash
npm run test:integration:builder
npm run test:integration:builder:docker
```

### 실제 HTTP E2E 시나리오

외부 공공데이터 API나 API key 없이 결정적으로 실행 가능한 BuildSpec을 사용합니다.

1. `GET /version`

   * Builder 서비스명 확인
   * API 계약 버전 확인

2. `POST /validate`

   * BuildSpec 구조 검증 성공
   * `status: "valid"` 확인

3. `POST /build`

   * 존재하지 않는 source로 실제 build 실행
   * HTTP 502 응답 확인
   * Studio의 `ApiError(502)` 변환 확인
   * 실패 source outcome 확인

4. `GET /artifacts/{run_id}`

   * 실패 build의 partial manifest 확인

5. `GET /builds`

   * 생성한 실패 run이 빌드 이력에 포함되는지 확인
   * 상태가 `failed`인지 확인

### GitHub Actions

실제 Builder 통합 테스트 전용 workflow를 추가했습니다.

* `workflow_dispatch` 지원
* 관련 파일이 변경된 PR에서 자동 실행
* Node.js 22 사용
* Studio와 Builder를 형제 디렉터리로 checkout
* Builder Docker 이미지 실제 빌드 및 실행
* 별도 secret이나 외부 API key 불필요
* 기존 일반 CI와 분리

## PR #170과의 범위 차이

PR #170은 MSW로 Builder 응답을 모의합니다.

이번 PR은 실제 Builder Docker 컨테이너와 통신합니다.

| 구분         | PR #170      | 이번 PR          |
| ---------- | ------------ | -------------- |
| Builder 실행 | 없음           | 실제 Docker 컨테이너 |
| HTTP 응답    | MSW 모의 응답    | 실제 Builder 응답  |
| 네트워크       | 요청 intercept | 실제 TCP/HTTP    |
| 외부 API     | 없음           | 없음             |
| CI 의존성     | Node         | Node + Docker  |

## 변경 파일

* `.github/workflows/builder-integration.yml`
* `__tests__/integration/builderHttp.e2e.ts`
* `docker-compose.integration.yml`
* `package.json`
* `scripts/run-builder-integration.sh`
* `vitest.integration.config.ts`

## 검증

* [x] `git diff --check`
* [x] `npm test` — 35 files, 144 tests passed
* [x] `npm run typecheck`
* [x] `npm run lint`
* [x] `npm run build`
* [x] `docker compose -f docker-compose.integration.yml config`
* [x] `npm run test:integration:builder:docker` — 1 file, 5 tests passed
* [x] 실제 `/build` HTTP 502 응답 확인
* [x] partial manifest 조회 확인
* [x] 실패 run의 빌드 이력 조회 확인
* [x] 테스트 종료 후 컨테이너·볼륨·네트워크 정리 확인
* [x] UI 변경 없음 — 스크린샷 해당 없음

## 관련 이슈

Closes #160
Refs #104
Refs #152
Depends on #174
