### PR TITLE
fix: complete Build Detail data rendering (#155)

### DIFF
--- a/__tests__/buildRoutes.test.tsx
+++ b/__tests__/buildRoutes.test.tsx
@@ -28,18 +28,24 @@ describe("build-centric routes", () => {
       // 조회된 스펙의 제목이 표시되고,
       expect(screen.getByRole("heading", { name: "대기오염 정보" })).toBeInTheDocument();
     });
-    // 어떤 실행인지 식별할 수 있도록 run id도 함께 노출된다.
-    expect(screen.getByText(/air-quality-20260621/)).toBeInTheDocument();
+    // 어떤 실행인지 식별할 수 있도록 run id도 함께 노출된다(eyebrow 영역).
+    expect(screen.getByText(/빌드 상세 · air-quality-20260621/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /편집/ })).toHaveAttribute(
       "href",
       "/builds/air-quality-20260621/edit",
     );
+    // Manifest 요약이 비동기로 표시된다(#155).
+    expect(await screen.findByText("Manifest 요약")).toBeInTheDocument();
+    // mock manifest의 artifact 파일명이 표시된다(#155). air-quality는 parquet를 export한다.
+    expect(screen.getByText("data.parquet")).toBeInTheDocument();
   });
 
   it("shows an error instead of placeholder data for an unknown buildId", async () => {
     renderAt("/builds/does-not-exist", <BuildDetailPage />);
     // 존재하지 않는 빌드를 실제 데이터처럼 보여주면 안 된다 (#119, #120).
     expect(await screen.findByText(/빌드를 찾을 수 없습니다/)).toBeInTheDocument();
+    // 존재하지 않는 build가 성공 상태로 렌더링되지 않아야 한다(#155).
+    expect(screen.queryByText(/Manifest 요약/)).not.toBeInTheDocument();
   });
 
   it("renders the run page with progress steps", () => {

--- a/src/features/runs/api/getBuild.ts
+++ b/src/features/runs/api/getBuild.ts
@@ -44,13 +44,4 @@ export async function getBuild(buildId: string): Promise<BuildRun> {
     );
   }
   throw new Error(`빌드를 찾을 수 없습니다: ${buildId}`);
-
-  if (isRealBuilderEnabled()) {
-    // 실연동 모드에서 목록이 비어 있는 원인은 Builder `GET /builds` 미연동이다(#102).
-    // 사용자가 "존재하지 않는 빌드"로 오해하지 않도록 원인을 드러낸다.
-    throw new Error(
-      `빌드를 찾을 수 없습니다: ${buildId}. Builder 이력 목록 연동(#102) 이후 조회할 수 있습니다.`,
-    );
-  }
-  throw new Error(`빌드를 찾을 수 없습니다: ${buildId}`);
 }

--- a/src/features/runs/api/getBuild.ts
+++ b/src/features/runs/api/getBuild.ts
@@ -34,11 +34,16 @@ export async function getBuild(buildId: string): Promise<BuildRun> {
     return storedSpec ? { ...build, spec: storedSpec } : build;
   }
 
-  // 목록에 없지만 스펙이 보관돼 있는 경우(방금 실행한 빌드, 또는 실연동 모드에서 이력
-  // 목록 연동이 아직 없는 상황). 실행 상태는 알 수 없으므로 지어내지 않는다.
-  if (storedSpec) {
-    return { id: buildId, spec: storedSpec, status: "succeeded" as const, startedAt: "" };
+  // 목록에 없으면 실제 실행 이력이 없는 것이다. 스펙만 저장돼 있다고 해서 성공 상태를
+  // 지어내면 안 된다(#155).
+  if (isRealBuilderEnabled()) {
+    // 실연동 모드에서 목록이 비어 있는 원인은 Builder `GET /builds` 미연동이다(#102).
+    // 사용자가 "존재하지 않는 빌드"로 오해하지 않도록 원인을 드러낸다.
+    throw new Error(
+      `빌드를 찾을 수 없습니다: ${buildId}. Builder 이력 목록 연동(#102) 이후 조회할 수 있습니다.`,
+    );
   }
+  throw new Error(`빌드를 찾을 수 없습니다: ${buildId}`);
 
   if (isRealBuilderEnabled()) {
     // 실연동 모드에서 목록이 비어 있는 원인은 Builder `GET /builds` 미연동이다(#102).

--- a/src/pages/BuildDetailPage.tsx
+++ b/src/pages/BuildDetailPage.tsx
@@ -147,33 +147,45 @@ export function BuildDetailPage() {
               <div>
                 <dt className="text-muted-foreground">레코드 수</dt>
                 <dd className="text-foreground">
-                  {manifestState.manifest.row_counts && Object.keys(manifestState.manifest.row_counts).length > 0
-                    ? Object.values(manifestState.manifest.row_counts)
-                        .reduce((sum, count) => sum + count, 0)
-                        .toLocaleString("ko-KR")
-                    : "미제공"}
+                  {manifestState.manifest.row_counts === undefined
+                  ? "미제공"
+                  : Object.values(manifestState.manifest.row_counts)
+                  .reduce((sum, count) => sum + count, 0)
+                  .toLocaleString("ko-KR")}
                 </dd>
               </div>
               <div>
                 <dt className="text-muted-foreground">데이터 소스</dt>
                 <dd className="text-foreground">
-                  {manifestState.manifest.provenance && manifestState.manifest.provenance.length > 0
-                    ? manifestState.manifest.provenance
-                        .map((p) => `${p.provider}.${p.dataset}`)
-                        .join(", ")
-                    : "미제공"}
+                {manifestState.manifest.provenance === undefined
+                ? "미제공"
+                : manifestState.manifest.provenance.length === 0
+                ? "소스 없음"
+                : manifestState.manifest.provenance
+                .map((provenance) => `${provenance.provider}.${provenance.dataset}`)
+                .join(", ")}
                 </dd>
               </div>
               <div>
                 <dt className="text-muted-foreground">생성 파일 수</dt>
                 <dd className="text-foreground">
-                  {manifestState.manifest.outputs?.length ?? 0}
+                {manifestState.manifest.outputs === undefined
+                ? "미제공"
+                : manifestState.manifest.outputs.length}
                 </dd>
               </div>
             </dl>
           </Card>
 
-          {manifestState.manifest.outputs && manifestState.manifest.outputs.length > 0 && (
+          {manifestState.manifest.outputs === undefined ? (
+            <Card variant="dashed">
+              <p className="text-sm text-muted-foreground">파일 정보 미제공</p>
+            </Card>
+          ) : manifestState.manifest.outputs.length === 0 ? (
+            <Card variant="dashed">
+              <p className="text-sm text-muted-foreground">생성된 파일이 없습니다.</p>
+            </Card>
+          ) : (
             <Card className="p-0">
               <div className="grid grid-cols-[1.6fr_0.6fr] gap-4 border-b border-border px-6 py-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                 <span>파일</span>

--- a/src/pages/BuildDetailPage.tsx
+++ b/src/pages/BuildDetailPage.tsx
@@ -3,8 +3,11 @@
  *
  * 빌드의 현재 상태와 편집/실행/결과물/게시로 이어지는 하위 흐름 진입점을 보여준다.
  */
+import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Card, LinkButton, PageHeader, Skeleton, StatusBadge } from "@/shared/ui";
+import { getBuildManifest } from "@/features/artifacts/api";
+import type { BuildManifest } from "@/shared/lib/types";
 import { useBuild } from "@/features/runs/useBuild";
 
 const SUBPAGES = [
@@ -14,6 +17,19 @@ const SUBPAGES = [
   { segment: "publish", label: "게시", description: "배포 전 검토 및 publish" },
 ] as const;
 
+interface ManifestState {
+  status: "loading" | "loaded" | "error";
+  manifest?: BuildManifest;
+  error?: string;
+}
+
+/** 파일 경로에서 표시용 이름과 형식(확장자)을 뽑는다. */
+function describeFile(path: string): { name: string; format: string } {
+  const name = path.split("/").pop() ?? path;
+  const dot = name.lastIndexOf(".");
+  return { name, format: dot >= 0 ? name.slice(dot + 1) : "—" };
+}
+
 /**
  * 빌드 상세 요약과 하위 흐름 진입 카드를 보여주는 페이지.
  *
@@ -22,6 +38,31 @@ const SUBPAGES = [
 export function BuildDetailPage() {
   const { buildId = "" } = useParams();
   const { build, isLoading, error } = useBuild(buildId);
+  const [manifestState, setManifestState] = useState<ManifestState>({ status: "loading" });
+
+  const loadManifest = useCallback(() => {
+    const controller = new AbortController();
+    setManifestState({ status: "loading" });
+    getBuildManifest(buildId, controller.signal)
+      .then((manifest) => {
+        if (!controller.signal.aborted) setManifestState({ status: "loaded", manifest });
+      })
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setManifestState({
+          status: "error",
+          error: cause instanceof Error ? cause.message : "manifest를 불러오지 못했습니다.",
+        });
+      });
+    return () => controller.abort();
+  }, [buildId]);
+
+  // build 조회 성공 시 manifest를 로드한다.
+  useEffect(() => {
+    if (build && !isLoading && !error) {
+      loadManifest();
+    }
+  }, [build, isLoading, error, loadManifest]);
 
   if (isLoading) {
     return (
@@ -82,6 +123,78 @@ export function BuildDetailPage() {
           </span>
         ) : null}
       </Card>
+
+      {/* Manifest 요약 */}
+      {manifestState.status === "loading" ? (
+        <Card>
+          <Skeleton className="h-20 w-full" />
+        </Card>
+      ) : manifestState.status === "error" ? (
+        <Card variant="error" className="text-red-700 dark:text-red-300">
+          Manifest를 불러오지 못했습니다: {manifestState.error}
+        </Card>
+      ) : manifestState.manifest ? (
+        <>
+          <Card>
+            <p className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+              Manifest 요약
+            </p>
+            <dl className="mt-3 grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
+              <div>
+                <dt className="text-muted-foreground">빌드 ID</dt>
+                <dd className="break-all text-foreground">{manifestState.manifest.build_id}</dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">레코드 수</dt>
+                <dd className="text-foreground">
+                  {Object.keys(manifestState.manifest.row_counts).length > 0
+                    ? Object.values(manifestState.manifest.row_counts)
+                        .reduce((sum, count) => sum + count, 0)
+                        .toLocaleString("ko-KR")
+                    : "미제공"}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">데이터 소스</dt>
+                <dd className="text-foreground">
+                  {manifestState.manifest.provenance.length > 0
+                    ? manifestState.manifest.provenance
+                        .map((p) => `${p.provider}.${p.dataset}`)
+                        .join(", ")
+                    : "미제공"}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">생성 파일 수</dt>
+                <dd className="text-foreground">{manifestState.manifest.outputs.length}</dd>
+              </div>
+            </dl>
+          </Card>
+
+          {manifestState.manifest.outputs.length > 0 && (
+            <Card className="p-0">
+              <div className="grid grid-cols-[1.6fr_0.6fr] gap-4 border-b border-border px-6 py-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                <span>파일</span>
+                <span>형식</span>
+              </div>
+              <ul>
+                {manifestState.manifest.outputs.map((path) => {
+                  const { name, format } = describeFile(path);
+                  return (
+                    <li
+                      key={path}
+                      className="grid grid-cols-[1.6fr_0.6fr] items-center gap-4 border-b border-border px-6 py-3 text-sm last:border-0"
+                    >
+                      <span className="break-all font-medium">{name}</span>
+                      <span className="uppercase text-muted-foreground">{format}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </Card>
+          )}
+        </>
+      ) : null}
 
       <section className="grid gap-4 sm:grid-cols-2">
         {SUBPAGES.map((sub) => (

--- a/src/pages/BuildDetailPage.tsx
+++ b/src/pages/BuildDetailPage.tsx
@@ -60,7 +60,7 @@ export function BuildDetailPage() {
   // build 조회 성공 시 manifest를 로드한다.
   useEffect(() => {
     if (build && !isLoading && !error) {
-      loadManifest();
+      return loadManifest();
     }
   }, [build, isLoading, error, loadManifest]);
 
@@ -147,7 +147,7 @@ export function BuildDetailPage() {
               <div>
                 <dt className="text-muted-foreground">레코드 수</dt>
                 <dd className="text-foreground">
-                  {Object.keys(manifestState.manifest.row_counts).length > 0
+                  {manifestState.manifest.row_counts && Object.keys(manifestState.manifest.row_counts).length > 0
                     ? Object.values(manifestState.manifest.row_counts)
                         .reduce((sum, count) => sum + count, 0)
                         .toLocaleString("ko-KR")
@@ -157,7 +157,7 @@ export function BuildDetailPage() {
               <div>
                 <dt className="text-muted-foreground">데이터 소스</dt>
                 <dd className="text-foreground">
-                  {manifestState.manifest.provenance.length > 0
+                  {manifestState.manifest.provenance && manifestState.manifest.provenance.length > 0
                     ? manifestState.manifest.provenance
                         .map((p) => `${p.provider}.${p.dataset}`)
                         .join(", ")
@@ -166,12 +166,14 @@ export function BuildDetailPage() {
               </div>
               <div>
                 <dt className="text-muted-foreground">생성 파일 수</dt>
-                <dd className="text-foreground">{manifestState.manifest.outputs.length}</dd>
+                <dd className="text-foreground">
+                  {manifestState.manifest.outputs?.length ?? 0}
+                </dd>
               </div>
             </dl>
           </Card>
 
-          {manifestState.manifest.outputs.length > 0 && (
+          {manifestState.manifest.outputs && manifestState.manifest.outputs.length > 0 && (
             <Card className="p-0">
               <div className="grid grid-cols-[1.6fr_0.6fr] gap-4 border-b border-border px-6 py-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                 <span>파일</span>


### PR DESCRIPTION
## 요약

PR #168에서 부분 구현된 Build Detail 화면을 Issue #155 완료 조건에 맞게 보완합니다.

이 PR은 PR #168의 head 브랜치인 `feat/issue-120-buildspec-schema-validation`을 base로 한 stacked PR입니다.
Build Detail의 실데이터 표시, manifest/artifacts 표시, 상태 정확성에 필요한 변경만 포함합니다.

## 변경 내용

### 실제 실행 이력 기준 상세 조회

* 실행 이력에 존재하지 않는 build를 `succeeded` 상태로 임의 생성하던 fallback 제거
* localStorage에 BuildSpec이 남아 있더라도 실제 실행 이력이 없으면 조회 오류로 처리
* 저장된 BuildSpec은 실제 실행 이력이 존재할 때 상세 정보를 보완하는 용도로만 사용

### Manifest 및 artifacts 표시

* 기존 `getBuildManifest()` API 재사용
* Build Detail 화면에 다음 manifest 요약 표시

  * 빌드 ID
  * 레코드 수
  * 데이터 소스
  * 생성 파일 수
* `manifest.outputs`를 기반으로 artifact 파일명과 형식 표시
* build 조회와 manifest 조회의 로딩·오류 상태 분리
* manifest 조회 실패 시 Build Detail 전체가 아닌 manifest 영역에만 오류 표시
* unmount 또는 build 변경 시 진행 중인 manifest 요청 취소

### 미제공 값과 빈 값 구분

Issue #119의 manifest 상태 표현과 정합되도록 다음 상태를 구분합니다.

| 필드             | 미제공 (`undefined`) | 빈 값             | 값 존재                  |
| -------------- | ----------------- | --------------- | --------------------- |
| `row_counts`   | `미제공`             | `0`             | 실제 합계                 |
| `provenance`   | `미제공`             | `소스 없음`         | `provider.dataset` 목록 |
| `outputs` 파일 수 | `미제공`             | `0`             | 실제 파일 수               |
| `outputs` 목록   | `파일 정보 미제공`       | `생성된 파일이 없습니다.` | artifact 목록           |

Builder가 제공하지 않은 값을 `0`이나 빈 정상값으로 가장하지 않습니다.

## 변경 파일

* `src/features/runs/api/getBuild.ts`
* `src/pages/BuildDetailPage.tsx`
* `__tests__/buildRoutes.test.tsx`

## 범위 제외

* Issue #156 Build Edit 기능
* Publish 기능
* Builder API 계약
* 패키지 및 lockfile
* CI 및 배포 workflow
* 관련 없는 리팩터링

## 검증

* [x] `git diff --check`
* [x] `npm test -- __tests__/buildRoutes.test.tsx`

  * 1 file, 5 tests passed
* [x] `npm run typecheck`
* [x] `npm run lint`
* [x] `npm run build`

전체 테스트 실행에서는 기존 localStorage 관련 실패가 재현됐으며, 이번 변경 대상인 Build Detail route 테스트는 모두 통과했습니다.

## PR 구조

* Base: `feat/issue-120-buildspec-schema-validation`
* Head: `fix/pr-168-complete-build-detail`
* Stacked on #168
* 변경 파일 3개

## 관련 이슈 및 PR

* Completes the remaining scope of #155
* Aligns with #119
* Stacked on #168
