### PR TITLE
feat: apiFetch 인증 헤더 주입 지점 (#186, S1)

### DIFF
--- a/src/shared/lib/builderApi.test.ts
+++ b/src/shared/lib/builderApi.test.ts
@@ -5,7 +5,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { builderApi } from "./builderApi";
+import { builderApi, setAuthTokenProvider, _resetAuthTokenProvider } from "./builderApi";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -57,5 +57,59 @@ describe("builderApi retry policy", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("apiFetch auth header injection (#186)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    _resetAuthTokenProvider();
+  });
+
+  afterEach(() => {
+    _resetAuthTokenProvider();
+    vi.restoreAllMocks();
+  });
+
+  function requestInitOf(fetchMock: ReturnType<typeof vi.spyOn>) {
+    // fetch(url, init) — 두 번째 인자가 RequestInit.
+    return fetchMock.mock.calls[0][1] as RequestInit;
+  }
+
+  it("does not send Authorization when no provider is set (회귀 없음)", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(200, { service: "kpubdata-builder", api_version: "1.0.0" }));
+
+    await builderApi.version();
+
+    const headers = requestInitOf(fetchMock).headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    // 미로그인/mock 모드에서 빈 헤더가 나가지 않는다.
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("sends Authorization: Bearer <token> when provider returns a token", async () => {
+    setAuthTokenProvider(() => "id-token-jwt");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(200, { service: "kpubdata-builder", api_version: "1.0.0" }));
+
+    await builderApi.version();
+
+    const headers = requestInitOf(fetchMock).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer id-token-jwt");
+  });
+
+  it("does not send Authorization when provider returns null (미로그인)", async () => {
+    setAuthTokenProvider(() => null);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(200, { service: "kpubdata-builder", api_version: "1.0.0" }));
+
+    await builderApi.version();
+
+    const headers = requestInitOf(fetchMock).headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
   });
 });

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -156,14 +156,12 @@ export async function apiFetch<T>(
   let response: Response | undefined;
   for (let attempt = 0; attempt <= retries; attempt++) {
     const { signal: combined, cleanup } = withTimeout(signal, timeoutMs);
-    // 인증 헤더: skipAuth이거나 provider가 토큰을 주지 않으면 붙이지 않는다 (#186).
-    // provider 미설정 시에는 기존(Content-Type만)과 완전히 동일하다.
     const headers: Record<string, string> = { "Content-Type": "application/json" };
-    if (!options.skipAuth) {
-      const token = authTokenProvider?.() ?? null;
-      if (token) headers.Authorization = `Bearer ${token}`;
-    }
     try {
+      if (!options.skipAuth) {
+        const token = authTokenProvider?.() ?? null;
+        if (token) headers.Authorization = `Bearer ${token}`;
+      }
       response = await fetch(`${API_BASE}${path}`, {
         method,
         signal: combined,

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -49,6 +49,33 @@ interface RequestOptions {
   timeoutMs?: number;
   /** 네트워크 오류·5xx 발생 시 추가 재시도 횟수(지수 백오프). 미지정 시 DEFAULT_RETRIES. */
   retries?: number;
+  /** 인증 헤더 생략 (/healthz 등 무인증 엔드포인트, #186). */
+  skipAuth?: boolean;
+}
+
+/**
+ * Builder 요청에 붙일 Bearer 토큰을 제공하는 provider (#186).
+ * null을 반환하면 해당 요청에 Authorization 헤더를 붙이지 않는다 —
+ * mock 모드·미로그인 상태에서 빈 헤더가 나가는 것을 방지한다.
+ */
+export type AuthTokenProvider = () => string | null;
+
+// Studio는 서버가 없는 정적 SPA라 토큰을 메모리(zustand 스토어)에만 보관한다 (#187 예정).
+// apiFetch는 주입받은 provider를 통해 그 토큰을 읽는다 — 전역을 직접 참조하면 테스트가 어렵다.
+let authTokenProvider: AuthTokenProvider | null = null;
+
+/**
+ * Builder 요청에 붙일 Bearer 토큰 provider를 등록한다 (#186).
+ * provider를 null로(또는 해제) 두면 인증 헤더가 나가지 않아, 미로그인/mock 모드에서
+ * 기존 요청 형태와 완전히 동일하게 동작한다(회귀 없음).
+ */
+export function setAuthTokenProvider(provider: AuthTokenProvider | null): void {
+  authTokenProvider = provider;
+}
+
+/** 테스트 격리용: 등록된 provider를 해제한다. */
+export function _resetAuthTokenProvider(): void {
+  authTokenProvider = null;
 }
 
 /** 자동 타임아웃 기본값(ms). Builder /build는 외부 API를 호출해 느릴 수 있어 넉넉히 잡는다. */
@@ -129,11 +156,18 @@ export async function apiFetch<T>(
   let response: Response | undefined;
   for (let attempt = 0; attempt <= retries; attempt++) {
     const { signal: combined, cleanup } = withTimeout(signal, timeoutMs);
+    // 인증 헤더: skipAuth이거나 provider가 토큰을 주지 않으면 붙이지 않는다 (#186).
+    // provider 미설정 시에는 기존(Content-Type만)과 완전히 동일하다.
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (!options.skipAuth) {
+      const token = authTokenProvider?.() ?? null;
+      if (token) headers.Authorization = `Bearer ${token}`;
+    }
     try {
       response = await fetch(`${API_BASE}${path}`, {
         method,
         signal: combined,
-        headers: { "Content-Type": "application/json" },
+        headers,
         body: body === undefined ? undefined : JSON.stringify(body),
       });
     } catch (cause) {


### PR DESCRIPTION
## 개요
Studio **S1**(= #186). `apiFetch`가 `Content-Type`만 하드코딩해 인증 헤더를 넣을 자리가 없었음 → Builder fail-closed 배포 시 실연동 전부 401. Builder 작업과 무관하게 **지금 착수 가능**한 리스크 없는 토대(Provider 주입 패턴).

## 변경 (`src/shared/lib/builderApi.ts`)
- `AuthTokenProvider = () => string | null` + `setAuthTokenProvider()` 모듈 세터. apiFetch가 provider로부터 토큰을 읽음.
- `RequestOptions.skipAuth` — `/healthz` 등 무인증 엔드포인트용.
- **provider 미설정 / null 반환 / skipAuth** → Authorization 헤더 부재. provider 미등록 시 요청이 기존과 byte-identical(회귀 없음).

## 테스트 (`builderApi.test.ts`)
- provider 미설정 → Authorization 없음(회귀 방지)
- 토큰 반환 → `Authorization: Bearer <token>`
- null 반환 → Authorization 없음

## 검증
- `tsc --noEmit` ✅ / `eslint` ✅ (전체 src)
- vitest는 이 환경에서 rolldown native binary 로드 실패로 로컬 실행 불가 — **CI가 실 검증**. 테스트 로직은 fetch mock 스파이 패턴으로 기존 테스트와 동일.

## 다음
S2(#187 Google 로그인)·S3(#188 메모리 보관)에서 provider를 zustand store에 연결. Builder B3(#385) 머지 후 활성화.

Refs #186
