### PR TITLE
feat: 401 토큰 만료 처리 + 인증 에러 콜백 테스트 (#189, #195)

### DIFF
--- a/src/features/auth/init.ts
+++ b/src/features/auth/init.ts
@@ -2,9 +2,10 @@
  * 인증 초기화 — auth store를 apiFetch의 토큰 provider에 연결한다 (S1↔S3).
  * 앱 진입점(main.tsx)에서 한 번 호출한다.
  */
-import { setAuthTokenProvider } from "@/shared/lib/builderApi";
-import { getAuthToken } from "./store";
+import { setAuthErrorCallback, setAuthTokenProvider } from "@/shared/lib/builderApi";
+import { useAuthStore } from "./store";
 
 export function initAuth(): void {
-  setAuthTokenProvider(() => getAuthToken());
+  setAuthTokenProvider(() => useAuthStore.getState().token);
+  setAuthErrorCallback(() => useAuthStore.getState().clear());
 }

--- a/src/shared/lib/builderApi.test.ts
+++ b/src/shared/lib/builderApi.test.ts
@@ -5,7 +5,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { builderApi, setAuthTokenProvider } from "./builderApi";
+import { builderApi, setAuthErrorCallback, setAuthTokenProvider } from "./builderApi";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -111,5 +111,39 @@ describe("apiFetch auth header injection (#186)", () => {
 
     const headers = requestInitOf(fetchMock).headers as Record<string, string>;
     expect(headers.Authorization).toBeUndefined();
+  });
+});
+
+describe("auth error callback on 401 (#189, S4)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    setAuthTokenProvider(null);
+    setAuthErrorCallback(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setAuthTokenProvider(null);
+    setAuthErrorCallback(null);
+  });
+
+  it("calls auth error callback on 401", async () => {
+    const cb = vi.fn();
+    setAuthErrorCallback(cb);
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(401, { error: "unauthorized" }));
+
+    await expect(builderApi.version()).rejects.toMatchObject({ status: 401 });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call auth error callback on 403", async () => {
+    const cb = vi.fn();
+    setAuthErrorCallback(cb);
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(403, { error: "forbidden" }));
+
+    await expect(builderApi.version()).rejects.toMatchObject({ status: 403 });
+    expect(cb).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -73,6 +73,14 @@ export function setAuthTokenProvider(provider: AuthTokenProvider | null): void {
   authTokenProvider = provider;
 }
 
+export type AuthErrorCallback = () => void;
+
+let authErrorCallback: AuthErrorCallback | null = null;
+
+export function setAuthErrorCallback(cb: AuthErrorCallback | null): void {
+  authErrorCallback = cb;
+}
+
 /** 자동 타임아웃 기본값(ms). Builder /build는 외부 API를 호출해 느릴 수 있어 넉넉히 잡는다. */
 export const DEFAULT_TIMEOUT_MS = 30_000;
 
@@ -208,7 +216,9 @@ export async function apiFetch<T>(
   }
 
   if (!response.ok) {
-    // 사용자에게 명시적인 에러 메시지 제공 (#159)
+    if (response.status === 401 && authErrorCallback) {
+      authErrorCallback();
+    }
     const message = formatApiErrorMessage(response.status, parsed);
     throw new ApiError(response.status, message, parsed);
   }


### PR DESCRIPTION
## 개요

Studio **S4 + S10**.

## S4 (#189): 토큰 만료 처리
- `setAuthErrorCallback()` — apiFetch가 401 수신 시 호출
- init.ts가 콜백을 `useAuthStore.clear()`에 연결 → LoginGate가 로그인 프롬프트 표시
- 403은 콜백 미호출 (접근 권한 거부, 재로그인 무의미)

## S10 (#195): 인증 경로 테스트
- 401 → auth error callback 호출됨 (1회)
- 403 → auth error callback 미호출

## 검증
tsc + eslint clean.

Closes #189, Closes #195
