### PR TITLE
fix: Build Detail 화면 manifest 요약 렌더링 (#155)

### DIFF
--- a/__tests__/buildRoutes.test.tsx
+++ b/__tests__/buildRoutes.test.tsx
@@ -34,6 +34,8 @@ describe("build-centric routes", () => {
       "href",
       "/builds/air-quality-20260621/edit",
     );
+    // manifest 요약(#155 살벤지)도 상세 화면에 함께 렌더된다.
+    expect(await screen.findByText("Manifest 요약")).toBeInTheDocument();
   });
 
   it("shows an error instead of placeholder data for an unknown buildId", async () => {

--- a/src/pages/BuildDetailPage.tsx
+++ b/src/pages/BuildDetailPage.tsx
@@ -2,10 +2,18 @@
  * 빌드 상세 요약 페이지 (/builds/:buildId).
  *
  * 빌드의 현재 상태와 편집/실행/결과물/게시로 이어지는 하위 흐름 진입점을 보여준다.
+ * 조회에 성공하면 manifest 요약(레코드 수·데이터 소스·생성 파일)을 함께 렌더한다(#155).
+ *
+ * NOTE: manifest의 "미제공(undefined)" 대 "비어 있음(빈 배열)" 구분은 #119(#165)에서
+ * BuildManifest 필드를 optional로 바꾼 뒤 도입한다. 현재 타입에서는 필드가 항상
+ * 존재하므로 여기서는 "비어 있음"만 구분한다.
  */
+import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import { Card, LinkButton, PageHeader, Skeleton, StatusBadge } from "@/shared/ui";
+import { getBuildManifest } from "@/features/artifacts/api";
 import { useBuild } from "@/features/runs/useBuild";
+import type { BuildManifest } from "@/shared/lib/types";
+import { Card, LinkButton, PageHeader, Skeleton, StatusBadge } from "@/shared/ui";
 
 const SUBPAGES = [
   { segment: "edit", label: "편집", description: "스펙 수정" },
@@ -13,6 +21,19 @@ const SUBPAGES = [
   { segment: "artifacts", label: "결과물", description: "파일과 manifest 확인" },
   { segment: "publish", label: "게시", description: "배포 전 검토 및 publish" },
 ] as const;
+
+interface ManifestState {
+  status: "loading" | "loaded" | "error";
+  manifest?: BuildManifest;
+  error?: string;
+}
+
+/** 파일 경로에서 표시용 이름과 형식(확장자)을 뽑는다. */
+function describeFile(path: string): { name: string; format: string } {
+  const name = path.split("/").pop() ?? path;
+  const dot = name.lastIndexOf(".");
+  return { name, format: dot >= 0 ? name.slice(dot + 1) : "—" };
+}
 
 /**
  * 빌드 상세 요약과 하위 흐름 진입 카드를 보여주는 페이지.
@@ -22,6 +43,31 @@ const SUBPAGES = [
 export function BuildDetailPage() {
   const { buildId = "" } = useParams();
   const { build, isLoading, error } = useBuild(buildId);
+  const [manifestState, setManifestState] = useState<ManifestState>({ status: "loading" });
+
+  const loadManifest = useCallback(() => {
+    const controller = new AbortController();
+    setManifestState({ status: "loading" });
+    getBuildManifest(buildId, controller.signal)
+      .then((manifest) => {
+        if (!controller.signal.aborted) setManifestState({ status: "loaded", manifest });
+      })
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setManifestState({
+          status: "error",
+          error: cause instanceof Error ? cause.message : "manifest를 불러오지 못했습니다.",
+        });
+      });
+    return () => controller.abort();
+  }, [buildId]);
+
+  // build 조회 성공 시 manifest를 로드한다.
+  useEffect(() => {
+    if (build && !isLoading && !error) {
+      return loadManifest();
+    }
+  }, [build, isLoading, error, loadManifest]);
 
   if (isLoading) {
     return (
@@ -82,6 +128,80 @@ export function BuildDetailPage() {
           </span>
         ) : null}
       </Card>
+
+      {/* Manifest 요약 */}
+      {manifestState.status === "loading" ? (
+        <Card>
+          <Skeleton className="h-20 w-full" />
+        </Card>
+      ) : manifestState.status === "error" ? (
+        <Card variant="error" className="text-red-700 dark:text-red-300">
+          Manifest를 불러오지 못했습니다: {manifestState.error}
+        </Card>
+      ) : manifestState.manifest ? (
+        <>
+          <Card>
+            <p className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+              Manifest 요약
+            </p>
+            <dl className="mt-3 grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
+              <div>
+                <dt className="text-muted-foreground">빌드 ID</dt>
+                <dd className="break-all text-foreground">{manifestState.manifest.build_id}</dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">레코드 수</dt>
+                <dd className="text-foreground">
+                  {Object.values(manifestState.manifest.row_counts)
+                    .reduce((sum, count) => sum + count, 0)
+                    .toLocaleString("ko-KR")}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">데이터 소스</dt>
+                <dd className="text-foreground">
+                  {manifestState.manifest.provenance.length === 0
+                    ? "소스 없음"
+                    : manifestState.manifest.provenance
+                        .map((provenance) => `${provenance.provider}.${provenance.dataset}`)
+                        .join(", ")}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">생성 파일 수</dt>
+                <dd className="text-foreground">{manifestState.manifest.outputs.length}</dd>
+              </div>
+            </dl>
+          </Card>
+
+          {manifestState.manifest.outputs.length === 0 ? (
+            <Card variant="dashed">
+              <p className="text-sm text-muted-foreground">생성된 파일이 없습니다.</p>
+            </Card>
+          ) : (
+            <Card className="p-0">
+              <div className="grid grid-cols-[1.6fr_0.6fr] gap-4 border-b border-border px-6 py-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                <span>파일</span>
+                <span>형식</span>
+              </div>
+              <ul>
+                {manifestState.manifest.outputs.map((path) => {
+                  const { name, format } = describeFile(path);
+                  return (
+                    <li
+                      key={path}
+                      className="grid grid-cols-[1.6fr_0.6fr] items-center gap-4 border-b border-border px-6 py-3 text-sm last:border-0"
+                    >
+                      <span className="break-all font-medium">{name}</span>
+                      <span className="uppercase text-muted-foreground">{format}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </Card>
+          )}
+        </>
+      ) : null}
 
       <section className="grid gap-4 sm:grid-cols-2">
         {SUBPAGES.map((sub) => (


### PR DESCRIPTION
## 개요

Build 상세 화면(`/builds/:buildId`)에 **manifest 요약**(레코드 수·데이터 소스·생성 파일 목록)을 추가하여 #155를 완성한다.

이 작업은 자동 종료된 fork PR #178(author @SeoL-ee)의 고유 UI 기여를 현재 `main` 위로 이식(salvage)한 것이다. #178은 base 브랜치(#168)가 병합·삭제되며 GitHub에 의해 자동 종료되었고, 브랜치가 #166/#172/#174 병합 이전 상태라 직접 병합이 불가능했다.

## 변경 사항

- `BuildDetailPage.tsx`: `useBuild` 훅으로 조회 성공 시 `getBuildManifest`로 manifest를 로드하여 요약 카드 + 파일 목록을 렌더
- `buildRoutes.test.tsx`: 상세 화면에 "Manifest 요약"이 노출되는지 검증 추가

## 범위 경계 (중복 구현 방지)

manifest의 **"미제공(undefined)" vs "비어 있음(빈 배열)"** 구분은 이 PR에 포함하지 **않는다**. 현재 `BuildManifest` 타입은 해당 필드가 필수(required)이므로 "비어 있음"만 처리한다. `undefined`(미제공) 구분은 `BuildManifest` 필드를 optional로 바꾸는 **#119의 정식 수정(#165)**이 담당한다.

## 검증

- `tsc --noEmit` 통과, `eslint` 통과
- 전체 테스트 165개 통과

Closes #178 (salvaged). Refs #155.

Co-authored-by: SeoL-ee <seohyun3864@gmail.com>