### PR TITLE
feat: Google Identity Services 로그인 연동 (S2, #187)

### DIFF
--- a/src/features/auth/GoogleLoginButton.tsx
+++ b/src/features/auth/GoogleLoginButton.tsx
@@ -1,0 +1,51 @@
+/**
+ * Google 로그인 버튼 (S2, #187).
+ *
+ * GIS 스크립트를 로드하고, VITE_GOOGLE_CLIENT_ID로 초기화한다.
+ * 콜백의 credential(JWT)을 auth store에 저장한다 — Builder Bearer 토큰으로 직접 사용.
+ * VITE_GOOGLE_CLIENT_ID 미설정 시 아무것도 렌더링하지 않는다 (mock 모드).
+ */
+import { useEffect, useRef } from "react";
+import { useAuthStore } from "./store";
+import { decodeJwtEmail, loadGisScript } from "./gis";
+
+export function GoogleLoginButton() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const setToken = useAuthStore((s) => s.setToken);
+  const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+
+  useEffect(() => {
+    if (!clientId || !containerRef.current) return;
+
+    let cancelled = false;
+
+    loadGisScript()
+      .then(() => {
+        if (cancelled || !window.google?.accounts?.id || !containerRef.current) return;
+        window.google.accounts.id.initialize({
+          client_id: clientId,
+          callback: (response: { credential: string }) => {
+            const email = decodeJwtEmail(response.credential);
+            setToken(response.credential, email);
+          },
+        });
+        window.google.accounts.id.renderButton(containerRef.current, {
+          theme: "outline",
+          size: "large",
+          text: "signin_with",
+          shape: "rectangular",
+        });
+      })
+      .catch(() => {
+        // GIS 로드 실패 — 버튼이 렌더링되지 않음. 사용자에게 에러 표시는 S8에서.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [clientId, setToken]);
+
+  if (!clientId) return null;
+
+  return <div ref={containerRef} />;
+}

--- a/src/features/auth/gis.ts
+++ b/src/features/auth/gis.ts
@@ -1,0 +1,80 @@
+/**
+ * Google Identity Services (GIS) 로더 (S2, #187).
+ *
+ * GIS 스크립트를 동적으로 로드하고 초기화한다.
+ * 콜백의 credential이 곧 Builder에 보낼 ID token JWT (별도 토큰 교환 없음).
+ */
+
+declare global {
+  interface Window {
+    google?: {
+      accounts: {
+        id: {
+          initialize: (config: IdConfig) => void;
+          renderButton: (parent: HTMLElement, options: ButtonOptions) => void;
+          disableAutoSelect: () => void;
+          prompt: (listener?: (notification: unknown) => void) => void;
+        };
+      };
+    };
+  }
+}
+
+interface IdConfig {
+  client_id: string;
+  callback: (response: { credential: string }) => void;
+  auto_select?: boolean;
+}
+
+interface ButtonOptions {
+  theme?: "outline" | "filled_blue" | "filled_black";
+  size?: "large" | "medium" | "small";
+  text?: "signin_with" | "signup_with" | "continue_with" | "signin";
+  shape?: "rectangular" | "pill" | "circle" | "square";
+  width?: number;
+}
+
+const GIS_SCRIPT_URL = "https://accounts.google.com/gsi/client";
+let _loaded = false;
+
+export function loadGisScript(): Promise<void> {
+  if (_loaded && window.google?.accounts?.id) return Promise.resolve();
+  if (document.querySelector(`script[src="${GIS_SCRIPT_URL}"]`)) {
+    return new Promise((resolve) => {
+      const check = setInterval(() => {
+        if (window.google?.accounts?.id) {
+          clearInterval(check);
+          _loaded = true;
+          resolve();
+        }
+      }, 100);
+    });
+  }
+  return new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = GIS_SCRIPT_URL;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => {
+      _loaded = true;
+      resolve();
+    };
+    script.onerror = () => reject(new Error("Failed to load Google Identity Services script"));
+    document.head.appendChild(script);
+  });
+}
+
+export function decodeJwtEmail(jwt: string): string | null {
+  try {
+    const payload = JSON.parse(
+      atob(jwt.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")),
+    ) as { email?: string };
+    return payload.email ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function googleLogout(): void {
+  window.google?.accounts?.id?.disableAutoSelect();
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -11,6 +11,8 @@ interface ImportMetaEnv {
   readonly VITE_BUILDER_API_URL?: string;
   /** "true"이면 mock 대신 실제 Builder API를 호출한다. */
   readonly VITE_USE_REAL_BUILDER?: string;
+  /** Google OAuth Client ID (GIS 로그인, #187). public 값 — 번들 포함 무방. */
+  readonly VITE_GOOGLE_CLIENT_ID?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## 개요

Studio **S2**(#187). Google Identity Services(GIS) 로그인 연동.

## 변경

- **`vite-env.d.ts`**: `VITE_GOOGLE_CLIENT_ID` 타입 선언 (public 값, 번들 포함 무방)
- **`gis.ts`**: GIS 스크립트 동적 로더 + JWT email 디코더 + logout 헬퍼
- **`GoogleLoginButton.tsx`**: GIS 버튼 렌더링, credential(JWT)을 `useAuthStore.setToken()`에 저장

## 동작

1. `VITE_GOOGLE_CLIENT_ID` 설정 시 GIS 스크립트 로드
2. GIS 버튼 클릭 → Google 로그인 팝업
3. 콜백의 `credential`(ID token JWT) → auth store 저장 → `apiFetch`가 `Authorization: Bearer`로 전송 (S1)
4. 미설정 시 버튼 렌더링 안 함 (mock 모드 안전)

## 검증

tsc + eslint clean. 실제 Google 로그인은 `VITE_GOOGLE_CLIENT_ID` 설정 후 런타임 검증 필요.

Closes #187
