### PR TITLE
fix: preserve Builder BuildSpec round trips (#234)

### DIFF
--- a/__tests__/schemas.test.ts
+++ b/__tests__/schemas.test.ts
@@ -21,6 +21,25 @@ describe("buildSpecSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts Builder-compatible JSON params and open export kinds (#234)", () => {
+    const result = buildSpecSchema.safeParse({
+      datasetId: "air-quality-seoul",
+      title: "Seoul Air Quality",
+      description: "Collects city air quality observations.",
+      sources: [
+        {
+          provider: "datago",
+          dataset: "air_quality",
+          params: { page: 1, includeMeta: true, filters: { grade: ["good"] } },
+        },
+      ],
+      exports: [{ format: "csv", options: { outputPath: "exports/data.csv" } }],
+      metadata: { outputPath: "artifacts/seoul-air" },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it("rejects an invalid build spec", () => {
     const result = buildSpecSchema.safeParse({
       datasetId: "",

--- a/__tests__/specMapping.test.ts
+++ b/__tests__/specMapping.test.ts
@@ -23,6 +23,41 @@ describe("toBuilderSpec (#37)", () => {
     });
   });
 
+  it("preserves JSON-valued source params and schema contracts (#234)", () => {
+    const result = toBuilderSpec({
+      ...spec,
+      sources: [
+        {
+          provider: "datago",
+          dataset: "air_quality",
+          params: {
+            sidoName: "서울",
+            page: 1,
+            includeMeta: true,
+            filters: { grade: ["good", "normal"] },
+          },
+          schema: {
+            required: ["station"],
+            dtypes: { value: "Float64" },
+            casts: { value: "float" },
+          },
+        },
+      ],
+    });
+
+    expect(result.sources[0]?.params).toEqual({
+      sidoName: "서울",
+      page: 1,
+      includeMeta: true,
+      filters: { grade: ["good", "normal"] },
+    });
+    expect(result.sources[0]?.schema).toEqual({
+      required: ["station"],
+      dtypes: { value: "Float64" },
+      casts: { value: "float" },
+    });
+  });
+
   it("maps export format → kind and derives output_path", () => {
     const result = toBuilderSpec(spec);
     expect(result.exports[0]).toEqual({
@@ -32,6 +67,33 @@ describe("toBuilderSpec (#37)", () => {
     // huggingface는 디렉터리 경로(옵션 우선).
     expect(result.exports[1].kind).toBe("huggingface");
     expect(result.exports[1].output_path).toBe("hf/aq");
+  });
+
+  it("preserves open export kinds and explicit output paths (#234)", () => {
+    const result = toBuilderSpec({
+      ...spec,
+      exports: [
+        { format: "csv", options: { outputPath: "exports/data.csv", delimiter: "," } },
+      ],
+    });
+
+    expect(result.exports[0]).toEqual({
+      kind: "csv",
+      output_path: "exports/data.csv",
+      options: { outputPath: "exports/data.csv", delimiter: "," },
+    });
+  });
+
+  it("derives distinct output paths for repeated export kinds (#234)", () => {
+    const result = toBuilderSpec({
+      ...spec,
+      exports: [{ format: "jsonl" }, { format: "jsonl" }],
+    });
+
+    expect(result.exports.map((target) => target.output_path)).toEqual([
+      "artifacts/builds/aq/data.jsonl",
+      "artifacts/builds/aq/data-2.jsonl",
+    ]);
   });
 
   it("omits alias when absent", () => {

--- a/src/features/artifacts/api/index.ts
+++ b/src/features/artifacts/api/index.ts
@@ -18,12 +18,16 @@ import type { ExportTarget } from "@/shared/lib/types";
  * (`.../data.<ext>`) mock/실연동 manifest의 파일 목록 표기를 일관되게 유지한다.
  * huggingface는 파일이 아닌 리포지토리 레이아웃이라 데이터 파일을 생성하지 않는다.
  */
-const EXPORT_EXTENSION: Record<ExportTarget["format"], string> = {
+const EXPORT_EXTENSION: Record<string, string> = {
   jsonl: "jsonl",
   markdown: "md",
   parquet: "parquet",
   huggingface: "",
 };
+
+function exportExtension(target: ExportTarget): string {
+  return EXPORT_EXTENSION[target.format] ?? target.format;
+}
 
 /**
  * 빌드 ID 기반의 결정적 mock manifest를 만든다(#30, #29 연동 전 임시).
@@ -56,7 +60,7 @@ function mockManifest(buildId: string): BuildManifest {
             .filter((target) => target.format !== "huggingface")
             .map(
               (target) =>
-                `artifacts/builds/${buildId}/data.${EXPORT_EXTENSION[target.format]}`,
+                `artifacts/builds/${buildId}/data.${exportExtension(target)}`,
             ),
           `artifacts/builds/${buildId}/README.md`,
           `artifacts/builds/${buildId}/manifest.json`,

--- a/src/features/build-spec/specMapping.test.ts
+++ b/src/features/build-spec/specMapping.test.ts
@@ -40,11 +40,46 @@ describe("fromBuilderSpec", () => {
     });
   });
 
-  it("알 수 없는 kind는 즉시 예외를 던진다", () => {
+  it("알 수 없는 Builder export kind도 round-trip 보존한다 (#234)", () => {
     const spec: BuilderSpec = {
       ...baseBuilderSpec,
-      exports: [{ kind: "unknown-format", output_path: "x" }],
+      exports: [{ kind: "csv", output_path: "exports/data.csv" }],
     };
-    expect(() => fromBuilderSpec(spec)).toThrow(/알 수 없는 export kind/);
+    const result = fromBuilderSpec(spec);
+
+    expect(result.exports[0]).toMatchObject({
+      format: "csv",
+      options: { outputPath: "exports/data.csv" },
+    });
+  });
+
+  it("JSON params와 source schema를 Studio spec으로 보존한다 (#234)", () => {
+    const spec: BuilderSpec = {
+      ...baseBuilderSpec,
+      sources: [
+        {
+          provider: "datago",
+          dataset: "air_quality",
+          params: { page: 1, includeMeta: true, filters: { grade: ["good"] } },
+          schema: {
+            required: ["station"],
+            dtypes: { value: "Float64" },
+            casts: { value: "float" },
+          },
+        },
+      ],
+    };
+    const result = fromBuilderSpec(spec);
+
+    expect(result.sources[0]?.params).toEqual({
+      page: 1,
+      includeMeta: true,
+      filters: { grade: ["good"] },
+    });
+    expect(result.sources[0]?.schema).toEqual({
+      required: ["station"],
+      dtypes: { value: "Float64" },
+      casts: { value: "float" },
+    });
   });
 });

--- a/src/features/build-spec/specMapping.ts
+++ b/src/features/build-spec/specMapping.ts
@@ -10,7 +10,7 @@
  *   - exports[].format → exports[].kind (+ output_path 파생)
  *   - sources 필드(provider/dataset/params/alias)는 이름이 동일하다.
  */
-import type { BuildSpec, ExportTarget } from "@/shared/lib/types";
+import type { BuildSpec, ExportTarget, JsonValue } from "@/shared/lib/types";
 
 /** Builder가 기대하는 export 대상(snake_case). */
 interface BuilderExport {
@@ -27,7 +27,7 @@ export interface BuilderSpec {
   sources: Array<{
     provider: string;
     dataset: string;
-    params: Record<string, string>;
+    params: Record<string, JsonValue>;
     alias?: string;
     /** 소스 스키마 계약 (VAL-1). Studio SourceRef.schema 와 동일 구조. */
     schema?: {
@@ -40,38 +40,25 @@ export interface BuilderSpec {
   metadata: Record<string, string>;
 }
 
-const FORMAT_EXTENSION: Record<ExportTarget["format"], string> = {
+const FORMAT_EXTENSION: Record<string, string> = {
   jsonl: "jsonl",
   markdown: "md",
   parquet: "parquet",
   huggingface: "",
 };
 
-/** Studio가 지원하는 export 형식 집합. Builder 응답의 kind 검증에 사용한다. */
-const KNOWN_FORMATS = new Set<ExportTarget["format"]>(
-  Object.keys(FORMAT_EXTENSION) as ExportTarget["format"][],
-);
-
-/**
- * Builder export의 kind를 Studio 형식으로 검증·변환한다.
- *
- * 알 수 없는 kind는 조용히 잘못된 스펙을 만들지 않도록 즉시 실패시킨다(#121).
- */
-function parseExportFormat(kind: string): ExportTarget["format"] {
-  if (KNOWN_FORMATS.has(kind as ExportTarget["format"])) {
-    return kind as ExportTarget["format"];
-  }
-  throw new Error(`알 수 없는 export kind입니다: ${kind}`);
-}
-
 /** export별 output_path를 파생한다. huggingface는 디렉터리, 그 외는 파일 경로. */
-function deriveOutputPath(spec: BuildSpec, target: ExportTarget): string {
+function deriveOutputPath(spec: BuildSpec, target: ExportTarget, index: number): string {
+  const explicitPath = target.options?.["outputPath"];
+  if (typeof explicitPath === "string" && explicitPath.length > 0) return explicitPath;
+
   const base = spec.metadata["outputPath"] ?? `artifacts/builds/${spec.datasetId}`;
   if (target.format === "huggingface") {
-    const outputPath = target.options?.outputPath;
-    return typeof outputPath === "string" ? outputPath : base;
+    return index === 0 ? base : `${base}-${index + 1}`;
   }
-  return `${base}/data.${FORMAT_EXTENSION[target.format]}`;
+  const extension = FORMAT_EXTENSION[target.format] ?? target.format;
+  const suffix = index === 0 ? "" : `-${index + 1}`;
+  return `${base}/data${suffix}.${extension}`;
 }
 
 /**
@@ -92,9 +79,9 @@ export function toBuilderSpec(spec: BuildSpec): BuilderSpec {
       ...(source.alias ? { alias: source.alias } : {}),
       ...(source.schema ? { schema: source.schema } : {}),
     })),
-    exports: spec.exports.map((target) => ({
+    exports: spec.exports.map((target, index) => ({
       kind: target.format,
-      output_path: deriveOutputPath(spec, target),
+      output_path: deriveOutputPath(spec, target, index),
       ...(target.options ? { options: target.options } : {}),
     })),
     metadata: spec.metadata,
@@ -136,7 +123,7 @@ export function fromBuilderSpec(spec: BuilderSpec): BuildSpec {
         options["outputPath"] = e.output_path;
       }
       return {
-        format: parseExportFormat(e.kind),
+        format: e.kind,
         ...(Object.keys(options).length > 0 ? { options } : {}),
       };
     }),

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -55,7 +55,7 @@ interface BuildFormValues {
   sourceDataset: string;
   sourceParams: string;
   outputPath: string;
-  exportFormats: Array<(typeof exportFormats)[number]>;
+  exportFormats: string[];
 }
 
 const initialValues: BuildFormValues = {

--- a/src/shared/lib/schemas.ts
+++ b/src/shared/lib/schemas.ts
@@ -13,8 +13,22 @@ export const exportFormatSchema = z.enum([
   "huggingface",
 ]);
 
-/** 문자열 키와 문자열 값만 허용하는 공통 레코드 스키마 */
+export type JsonValueInput = string | number | boolean | null | JsonValueInput[] | { [key: string]: JsonValueInput };
+
+export const jsonValueSchema: z.ZodType<JsonValueInput> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number().finite(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonValueSchema),
+    z.record(z.string(), jsonValueSchema),
+  ]),
+);
+
 export const recordSchema = z.record(z.string(), z.string());
+
+export const jsonRecordSchema = z.record(z.string(), jsonValueSchema);
 
 /** export 옵션은 문자열 키에 임의 값(unknown)을 허용한다 (ExportTarget.options 규약과 정렬) */
 export const exportOptionsSchema = z.record(z.string(), z.unknown());
@@ -30,14 +44,14 @@ export const schemaContractSchema = z.object({
 export const sourceRefSchema = z.object({
   provider: z.string().min(1, "Provider is required."),
   dataset: z.string().min(1, "Dataset is required."),
-  params: recordSchema,
+  params: jsonRecordSchema,
   alias: z.string().min(1, "Alias cannot be empty.").optional(),
   schema: schemaContractSchema.optional(),
 });
 
 /** 결과물 export 대상 정의를 검증하는 스키마 */
 export const exportTargetSchema = z.object({
-  format: exportFormatSchema,
+  format: z.string().min(1, "Export format is required."),
   options: exportOptionsSchema.optional(),
 });
 
@@ -65,7 +79,7 @@ export const buildFormValuesSchema = z.object({
   sourceDataset: z.string(),
   sourceParams: z.string(),
   outputPath: z.string(),
-  exportFormats: z.array(exportFormatSchema),
+  exportFormats: z.array(z.string()),
 });
 
 /** `buildFormValuesSchema`를 통과한 폼 입력 타입 추론 결과 */

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -22,6 +22,9 @@ export type PublishStatus =
   | "published"
   | "publish_failed";
 
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
 export interface BuildSpec {
   /** Studio와 Builder 전체에서 공통으로 사용하는 데이터셋 식별자 */
   datasetId: string;
@@ -51,8 +54,7 @@ export interface SourceRef {
   provider: string;
   /** provider 내부의 dataset 이름 또는 코드 */
   dataset: string;
-  /** provider 요청 시 전달할 문자열 기반 파라미터 집합 */
-  params: Record<string, string>;
+  params: Record<string, JsonValue>;
   /** 동일 provider/dataset을 여러 번 사용할 때 구분용 별칭 */
   alias?: string;
   /** 소스 스키마 계약 (VAL-1). undefined면 Silver 검증을 생략한다 (하위 호환). */
@@ -61,7 +63,7 @@ export interface SourceRef {
 
 export interface ExportTarget {
   /** 결과물을 어떤 형식으로 내보낼지 결정하는 식별자 */
-  format: "markdown" | "jsonl" | "parquet" | "huggingface";
+  format: string;
   /** 특정 export 형식에만 필요한 추가 옵션 집합 */
   options?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- widen Studio BuildSpec source params to JSON-compatible values and allow open export kinds
- preserve Builder source schema and explicit export outputPath values during mapping
- derive collision-free output paths for repeated export targets and keep open exporter formats flowing through Studio consumers

Closes #234

## Verification
- npm test -- --run __tests__/specMapping.test.ts src/features/build-spec/specMapping.test.ts __tests__/schemas.test.ts
- npm run typecheck
- npm run lint
- npm test
- npm run build
- GIT_MASTER=1 git diff --check