### PR TITLE
feat: AssistProvider + BYOK 설정 + 시크릿 스크러빙 (ST-A2, ST-A3)

### DIFF
--- a/src/features/assistant/config.ts
+++ b/src/features/assistant/config.ts
@@ -1,0 +1,88 @@
+/**
+ * 어시스턴트 설정 상태 (#205, ST-A2).
+ *
+ * LLM API 키는 **기본 메모리 전용**. 인증 토큰과 달리 세션마다 재입력받으면
+ * 마찰이 크므로 "이 브라우저에 저장" 옵트인을 명시적 경고와 함께 제공한다.
+ * 기본값은 저장하지 않는 쪽이다.
+ */
+import { create } from "zustand";
+
+const STORAGE_KEY = "kpubdata-assist-key";
+const STORAGE_WARNING =
+  "LLM API 키가 이 브라우저에 평문으로 저장됩니다. XSS 공격 시 탈취될 수 있습니다. 신뢰하지 않는 확장 프로그램이 있다면 저장하지 마세요.";
+
+interface AssistConfigState {
+  apiKey: string;
+  model: string;
+  baseUrl: string;
+  persistToStorage: boolean;
+  isConfigured: boolean;
+  setConfig: (config: { apiKey: string; model?: string; baseUrl?: string }) => void;
+  enablePersistence: () => void;
+  disablePersistence: () => void;
+  clear: () => void;
+}
+
+function _loadPersistedKey(): string {
+  try {
+    return localStorage.getItem(STORAGE_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function savePersistedKey(key: string): void {
+  try {
+    if (key) localStorage.setItem(STORAGE_KEY, key);
+    else localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // localStorage 접근 실패(SSR/프라이빗 모드)는 무시
+  }
+}
+
+export const useAssistConfig = create<AssistConfigState>((set, get) => ({
+  apiKey: "",
+  model: "",
+  baseUrl: "",
+  persistToStorage: false,
+  isConfigured: false,
+  setConfig: (config) => {
+    set({
+      apiKey: config.apiKey,
+      model: config.model ?? "",
+      baseUrl: config.baseUrl ?? "",
+      isConfigured: config.apiKey.length > 0,
+    });
+    if (get().persistToStorage) savePersistedKey(config.apiKey);
+  },
+  enablePersistence: () => {
+    if (typeof window !== "undefined" && window.confirm(STORAGE_WARNING)) {
+      set({ persistToStorage: true });
+      savePersistedKey(get().apiKey);
+    }
+  },
+  disablePersistence: () => {
+    set({ persistToStorage: false });
+    savePersistedKey("");
+  },
+  clear: () => {
+    set({ apiKey: "", isConfigured: false });
+    savePersistedKey("");
+  },
+}));
+
+// 옵트인한 경우에만 시작 시 로드
+if (typeof window !== "undefined") {
+  try {
+    const persisted = localStorage.getItem(STORAGE_KEY);
+    if (persisted) {
+      useAssistConfig.setState({
+        apiKey: persisted,
+        isConfigured: true,
+        persistToStorage: true,
+      });
+    }
+  } catch {
+    // 무시
+  }
+}

--- a/src/features/assistant/provider.ts
+++ b/src/features/assistant/provider.ts
@@ -1,0 +1,91 @@
+/**
+ * BuildSpec 어시스턴트 — LLM 호출 추상화 (#205, ST-A2).
+ *
+ * Studio는 정적 SPA라 서버가 없다. v1은 BYOK(Bring Your Own Key)로
+ * 사용자가 Settings에서 자기 API 키를 입력하고 브라우저가 LLM API를 직접 호출한다.
+ *
+ * **공용 키를 VITE_*로 주입하는 것은 절대 금지** — 번들에 평문으로 박힌다.
+ */
+
+export interface AssistMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface AssistProvider {
+  stream(messages: AssistMessage[], signal?: AbortSignal): AsyncIterable<string>;
+  readonly isConfigured: boolean;
+}
+
+export interface AssistConfig {
+  apiKey: string;
+  model: string;
+  baseUrl: string;
+}
+
+const DEFAULT_MODEL = "gpt-4o-mini";
+const DEFAULT_BASE_URL = "https://api.openai.com/v1";
+
+export class ByokProvider implements AssistProvider {
+  constructor(private config: AssistConfig) {}
+
+  get isConfigured(): boolean {
+    return this.config.apiKey.length > 0;
+  }
+
+  async *stream(messages: AssistMessage[], signal?: AbortSignal): AsyncIterable<string> {
+    const response = await fetch(`${this.config.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.config.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.config.model,
+        messages,
+        stream: true,
+      }),
+      signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`LLM API error ${response.status}: ${text}`);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("No response body");
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith("data: ")) continue;
+        const data = trimmed.slice(6);
+        if (data === "[DONE]") return;
+        try {
+          const parsed = JSON.parse(data);
+          const delta = parsed.choices?.[0]?.delta?.content;
+          if (delta) yield delta as string;
+        } catch {
+          // SSE 파싱 오류는 무시 — 일부 청크는 불완전할 수 있음
+        }
+      }
+    }
+  }
+}
+
+export function createProvider(config: AssistConfig): AssistProvider {
+  return new ByokProvider({
+    ...config,
+    model: config.model || DEFAULT_MODEL,
+    baseUrl: config.baseUrl || DEFAULT_BASE_URL,
+  });
+}

--- a/src/features/assistant/scrub.ts
+++ b/src/features/assistant/scrub.ts
@@ -1,0 +1,77 @@
+/**
+ * 시크릿 스크러빙 — LLM 전송 전 마스킹 (#206, ST-A3).
+ *
+ * sourceParams에 공공데이터포털 서비스 키 등이 들어갈 수 있다.
+ * 이걸 그대로 LLM에 보내면 사용자 시크릿이 외부 사업자에게 전송된다.
+ *
+ * 호출 경로의 공통 계층에 두어 프록시 모드로 바뀌어도 우회되지 않게 한다.
+ */
+
+const SECRET_KEY_PATTERNS = [
+  /^servicekey$/i,
+  /^api[_-]?key$/i,
+  /^.*[_-]?key$/i,
+  /^.*[_-]?token$/i,
+  /^.*[_-]?secret$/i,
+];
+
+const ENTROPY_THRESHOLD = 40;
+const MIN_LENGTH_FOR_ENTROPY = 16;
+
+export function isSecretKey(keyName: string): boolean {
+  return SECRET_KEY_PATTERNS.some((p) => p.test(keyName));
+}
+
+export function looksLikeSecret(value: string): boolean {
+  if (value.length < MIN_LENGTH_FOR_ENTROPY) return false;
+  const unique = new Set(value).size;
+  const entropy = (unique / value.length) * 100;
+  return entropy > ENTROPY_THRESHOLD;
+}
+
+const SCRUBBED_PREFIX = "__SCRUBBED_";
+
+export interface ScrubResult {
+  scrubbed: unknown;
+  placeholders: Map<string, string>;
+}
+
+export function scrubSecrets(data: unknown): ScrubResult {
+  const placeholders = new Map<string, string>();
+  let counter = 0;
+
+  function scrubValue(key: string, value: unknown): unknown {
+    if (typeof value === "string" && (isSecretKey(key) || looksLikeSecret(value))) {
+      const placeholder = `${SCRUBBED_PREFIX}${counter++}__`;
+      placeholders.set(placeholder, value);
+      return placeholder;
+    }
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const obj = value as Record<string, unknown>;
+      const result: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(obj)) {
+        result[k] = scrubValue(k, v);
+      }
+      return result;
+    }
+    return value;
+  }
+
+  const scrubbed = scrubValue("root", data);
+  return { scrubbed, placeholders };
+}
+
+export function restoreSecrets(data: unknown, placeholders: Map<string, string>): unknown {
+  if (typeof data === "string" && data.startsWith(SCRUBBED_PREFIX)) {
+    return placeholders.get(data) ?? data;
+  }
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    const obj = data as Record<string, unknown>;
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      result[k] = restoreSecrets(v, placeholders);
+    }
+    return result;
+  }
+  return data;
+}


### PR DESCRIPTION
## 개요

Studio **ST-A2 + ST-A3**.

## ST-A2 (#205): AssistProvider + BYOK
- `AssistProvider` 인터페이스 (stream, isConfigured)
- `ByokProvider` — OpenAI 호환 API 직접 호출, SSE 스트리밍
- `useAssistConfig` zustand store — 기본 메모리, "저장" 옵트인 경고

## ST-A3 (#206): 시크릿 스크러빙
- `scrubSecrets()` — serviceKey/apiKey/*_key/*_token/*_secret 패턴 마스킹
- 고엔트로피 문자열 휴리스틱 보조 검사
- 플레이스홀더 시스템 — 승인 후 `restoreSecrets()`로 원래 값 복원
- **호출 경로 공통 계층** — 프록시 모드 전환 시 우회 방지

## 검증
tsc + eslint clean.

Closes #205, Closes #206
