### PR TITLE
fix: 계약 버전 1.1.0 동기화 + _resetAuthTokenProvider 제거 (#192, #197)

### DIFF
--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -2,7 +2,7 @@
  * Builder API 계약 적합성 테스트 (#36).
  *
  * Studio가 의존하는 Builder 계약 버전과 엔드포인트 집합을 고정해, 한쪽이 바뀌면 CI에서
- * 깨지도록 한다. Builder 측 계약은 builder #209(API_CONTRACT_VERSION="1.0.0")가 소유한다.
+ * 깨지도록 한다. Builder 측 계약은 builder #209(API_CONTRACT_VERSION="1.1.0")가 소유한다.
  */
 import { describe, expect, it } from "vitest";
 import { API_CONTRACT_VERSION, builderApi } from "@/shared/lib/builderApi";
@@ -12,7 +12,7 @@ const EXPECTED_OPERATIONS = ["version", "validate", "preview", "build", "artifac
 
 describe("Builder API contract conformance (#36)", () => {
   it("pins the contract version Studio targets (must match builder #209)", () => {
-    expect(API_CONTRACT_VERSION).toBe("1.0.0");
+    expect(API_CONTRACT_VERSION).toBe("1.1.0");
   });
 
   it("exposes exactly the expected client operations", () => {

--- a/src/shared/lib/builderApi.test.ts
+++ b/src/shared/lib/builderApi.test.ts
@@ -5,7 +5,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { builderApi, setAuthTokenProvider, _resetAuthTokenProvider } from "./builderApi";
+import { builderApi, setAuthTokenProvider } from "./builderApi";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -63,11 +63,11 @@ describe("builderApi retry policy", () => {
 describe("apiFetch auth header injection (#186)", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    _resetAuthTokenProvider();
+    setAuthTokenProvider(null);
   });
 
   afterEach(() => {
-    _resetAuthTokenProvider();
+    setAuthTokenProvider(null);
     vi.restoreAllMocks();
   });
 

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -22,7 +22,7 @@ import * as schemas from "./builderApi.schema";
 import { z } from "zod";
 
 /** Builder API 계약 버전. builder #209의 API_CONTRACT_VERSION과 일치해야 한다. */
-export const API_CONTRACT_VERSION = "1.0.0";
+export const API_CONTRACT_VERSION = "1.1.0";
 
 /** 실제 Builder 호출 활성화 여부(미설정 시 mock 사용). */
 export function isRealBuilderEnabled(): boolean {
@@ -71,11 +71,6 @@ let authTokenProvider: AuthTokenProvider | null = null;
  */
 export function setAuthTokenProvider(provider: AuthTokenProvider | null): void {
   authTokenProvider = provider;
-}
-
-/** 테스트 격리용: 등록된 provider를 해제한다. */
-export function _resetAuthTokenProvider(): void {
-  authTokenProvider = null;
 }
 
 /** 자동 타임아웃 기본값(ms). Builder /build는 외부 API를 호출해 느릴 수 있어 넉넉히 잡는다. */


### PR DESCRIPTION
## 개요

2건 수정:
- **#192 (S7)**: `API_CONTRACT_VERSION` 1.0.0 → 1.1.0 (Builder #405 동기화)
- **#197**: `_resetAuthTokenProvider` export 제거, `setAuthTokenProvider(null)`로 대체

## 검증

- `tsc --noEmit` ✅ / `eslint` ✅
- `_resetAuthTokenProvider` 참조 전부 제거 확인

Closes #192, Closes #197
