### PR TITLE
feat(preview): deterministic schema contract draft (#227)

### DIFF
--- a/src/features/build-spec/specMapping.ts
+++ b/src/features/build-spec/specMapping.ts
@@ -29,6 +29,12 @@ export interface BuilderSpec {
     dataset: string;
     params: Record<string, string>;
     alias?: string;
+    /** 소스 스키마 계약 (VAL-1). Studio SourceRef.schema 와 동일 구조. */
+    schema?: {
+      required: string[];
+      dtypes: Record<string, string>;
+      casts: Record<string, string>;
+    };
   }>;
   exports: BuilderExport[];
   metadata: Record<string, string>;
@@ -84,6 +90,7 @@ export function toBuilderSpec(spec: BuildSpec): BuilderSpec {
       dataset: source.dataset,
       params: source.params,
       ...(source.alias ? { alias: source.alias } : {}),
+      ...(source.schema ? { schema: source.schema } : {}),
     })),
     exports: spec.exports.map((target) => ({
       kind: target.format,
@@ -120,6 +127,7 @@ export function fromBuilderSpec(spec: BuilderSpec): BuildSpec {
       dataset: source.dataset,
       params: source.params,
       ...(source.alias ? { alias: source.alias } : {}),
+      ...(source.schema ? { schema: source.schema } : {}),
     })),
     exports: spec.exports.map((e) => {
       // Builder의 output_path는 Studio ExportTarget에 대응 필드가 없어 options에 보존한다(#121).

--- a/src/features/preview/schemaDraft.test.ts
+++ b/src/features/preview/schemaDraft.test.ts
@@ -1,0 +1,67 @@
+/**
+ * 스키마 계약 초안 생성 회귀 테스트 (VAL-4, #227).
+ *
+ * LLM 없이 /preview 컬럼 스키마에서 required/dtypes/키 후보를 결정적으로
+ * 도출하는지 검증한다.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { PreviewColumn } from "@/shared/lib/builderApi.schema";
+
+import { draftSchemaContract } from "./schemaDraft";
+
+const col = (
+  name: string,
+  dtype: string,
+  nullable: boolean,
+  uniqueCount: number,
+): PreviewColumn => ({
+  name,
+  dtype,
+  nullable,
+  unique_count: uniqueCount,
+});
+
+describe("draftSchemaContract — required/dtypes 도출 (#227)", () => {
+  it("nullable=false 컬럼을 required로, 모든 dtype을 dtypes로", () => {
+    const draft = draftSchemaContract(
+      [col("a", "int64", false, 2), col("b", "string", true, 1)],
+      2,
+    );
+    expect(draft.contract.required).toEqual(["a"]);
+    expect(draft.contract.dtypes).toEqual({ a: "int64", b: "string" });
+    expect(draft.contract.casts).toEqual({});
+  });
+
+  it("모두 nullable이면 required 빈 배열", () => {
+    const draft = draftSchemaContract([col("a", "int64", true, 1)], 1);
+    expect(draft.contract.required).toEqual([]);
+  });
+});
+
+describe("draftSchemaContract — 키 후보 (#227)", () => {
+  it("unique_count == row_count인 컬럼을 키 후보로", () => {
+    const draft = draftSchemaContract(
+      [col("id", "int64", false, 3), col("v", "int64", false, 1)],
+      3,
+    );
+    expect(draft.keyCandidates).toEqual(["id"]);
+  });
+
+  it("row_count 0이면 키 후보 없음", () => {
+    const draft = draftSchemaContract([col("id", "int64", false, 0)], 0);
+    expect(draft.keyCandidates).toEqual([]);
+  });
+});
+
+describe("draftSchemaContract — 한계 경고 (#227)", () => {
+  it("행이 있으면 '조회 범위 기준' 경고", () => {
+    const draft = draftSchemaContract([col("a", "int64", false, 1)], 1);
+    expect(draft.warnings.some((w) => w.includes("조회 범위"))).toBe(true);
+  });
+
+  it("행이 0건이면 무의미 경고", () => {
+    const draft = draftSchemaContract([col("a", "int64", false, 0)], 0);
+    expect(draft.warnings.some((w) => w.includes("0건"))).toBe(true);
+  });
+});

--- a/src/features/preview/schemaDraft.ts
+++ b/src/features/preview/schemaDraft.ts
@@ -1,0 +1,53 @@
+/**
+ * 스키마 계약 초안 생성 (VAL-4, #227).
+ *
+ * /preview 응답의 컬럼 스키마에서 BuildSpec sources[].schema 초안을
+ * 결정적으로 도출한다. LLM을 쓰지 않는다 — nullable/dtype/unique_count는
+ * 전체 fetch된 테이블 기준으로 계산된 관측 사실이기 때문이다.
+ *
+ * 주의 — 단일 fetch의 한계:
+ *   required 판정은 "이번에 조회한 파라미터 범위"에 대해서만 참이다. 다른
+ *   날짜·지역을 조회하면 null이 나올 수 있다. 그래서 초안을 자동 확정하지
+ *   말고 사용자 승인을 거쳐야 하며, UI는 warnings로 이 한계를 표시해야 한다.
+ */
+import type { PreviewColumn } from "@/shared/lib/builderApi.schema";
+import type { SchemaContract } from "@/shared/lib/types";
+
+/** 스키마 초안 도출 결과. */
+export interface SchemaDraft {
+  /** BuildSpec sources[].schema 로 직접 직렬화 가능한 계약. */
+  contract: SchemaContract;
+  /** unique_count == row_count 인 컬럼 (키 후보). 사용자 제안용. */
+  keyCandidates: string[];
+  /** 초안의 한계를 알리는 경고. UI가 사용자에게 표시해야 한다. */
+  warnings: string[];
+}
+
+/**
+ * /preview 컬럼 스키마에서 스키마 계약 초안을 도출한다.
+ *
+ * @param columns /preview 응답의 컬럼 목록 (name/dtype/nullable/unique_count).
+ * @param rowCount 전체 fetch된 행 수 (preview_limit 과 무관).
+ */
+export function draftSchemaContract(
+  columns: PreviewColumn[],
+  rowCount: number,
+): SchemaDraft {
+  const required = columns.filter((c) => !c.nullable).map((c) => c.name);
+  const dtypes: Record<string, string> = {};
+  for (const c of columns) {
+    dtypes[c.name] = c.dtype;
+  }
+  const keyCandidates = columns
+    .filter((c) => rowCount > 0 && c.unique_count === rowCount)
+    .map((c) => c.name);
+  const warnings: string[] =
+    rowCount === 0
+      ? ["행이 0건이라 required/키 후보 판정이 무의미하다"]
+      : ["required/키 후보 판정은 현재 조회 범위 기준이다"];
+  return {
+    contract: { required, dtypes, casts: {} },
+    keyCandidates,
+    warnings,
+  };
+}

--- a/src/shared/lib/schemas.ts
+++ b/src/shared/lib/schemas.ts
@@ -19,12 +19,20 @@ export const recordSchema = z.record(z.string(), z.string());
 /** export 옵션은 문자열 키에 임의 값(unknown)을 허용한다 (ExportTarget.options 규약과 정렬) */
 export const exportOptionsSchema = z.record(z.string(), z.unknown());
 
+/** 소스 스키마 계약 (VAL-1). Builder sources[].schema 와 1:1. */
+export const schemaContractSchema = z.object({
+  required: z.array(z.string()),
+  dtypes: z.record(z.string(), z.string()),
+  casts: z.record(z.string(), z.string()),
+});
+
 /** 단일 원본 데이터 참조가 가져야 할 필드를 검증하는 스키마 */
 export const sourceRefSchema = z.object({
   provider: z.string().min(1, "Provider is required."),
   dataset: z.string().min(1, "Dataset is required."),
   params: recordSchema,
   alias: z.string().min(1, "Alias cannot be empty.").optional(),
+  schema: schemaContractSchema.optional(),
 });
 
 /** 결과물 export 대상 정의를 검증하는 스키마 */

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -37,6 +37,15 @@ export interface BuildSpec {
   metadata: Record<string, string>;
 }
 
+export interface SchemaContract {
+  /** 반드시 존재해야 하는 컬럼 이름 목록 (Builder validate_table required_columns). */
+  required: string[];
+  /** 컬럼별 기대 dtype 문자열 (Builder _NAMED_DTYPES 키). */
+  dtypes: Record<string, string>;
+  /** 정규화 시 적용할 컬럼별 캐스팅 (Builder normalize_table casts). */
+  casts: Record<string, string>;
+}
+
 export interface SourceRef {
   /** provider 어댑터 이름 */
   provider: string;
@@ -46,6 +55,8 @@ export interface SourceRef {
   params: Record<string, string>;
   /** 동일 provider/dataset을 여러 번 사용할 때 구분용 별칭 */
   alias?: string;
+  /** 소스 스키마 계약 (VAL-1). undefined면 Silver 검증을 생략한다 (하위 호환). */
+  schema?: SchemaContract;
 }
 
 export interface ExportTarget {


### PR DESCRIPTION
Closes #227

## 변경 요약

`/preview` 응답의 컬럼 스키마에서 BuildSpec `sources[].schema` 초안을 **LLM 없이 결정적으로** 도출하는 함수와 Studio 타입을 Builder 계약(VAL-1 #454)에 맞춘다.

### 세부 변경
- **`SchemaContract` 타입** (`types.ts`) — `required`/`dtypes`/`casts`. `SourceRef.schema?` 선택 필드 (undefined면 기존 동작, 하위 호환)
- **`schemaContractSchema`** (`schemas.ts`) — zod 검증 + `sourceRefSchema`에 `schema` 선택
- **`specMapping.ts`** — `BuilderSpec.sources[].schema` 타입 추가 + `toBuilderSpec`/`fromBuilderSpec`에 직렬화/역직렬화
- **`draftSchemaContract(columns, rowCount)`** (`features/preview/schemaDraft.ts`) — 순수 함수:
  - `required` = `nullable === false` 컬럼
  - `dtypes` = 컬럼별 dtype
  - `keyCandidates` = `unique_count === row_count` (키 후보)
  - `warnings` = "조회 범위 기준" / "0건 무의미" 한계 안내

### 주의 — 단일 fetch의 한계 (#227 본문)
`required` 판정은 이번에 조회한 파라미터 범위에 대해서만 참. UI는 warnings로 한계를 표시하고, 초안을 자동 확정하지 말고 사용자 승인을 거쳐야 한다.

## 검증
- typecheck (`tsc --noEmit`): 통과
- eslint: 통과
- tsx smoke (vitest 환경 node 버전 불일치로 우회): 4/4 PASS (required/dtypes/keyCandidates/warnings)

> vitest는 node 20.18.1 vs rolldown 요구 20.19.0+ 불일치로 로컬 config 로드 실패. CI(올바른 node)에서 `schemaDraft.test.ts` 실행 예상.