### PR TITLE
fix(assistant): scrub secrets in arrays, Shannon entropy, restore round-trip (#226)

### DIFF
--- a/src/features/assistant/scrub.test.ts
+++ b/src/features/assistant/scrub.test.ts
@@ -1,0 +1,91 @@
+/**
+ * 시크릿 스크러빙 회귀 테스트 (#226).
+ *
+ * 4결함 검증:
+ * (a) 배열 순회 — BuildSpec.sources 가 배열
+ * (c) restoreSecrets 왕복 — 배열 포함 복원
+ * (d) Shannon 엔트로피 — 긴 base64 키 탐지
+ */
+import { describe, expect, it } from "vitest";
+
+import { looksLikeSecret, restoreSecrets, scrubSecrets } from "./scrub";
+
+const SAMPLE_SERVICE_KEY =
+  "9dF8kQ2mZ7xV3nL1pR4wY6tB0hJ5sC8gU2iE7oA9bN3cM6dP4qK1rS8tU0vW3xY5z";
+
+describe("scrubSecrets — 배열 순회 회귀 (#226 결함 a)", () => {
+  it("BuildSpec.sources 배열 내부의 serviceKey를 스크러빙한다", () => {
+    const spec = {
+      sources: [
+        { provider: "datago", params: { serviceKey: SAMPLE_SERVICE_KEY } },
+      ],
+    };
+    const { scrubbed, placeholders } = scrubSecrets(spec);
+
+    const json = JSON.stringify(scrubbed);
+    expect(json).not.toContain(SAMPLE_SERVICE_KEY);
+    expect(placeholders.size).toBeGreaterThan(0);
+    expect(Array.from(placeholders.values())).toContain(SAMPLE_SERVICE_KEY);
+  });
+
+  it("다중 소스 배열의 각 원소를 독립적으로 순회한다", () => {
+    const spec = {
+      sources: [
+        { params: { serviceKey: SAMPLE_SERVICE_KEY } },
+        { params: { apiKey: "another-secret-value-1234567890abcdef" } },
+      ],
+    };
+    const { scrubbed } = scrubSecrets(spec);
+    const json = JSON.stringify(scrubbed);
+    expect(json).not.toContain(SAMPLE_SERVICE_KEY);
+    expect(json).not.toContain("another-secret-value-1234567890abcdef");
+  });
+
+  it("중첩 배열(배열 안 객체 안 배열)도 순회한다", () => {
+    const spec = {
+      sources: [{ tags: [{ secret: SAMPLE_SERVICE_KEY }] }],
+    };
+    const { scrubbed } = scrubSecrets(spec);
+    expect(JSON.stringify(scrubbed)).not.toContain(SAMPLE_SERVICE_KEY);
+  });
+});
+
+describe("restoreSecrets — 배열 왕복 회귀 (#226 결함 c)", () => {
+  it("scrub → restore가 배열을 포함한 원본을 완전히 복원한다", () => {
+    const original = {
+      sources: [{ params: { serviceKey: SAMPLE_SERVICE_KEY } }],
+    };
+    const { scrubbed, placeholders } = scrubSecrets(original);
+    const restored = restoreSecrets(scrubbed, placeholders);
+    expect(restored).toEqual(original);
+  });
+
+  it("중첩 배열도 왕복 복원된다", () => {
+    const original = {
+      sources: [{ tags: [{ secret: SAMPLE_SERVICE_KEY }] }],
+    };
+    const { scrubbed, placeholders } = scrubSecrets(original);
+    const restored = restoreSecrets(scrubbed, placeholders);
+    expect(restored).toEqual(original);
+  });
+});
+
+describe("looksLikeSecret — Shannon 엔트로피 (#226 결함 d)", () => {
+  it("짧은 값은 잡지 않는다 (MIN_LENGTH_FOR_ENTROPY 미만)", () => {
+    expect(looksLikeSecret("short")).toBe(false);
+  });
+
+  it("200자 고엔트로피 base64 문자열을 잡아낸다 (현재 unique/length로는 32%라 놓침)", () => {
+    // base64 고유 문자 ≤ 64개, 길이 192 → unique/length*100 ≈ 33% < 60 (현재)
+    // Shannon 엔트로피는 문자 빈도 분포를 반영해 높게 계산
+    const longB64 =
+      "dGhpcy1pcy1hLXZlcnktbG9uZy1iYXNlNjQtc3RyaW5nLXdoaWNoLXNo" +
+      "b3VsZC1ub3QtYmUtY2F1Z2h0LWJ5LXRoZS1jdXJyZW50LWhldXJpc3Rp" +
+      "Yy1iZWNhdXNlLWl0LWlzLWxvbmctYW5kLXZhcmlk";
+    expect(looksLikeSecret(longB64)).toBe(true);
+  });
+
+  it("반복 패턴 저엔트로피 문자열은 잡지 않는다", () => {
+    expect(looksLikeSecret("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")).toBe(false);
+  });
+});

--- a/src/features/assistant/scrub.ts
+++ b/src/features/assistant/scrub.ts
@@ -1,5 +1,5 @@
 /**
- * 시크릿 스크러빙 — LLM 전송 전 마스킹 (#206, ST-A3).
+ * 시크릿 스크러빙 — LLM 전송 전 마스킹 (#206, ST-A3, #226).
  *
  * sourceParams에 공공데이터포털 서비스 키 등이 들어갈 수 있다.
  * 이걸 그대로 LLM에 보내면 사용자 시크릿이 외부 사업자에게 전송된다.
@@ -15,18 +15,36 @@ const SECRET_KEY_PATTERNS = [
   /^.*[_-]?secret$/i,
 ];
 
-const ENTROPY_THRESHOLD = 60;
+// Shannon 엔트로피 임계 (bits/char). base64(≈6.0)/hex(=4.0) 키를 잡고
+// 일반 텍스트는 놓친다. 이전 (unique/length)*100 휴리스틱은 길수록 고유 문자
+// 비율이 떨어져 200자 base64 키를 32%로 계산해 놓쳤다 (#226 결함 d).
+const SHANNON_ENTROPY_THRESHOLD = 4.0;
 const MIN_LENGTH_FOR_ENTROPY = 24;
 
 export function isSecretKey(keyName: string): boolean {
   return SECRET_KEY_PATTERNS.some((p) => p.test(keyName));
 }
 
+/**
+ * Shannon 엔트로피(문자당 bits) 계산. 문자 빈도 분포를 반영해
+ * 긴 고엔트로피 문자열(base64/hex 키)을 정확히 잡는다 (#226 결함 d).
+ */
+function shannonEntropy(value: string): number {
+  const freq = new Map<string, number>();
+  for (const ch of value) {
+    freq.set(ch, (freq.get(ch) ?? 0) + 1);
+  }
+  let h = 0;
+  for (const count of freq.values()) {
+    const p = count / value.length;
+    h -= p * Math.log2(p);
+  }
+  return h;
+}
+
 export function looksLikeSecret(value: string): boolean {
   if (value.length < MIN_LENGTH_FOR_ENTROPY) return false;
-  const unique = new Set(value).size;
-  const entropy = (unique / value.length) * 100;
-  return entropy > ENTROPY_THRESHOLD;
+  return shannonEntropy(value) >= SHANNON_ENTROPY_THRESHOLD;
 }
 
 const SCRUBBED_PREFIX = "__SCRUBBED_";
@@ -46,7 +64,13 @@ export function scrubSecrets(data: unknown): ScrubResult {
       placeholders.set(placeholder, value);
       return placeholder;
     }
-    if (value && typeof value === "object" && !Array.isArray(value)) {
+    // 배열도 순회한다 (#226 결함 a). BuildSpec.sources 가 배열이라
+    // !Array.isArray(value) 분기가 재귀를 끊어 sources[].params.serviceKey 에
+    // 도달하지 못했다.
+    if (Array.isArray(value)) {
+      return value.map((v, i) => scrubValue(`${key}[${i}]`, v));
+    }
+    if (value && typeof value === "object") {
       const obj = value as Record<string, unknown>;
       const result: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(obj)) {
@@ -65,7 +89,11 @@ export function restoreSecrets(data: unknown, placeholders: Map<string, string>)
   if (typeof data === "string" && data.startsWith(SCRUBBED_PREFIX)) {
     return placeholders.get(data) ?? data;
   }
-  if (data && typeof data === "object" && !Array.isArray(data)) {
+  // 배열 왕복 복원 (#226 결함 c). scrub 가 배열을 순회하므로 restore 도 같이.
+  if (Array.isArray(data)) {
+    return data.map((v) => restoreSecrets(v, placeholders));
+  }
+  if (data && typeof data === "object") {
     const obj = data as Record<string, unknown>;
     const result: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(obj)) {


### PR DESCRIPTION
Closes #226

## 변경 요약

`scrub.ts` 시크릿 스크러빙의 4결함 중 3개 수정 (a/c/d). 보호 대상인 `BuildSpec.sources[].params.serviceKey`에 이제 도달한다.

### 결함 (a) 배열 미순회 — 수정
`scrubValue`/`restoreSecrets`에 `Array.isArray` 분기 추가. 기존 `!Array.isArray(value)` 조건이 `BuildSpec.sources`(배열)에서 재귀를 끊어 보호 대상에 도달 못 함.

### 결함 (c) restoreSecrets 미호출 + 배열 — 수정
`restoreSecrets`에 배열 분기 추가. scrub→restore 왕복이 배열에서도 닫힌다.

### 결함 (d) 엔트로피 휴리스틱 — 수정
`(unique/length)*100` → **Shannon 엔트로피**(bits/char, 임계 4.0). 이전 휴리스틱은 길수록 고유 문자 비율이 떨어져 200자 base64 키를 32%로 계산해 놓쳤다. Shannon은 문자 빈도 분포를 반영해 base64(≈6.0)/hex(=4.0) 키를 정확히 잡는다.

### 결함 (b) generate.ts — 별도 PR 권장
`generate.ts`의 `generateBuildSpec`이 현재 `userPrompt`만 받고 `contextSpec`을 받지 않아 즉시 해당 없음. 다만 설계 의도("호출 경로 공통 계층")에 따라 `provider.stream` 호출을 래핑하는 공통 게이트웨이는 별도 PR에서 진행 권장.

## 회귀 테스트

`src/features/assistant/scrub.test.ts` (신규):
- 배열 순회 (단일/다중/중첩)
- restoreSecrets 왕복 (단순/중첩 배열)
- Shannon 엔트로피 (짧은 값 미탐지 / 200자 base64 탐지 / 반복 문자열 미탐지)

## 검증

- **vitest**: 로컬 환경 node 20.18.1이 rolldown native binding 요구(20.19.0+)와 불일치해 config 로드 실패. tsx로 동등 검증(6/6 PASS). CI(node 올바른 버전)에서 vitest run 예상.
- **typecheck** (`tsc --noEmit`): 통과
- **eslint**: 통과