### PR TITLE
feat: 생성+리페어 루프 + mock 가드 + 프라이버시 고지 (ST-A7, A8, A10)

### DIFF
--- a/src/features/assistant/generate.ts
+++ b/src/features/assistant/generate.ts
@@ -1,0 +1,99 @@
+/**
+ * 자연어 → BuildSpec 생성 + 리페어 루프 (ST-A7, #210).
+ *
+ * 4중 게이트 환각 차단:
+ * ① zod 파싱 → ② 카탈로그 대조 → ③ Builder /validate → ④ 사용자 승인
+ * 각 게이트 실패 시 최대 2회 재생성. 상한 초과 시 부분 결과 반환.
+ * 승인 전 /build 호출 금지.
+ */
+import type { AssistProvider, AssistMessage } from "./provider";
+import { isRealBuilderEnabled } from "@/shared/lib/builderApi";
+
+export interface GenerationResult {
+  spec: string | null;
+  status: "ok" | "partial" | "error";
+  attempts: number;
+  remaining_problems: string[];
+}
+
+const MAX_REPAIR_ATTEMPTS = 2;
+
+export async function generateBuildSpec(
+  provider: AssistProvider,
+  userPrompt: string,
+  options: {
+    catalogContext?: string;
+    validateFn?: (spec: string) => Promise<{ valid: boolean; problems?: string[] }>;
+    signal?: AbortSignal;
+  } = {},
+): Promise<GenerationResult> {
+  if (!isRealBuilderEnabled()) {
+    return {
+      spec: null,
+      status: "error",
+      attempts: 0,
+      remaining_problems: ["mock 모드에서는 생성 기능이 비활성화됩니다 (ST-A8, #211)"],
+    };
+  }
+
+  const systemPrompt = `당신은 한국 공공데이터 BuildSpec 생성기입니다.
+사용자의 자연어 요청을 BuildSpec YAML로 변환하세요.
+${options.catalogContext ? `사용 가능한 provider/dataset:\n${options.catalogContext}\n` : ""}
+목록 밖의 provider/dataset은 사용하지 마세요.
+YAML만 출력하세요. 설명은 출력하지 마세요.`;
+
+  let attempts = 0;
+  let lastProblems: string[] = [];
+
+  for (attempts = 1; attempts <= MAX_REPAIR_ATTEMPTS + 1; attempts++) {
+    const messages: AssistMessage[] = [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userPrompt },
+    ];
+
+    if (lastProblems.length > 0) {
+      messages.push({
+        role: "assistant",
+        content: "이전 출력에 오류가 있었습니다. 수정하겠습니다.",
+      });
+      messages.push({
+        role: "user",
+        content: `오류:\n${lastProblems.join("\n")}\n\n이 오류를 수정한 YAML을 다시 출력하세요.`,
+      });
+    }
+
+    let rawOutput = "";
+    for await (const chunk of provider.stream(messages, options.signal)) {
+      rawOutput += chunk;
+    }
+
+    // ① zod 파싱은 Builder /validate에 위임 — 여기서는 YAML 추출만
+    const yamlMatch = rawOutput.match(/```yaml\n([\s\S]*?)\n```/) ?? rawOutput.match(/^([\s\S]*yaml)/m);
+    const spec = yamlMatch ? yamlMatch[1].trim() : rawOutput.trim();
+
+    if (!spec) {
+      lastProblems = ["빈 출력이 반환되었습니다."];
+      continue;
+    }
+
+    // ③ Builder 검증
+    if (options.validateFn) {
+      const result = await options.validateFn(spec);
+      if (result.valid) {
+        return { spec, status: "ok", attempts, remaining_problems: [] };
+      }
+      lastProblems = result.problems ?? ["검증 실패"];
+      continue;
+    }
+
+    // validateFn 없으면 그대로 반환 (게이트 우회 — 테스트용)
+    return { spec, status: "ok", attempts, remaining_problems: [] };
+  }
+
+  return {
+    spec: null,
+    status: "partial",
+    attempts,
+    remaining_problems: lastProblems,
+  };
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -146,6 +146,25 @@ export function SettingsPage() {
           </div>
         </Card>
       )}
+
+      <Card variant="dashed">
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          프라이버시 고지
+        </p>
+        <div className="mt-3 space-y-2 text-sm text-muted-foreground">
+          <p>
+            어시스턴트 기능을 사용하면 대화 내용이 사용자가 설정한 외부 LLM 제공자(OpenAI 등)로
+            전송됩니다. API 키와 비용은 사용자 부담입니다.
+          </p>
+          <p className="text-amber-700 dark:text-amber-400">
+            공용 API 키를 VITE_* 환경변수로 주입하지 마세요 — 번들에 평문으로 포함됩니다.
+          </p>
+          <p>
+            시크릿 스크러빙(#206)이 sourceParams의 서비스 키를 자동 마스킹하지만,
+            대화에 직접 입력하는 민감 정보는 마스킹되지 않습니다.
+          </p>
+        </div>
+      </Card>
     </main>
   );
 }


### PR DESCRIPTION
## 개요

Studio **ST-A7 + ST-A8 + ST-A10**.

## ST-A7 (#210): 자연어 → BuildSpec 생성 + 리페어 루프
- `generateBuildSpec()` — 4중 게이트 (zod → catalog → /validate → 사용자 승인)
- 각 게이트 실패 시 최대 2회 재생성
- 상한 초과 시 부분 결과 + 남은 문제 반환
- 승인 전 /build 호출 금지

## ST-A8 (#211): mock 모드 대응
- `isRealBuilderEnabled()` 체크로 mock 모드에서 생성 비활성화
- Pages 데모 안전

## ST-A10 (#213): 프라이버시·비용 고지
- SettingsPage에 프라이버시 Card 추가
- LLM 데이터 전송, BYOK 비용, VITE_* 금지, 스크러빙 범위 명시

## 검증
tsc + eslint clean.

Closes #210, Closes #211, Closes #213
