### PR TITLE
feat: validate 설명 모드 + catalog API 클라이언트 (ST-A5, ST-A6, #208, #209)

### DIFF
--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import { API_CONTRACT_VERSION, builderApi } from "@/shared/lib/builderApi";
 
 // Studio 클라이언트가 호출하는 Builder service 오퍼레이션(현재 구현 기준).
-const EXPECTED_OPERATIONS = ["version", "validate", "preview", "build", "artifacts", "listBuilds"] as const;
+const EXPECTED_OPERATIONS = ["version", "validate", "preview", "build", "artifacts", "listBuilds", "catalog"] as const;
 
 describe("Builder API contract conformance (#36)", () => {
   it("pins the contract version Studio targets (must match builder #209)", () => {

--- a/src/pages/ValidatePage.tsx
+++ b/src/pages/ValidatePage.tsx
@@ -1,33 +1,31 @@
 /**
  * 검증 결과 페이지 (/validate, 레거시 딥링크).
  *
- * 검증은 이제 New Build 마법사의 ‘검증·실행’ 단계에 통합되어 있다(제안 §5.4).
- * 이 화면은 딥링크 호환을 위해 유지하며, 마법사로 안내한다.
+ * 검증은 New Build 마법사에 통합되어 있지만, 이 페이지에서 어시스턴트(ST-A5)를
+ * 통해 검증 오류 설명과 수정 제안을 받을 수 있다.
  */
 import { Card, EmptyState, PageHeader } from "@/shared/ui";
+import { AssistantChat } from "@/features/assistant/AssistantChat";
 
-/**
- * 검증 흐름을 마법사로 안내하는 레거시 페이지.
- *
- * @returns 검증 안내 화면.
- */
 export function ValidatePage() {
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
       <PageHeader
         eyebrow="검증"
         title="검증 결과"
-        description="입력값과 빌드 설정에서 수정이 필요한 항목을 확인하는 단계입니다."
+        description="필요한 항목을 확인하고 어시스턴트에게 수정 제안을 물어보세요."
       />
 
       <Card className="p-0">
         <EmptyState
           title="검증은 새 빌드 만들기 안에서 진행됩니다"
-          description="필드별 오류와 수정 가이드는 New Build 마법사의 ‘검증·실행’ 단계에서 바로 확인할 수 있습니다."
+          description="필드별 오류와 수정 가이드는 New Build 마법사의 '검증·실행' 단계에서 바로 확인할 수 있습니다."
           actionLabel="새 빌드 만들기"
           actionHref="/builds/new"
         />
       </Card>
+
+      <AssistantChat />
     </main>
   );
 }

--- a/src/shared/lib/builderApi.schema.ts
+++ b/src/shared/lib/builderApi.schema.ts
@@ -211,3 +211,25 @@ export type SpecLoadError = z.infer<typeof specLoadErrorSchema>;
 export type BadRequest = z.infer<typeof badRequestSchema>;
 export type NotFound = z.infer<typeof notFoundSchema>;
 export type BuildPartialFailure = z.infer<typeof buildPartialFailureSchema>;
+
+/**
+ * GET /catalog 응답 스키마 (#416, BL2)
+ */
+export const catalogDatasetSchema = z.object({
+  name: z.string(),
+  title: z.string(),
+  requires_service_key: z.boolean(),
+});
+
+export const catalogProviderSchema = z.object({
+  name: z.string(),
+  datasets: z.array(catalogDatasetSchema),
+});
+
+export const catalogResponseSchema = z.object({
+  providers: z.array(catalogProviderSchema),
+});
+
+export type CatalogDataset = z.infer<typeof catalogDatasetSchema>;
+export type CatalogProvider = z.infer<typeof catalogProviderSchema>;
+export type CatalogResponse = z.infer<typeof catalogResponseSchema>;

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -389,4 +389,8 @@ export const builderApi = {
     const query = limit !== undefined ? `?limit=${limit}` : "";
     return apiFetch<BuildsResponse>(`/builds${query}`, { signal });
   },
+
+  /** GET /catalog — provider/dataset 카탈로그 (#416, BL2). */
+  catalog: (signal?: AbortSignal) =>
+    apiFetch<schemas.CatalogResponse>("/catalog", { signal }),
 };


### PR DESCRIPTION
## 개요

Studio **ST-A5 + ST-A6**.

## ST-A5 (#208): validate 실패 설명 모드 (v1)
- `AssistantChat` 컴포넌트를 ValidatePage에 배치
- 검증 오류 설명, 수정 제안을 자연어로 질문 가능
- BYOK 게이트: API 키 없으면 Settings 안내

## ST-A6 (#209): 카탈로그 API 클라이언트
- `builderApi.catalog()` 메서드 + zod 스키마 (CatalogResponse/Provider/Dataset)
- GET /catalog 호출 — Builder BL2(#416)과 짝
- 어시스턴트가 provider/dataset을 카탈로그에서 조회해 환각 방지

## 검증
tsc + eslint clean.

Closes #208, Closes #209
