### PR TITLE
fix: align Studio Builder API contract version

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -60,7 +60,7 @@ Builder API의 계약 버전을 확인합니다. Studio가 기동 시 호환성�
 **요청:** 없음
 **응답 예시:**
 ```json
-{ "service": "kpubdata-builder", "api_version": "1.0.0" }
+{ "service": "kpubdata-builder", "api_version": "1.2.0" }
 ```
 
 ---
@@ -82,7 +82,7 @@ Builder API의 계약 버전을 확인합니다. Studio가 기동 시 호환성�
 
 **응답 예시 (성공):**
 ```json
-{ "status": "valid", "dataset_id": "weather_report", "api_version": "1.0.0" }
+{ "status": "valid", "dataset_id": "weather_report", "api_version": "1.2.0" }
 ```
 
 **응답 예시 (검증 실패, HTTP 400):**
@@ -148,7 +148,7 @@ Builder API의 계약 버전을 확인합니다. Studio가 기동 시 호환성�
     { "source_key": "kma__forecast", "status": "ok", "stages_completed": ["bronze", "silver"], "error": null }
   ],
   "manifest": "output/run_99/manifest.json",
-  "api_version": "1.0.0"
+  "api_version": "1.2.0"
 }
 ```
 
@@ -161,7 +161,7 @@ Builder API의 계약 버전을 확인합니다. Studio가 기동 시 호환성�
     { "source_key": "kma__forecast", "status": "failed", "stages_completed": [], "error": "upstream API timeout" }
   ],
   "manifest": "output/run_99/manifest.json",
-  "api_version": "1.0.0"
+  "api_version": "1.2.0"
 }
 ```
 
@@ -302,7 +302,7 @@ flowchart TD
 
 ## Builder 통합 현황 (#36)
 
-Studio는 Builder 계약 **v1.0.0**(builder #209의 `API_CONTRACT_VERSION`)을 대상으로 한다.
+Studio는 Builder 계약 **v1.2.0**(Builder SSOT의 `API_CONTRACT_VERSION`)을 대상으로 한다.
 계약 버전과 클라이언트 오퍼레이션 집합은 `__tests__/contractConformance.test.ts`가 고정해,
 한쪽이 바뀌면 CI에서 깨진다.
 

--- a/__tests__/builderApiE2E.test.ts
+++ b/__tests__/builderApiE2E.test.ts
@@ -17,7 +17,7 @@ describe("Builder API E2E (MSW)", () => {
   it("GET /version returns service info", async () => {
     const result = await builderApi.version();
     expect(result.service).toBe("kpubdata-builder");
-    expect(result.api_version).toBe("1.1.0");
+    expect(result.api_version).toBe("1.2.0");
   });
 
   it("POST /validate accepts a spec and returns valid", async () => {

--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -2,7 +2,7 @@
  * Builder API 계약 적합성 테스트 (#36).
  *
  * Studio가 의존하는 Builder 계약 버전과 엔드포인트 집합을 고정해, 한쪽이 바뀌면 CI에서
- * 깨지도록 한다. Builder 측 계약은 builder #209(API_CONTRACT_VERSION="1.1.0")가 소유한다.
+ * 깨지도록 한다. Builder 측 SSOT(API_CONTRACT_VERSION="1.2.0")와 일치해야 한다.
  */
 import { describe, expect, it } from "vitest";
 import { API_CONTRACT_VERSION, builderApi } from "@/shared/lib/builderApi";
@@ -12,7 +12,7 @@ const EXPECTED_OPERATIONS = ["version", "validate", "preview", "build", "artifac
 
 describe("Builder API contract conformance (#36)", () => {
   it("pins the contract version Studio targets (must match builder #209)", () => {
-    expect(API_CONTRACT_VERSION).toBe("1.1.0");
+    expect(API_CONTRACT_VERSION).toBe("1.2.0");
   });
 
   it("exposes exactly the expected client operations", () => {

--- a/__tests__/mocks/handlers.ts
+++ b/__tests__/mocks/handlers.ts
@@ -14,14 +14,14 @@ export const handlers = [
   ),
 
   http.get(`${BASE}/version`, () =>
-    HttpResponse.json({ service: "kpubdata-builder", api_version: "1.1.0" }),
+    HttpResponse.json({ service: "kpubdata-builder", api_version: "1.2.0" }),
   ),
 
   http.post(`${BASE}/validate`, () =>
     HttpResponse.json({
       status: "valid",
       dataset_id: "dataset.sample",
-      api_version: "1.1.0",
+      api_version: "1.2.0",
     }),
   ),
 
@@ -49,7 +49,7 @@ export const handlers = [
         { source_key: "sample", status: "ok", stages_completed: ["bronze", "silver", "gold"], error: null },
       ],
       manifest: "/data/test-run-001/manifest.json",
-      api_version: "1.1.0",
+      api_version: "1.2.0",
     }),
   ),
 

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -21,8 +21,8 @@ import { API_BASE } from "@/shared/config/env";
 import * as schemas from "./builderApi.schema";
 import { z } from "zod";
 
-/** Builder API 계약 버전. builder #209의 API_CONTRACT_VERSION과 일치해야 한다. */
-export const API_CONTRACT_VERSION = "1.1.0";
+/** Builder API 계약 버전. builder SSOT의 API_CONTRACT_VERSION과 일치해야 한다. */
+export const API_CONTRACT_VERSION = "1.2.0";
 
 /** 실제 Builder 호출 활성화 여부(미설정 시 mock 사용). */
 export function isRealBuilderEnabled(): boolean {


### PR DESCRIPTION
## Summary
- Fix #231 by updating Studio API_CONTRACT_VERSION to Builder SSOT 1.2.0.
- Align contract conformance tests, MSW Builder mocks, E2E version assertion, and API_CONTRACT examples.

## Validation
- npm test -- --run __tests__/contractConformance.test.ts __tests__/settingsVersionCheck.test.tsx __tests__/builderApiE2E.test.ts
- npm run typecheck
- npm run lint

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)