### PR TITLE
feat: 로그인 게이트 + Settings 로그인 상태 + 오리진 정합 문서 (#190, #191, #194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,22 @@ src/
 - **v0.1**: Vite + React SPA 셸 구성, React Router 기반 화면 전환, feature 기반 모듈 구조 정착, Builder API 연동 기초 작업
 - **v0.2**: 실시간 미리보기 기능, 데이터 검증 뷰, 빌드 결과물 뷰어 구현
 - **v0.3**: 최종 게시(Publish) 워크플로우 완성 및 전체 프로젝트 대시보드 제공
+
+---
+
+## 오리진 정합 — Google Console ↔ Builder CORS (#194, S9)
+
+실연동 모드에서 Studio가 Builder를 호출하려면 **같은 오리진 목록**을 양쪽에 등록해야 한다:
+
+1. **Google Cloud Console** → APIs & Services → Credentials → OAuth client ID → **Authorized JavaScript origins**
+2. **Builder** → `KPUBDATA_BUILDER_ALLOWED_ORIGINS` 환경변수 (CORS default-deny)
+
+두 값이 어긋나면 증상이 **CORS 오류**로 나타나 원인 추적이 어렵다. 로컬과 실배포 오리진을 모두 양쪽에 등록할 것.
+
+| 환경 | Studio 오리진 | Google Console | Builder CORS env |
+| :--- | :--- | :--- | :--- |
+| 로컬 개발 | `http://localhost:5173` | ✅ 등록 | ✅ 등록 |
+| 실배포 | `https://<studio-host>` | ✅ 등록 | ✅ 등록 |
+| Pages 데모 | `https://yeongseon.github.io` | ❌ (mock 모드, Builder 호출 안 함) | ❌ |
+
+> Pages 데모는 mock 모드(`VITE_USE_REAL_BUILDER` 미설정)라 Builder를 호출하지 않으므로 등록 대상이 아니다.

--- a/src/features/auth/LoginGate.tsx
+++ b/src/features/auth/LoginGate.tsx
@@ -1,0 +1,31 @@
+/**
+ * 로그인 게이트 (S5, #190).
+ *
+ * 실연동 모드(VITE_USE_REAL_BUILDER=true)에서만 로그인을 요구한다.
+ * mock 모드(Pages 데모 포함)에서는 게이트 없이 children을 렌더링한다.
+ * 데모가 깨지지 않는 것이 핵심 — 리뷰 시 Pages 데모 동작 확인 필수.
+ */
+import type { ReactNode } from "react";
+import { isRealBuilderEnabled } from "@/shared/lib/builderApi";
+import { useAuthStore } from "./store";
+
+export function LoginGate({ children }: { children: ReactNode }) {
+  const token = useAuthStore((s) => s.token);
+
+  if (!isRealBuilderEnabled()) {
+    return <>{children}</>;
+  }
+
+  if (!token) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4 px-5 py-20">
+        <p className="text-lg font-semibold text-foreground">로그인이 필요합니다</p>
+        <p className="max-w-md text-center text-sm text-muted-foreground">
+          실연동 모드에서는 Builder API 호출을 위해 Google 계정 로그인이 필요합니다.
+        </p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ import {
   isRealBuilderEnabled,
 } from "@/shared/lib/builderApi";
 import { WorkspaceSwitcher } from "@/features/workspace/WorkspaceSwitcher";
+import { useAuthStore } from "@/features/auth/store";
 import { Card, PageHeader, StatusBadge } from "@/shared/ui";
 
 interface ConnectionState {
@@ -28,6 +29,7 @@ interface ConnectionState {
  */
 export function SettingsPage() {
   const realEnabled = isRealBuilderEnabled();
+  const { email, clear } = useAuthStore();
   const [connection, setConnection] = useState<ConnectionState>({ status: "idle" });
 
   useEffect(() => {
@@ -118,6 +120,32 @@ export function SettingsPage() {
           ) : null}
         </div>
       </Card>
+
+      {realEnabled && (
+        <Card>
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            로그인 상태
+          </p>
+          <div className="mt-4 text-sm">
+            {email ? (
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-foreground">{email}</span>
+                <button
+                  type="button"
+                  onClick={() => clear()}
+                  className="rounded-lg border border-border px-3 py-1 text-xs text-muted-foreground hover:bg-muted"
+                >
+                  로그아웃
+                </button>
+              </div>
+            ) : (
+              <p className="text-muted-foreground">
+                로그인되지 않았습니다. 실연동 모드에서는 Builder 호출을 위해 Google 로그인이 필요합니다.
+              </p>
+            )}
+          </div>
+        </Card>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## 개요

Studio **S5 + S6 + S9**.

## S5 (#190): 로그인 게이트
`LoginGate` 컴포넌트 — `isRealBuilderEnabled()`가 true일 때만 로그인 요구. mock 모드(Pages 데모)는 children 그대로 렌더링.

## S6 (#191): Settings 로그인 상태
SettingsPage에 로그인 상태 Card 추가. `useAuthStore`에서 email 읽어 표시 + 로그아웃 버튼.

## S9 (#194): 오리진 정합 문서
README에 Google Console origins ↔ Builder CORS 정합 섹션 추가. 어긋나면 CORS 오류로 원인 추적 곤란.

## 검증
tsc + eslint clean.

Closes #190, Closes #191, Closes #194
