### PR TITLE
fix: surface preview source failures (#235)

### DIFF
--- a/__tests__/newBuildWizard.test.tsx
+++ b/__tests__/newBuildWizard.test.tsx
@@ -1,10 +1,18 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { NewBuildPage } from "@/pages/NewBuildPage";
 import { API_BASE } from "@/shared/config/env";
 import { mswServer } from "../vitest.setup";
+
+const { previewBuildMock } = vi.hoisted(() => ({
+  previewBuildMock: vi.fn(),
+}));
+
+vi.mock("@/features/preview/api", () => ({
+  previewBuild: previewBuildMock,
+}));
 
 function renderWizard() {
   return render(
@@ -41,6 +49,29 @@ function useCatalogFixture() {
     ),
   );
 }
+
+async function goToPreviewStep() {
+  renderWizard();
+  skipTemplateStep();
+  fireEvent.change(screen.getByLabelText(/데이터셋 ID/), { target: { value: "kma-daily" } });
+  fireEvent.change(screen.getByLabelText(/제목/), { target: { value: "기상청 일별" } });
+  fireEvent.change(screen.getByLabelText(/설명/), { target: { value: "일별 관측 데이터" } });
+  fireEvent.click(screen.getByRole("button", { name: "다음" }));
+
+  await screen.findByRole("heading", { name: "데이터 소스" });
+  fireEvent.change(screen.getByLabelText(/제공자/), { target: { value: "datago" } });
+  fireEvent.change(screen.getByLabelText(/데이터셋/), { target: { value: "air-quality" } });
+  fireEvent.click(screen.getByRole("button", { name: "다음" }));
+
+  await screen.findByRole("heading", { name: "파라미터" });
+  fireEvent.click(screen.getByRole("button", { name: "다음" }));
+
+  await screen.findByRole("heading", { name: "미리보기" });
+}
+
+afterEach(() => {
+  previewBuildMock.mockReset();
+});
 
 describe("New Build Wizard", () => {
   it("starts on the template step", () => {
@@ -129,5 +160,20 @@ describe("New Build Wizard", () => {
 
     expect(await screen.findByText(/올바른 JSON이 아닙니다/)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "파라미터" })).toBeInTheDocument();
+  });
+
+  it("shows source failure warnings beside successful preview rows (#235)", async () => {
+    previewBuildMock.mockResolvedValue({
+      rows: [{ id: "x" }],
+      schema: { id: "string" },
+      warnings: [{ sourceKey: "datago.air", error: "인증 실패" }],
+    });
+
+    await goToPreviewStep();
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 새로고침" }));
+
+    expect(await screen.findByText("1개 샘플 행 · 1개 컬럼")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("datago.air: 인증 실패");
+    expect(screen.queryByText("조건에 맞는 데이터가 없습니다")).not.toBeInTheDocument();
   });
 });

--- a/__tests__/previewApi.test.ts
+++ b/__tests__/previewApi.test.ts
@@ -5,7 +5,7 @@
  * {rows, schema}로 변환하는지, mock 모드에서는 네트워크 없이 결정적 mock 데이터를 반환하는지 검증한다.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { previewBuild } from "@/features/preview/api";
+import { PreviewSourceFailureError, previewBuild } from "@/features/preview/api";
 import type { BuildSpec } from "@/shared/lib/types";
 
 function mockResponse(status: number, body: unknown): Response {
@@ -93,6 +93,61 @@ describe("previewBuild (#93)", () => {
 
     expect(result.schema).toEqual({ id: "string" });
     expect(result.rows).toEqual([{ id: "x" }]);
+  });
+
+  it("throws source-keyed errors when every Builder preview source failed (#235)", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse(200, {
+          dataset_id: "multi",
+          previews: [
+            { source_key: "datago.air", status: "failed", error: "인증 실패", schema: [], sample: [], total_rows: 0 },
+            { source_key: "kosis.pop", status: "failed", error: "조회 실패", schema: [], sample: [], total_rows: 0 },
+          ],
+        }),
+      ),
+    );
+
+    const error = await previewBuild(SPEC).catch((cause) => cause);
+
+    expect(error).toBeInstanceOf(PreviewSourceFailureError);
+    expect((error as PreviewSourceFailureError).message).toBe(
+      "모든 미리보기 소스가 실패했습니다: datago.air: 인증 실패; kosis.pop: 조회 실패",
+    );
+    expect((error as PreviewSourceFailureError).failures).toEqual([
+      { sourceKey: "datago.air", error: "인증 실패" },
+      { sourceKey: "kosis.pop", error: "조회 실패" },
+    ]);
+  });
+
+  it("preserves failed source warnings beside the first successful preview (#235)", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse(200, {
+          dataset_id: "multi",
+          previews: [
+            { source_key: "datago.air", status: "failed", error: "인증 실패", schema: [], sample: [], total_rows: 0 },
+            {
+              source_key: "kosis.pop",
+              status: "ok",
+              error: null,
+              schema: [{ name: "id", dtype: "string", nullable: false, unique_count: 1 }],
+              sample: [{ id: "x" }],
+              total_rows: 1,
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await previewBuild(SPEC);
+
+    expect(result.rows).toEqual([{ id: "x" }]);
+    expect(result.warnings).toEqual([{ sourceKey: "datago.air", error: "인증 실패" }]);
   });
 
   it("returns deterministic mock data without network in mock mode", async () => {

--- a/src/features/preview/api/index.ts
+++ b/src/features/preview/api/index.ts
@@ -13,10 +13,23 @@ import {
 } from "@/shared/lib/builderApi";
 import type { BuildSpec } from "@/shared/lib/types";
 
+export interface PreviewSourceFailure {
+  sourceKey: string;
+  error: string;
+}
+
+export class PreviewSourceFailureError extends Error {
+  constructor(readonly failures: PreviewSourceFailure[]) {
+    super(`모든 미리보기 소스가 실패했습니다: ${formatFailures(failures)}`);
+    this.name = "PreviewSourceFailureError";
+  }
+}
+
 /** 미리보기 결과(샘플 행 배열과 컬럼명→타입 스키마 맵). */
 export interface PreviewResult {
   rows: Record<string, unknown>[];
   schema: Record<string, string>;
+  warnings: PreviewSourceFailure[];
 }
 
 /** mock 모드에서 보여줄 결정적 샘플 행. */
@@ -33,6 +46,17 @@ const MOCK_SCHEMA: Record<string, string> = {
   measured_at: "string",
 };
 
+function formatFailures(failures: readonly PreviewSourceFailure[]): string {
+  return failures.map((failure) => `${failure.sourceKey}: ${failure.error}`).join("; ");
+}
+
+function sourceFailure(source: PreviewResponse["previews"][number]): PreviewSourceFailure {
+  return {
+    sourceKey: source.source_key,
+    error: source.error ?? "원인을 알 수 없는 소스 오류",
+  };
+}
+
 /**
  * Builder /preview 응답을 UI가 쓰는 `{ rows, schema }`로 변환한다.
  *
@@ -43,15 +67,22 @@ const MOCK_SCHEMA: Record<string, string> = {
  * @returns 대표 소스의 샘플 행과 컬럼명→타입 스키마.
  */
 function transformPreviewResponse(response: PreviewResponse): PreviewResult {
-  const source =
-    response.previews.find((preview) => preview.status === "ok") ?? response.previews[0];
-  if (!source) return { rows: [], schema: {} };
+  const source = response.previews.find((preview) => preview.status === "ok");
+  if (!source) {
+    const failures = response.previews.map(sourceFailure);
+    if (failures.length > 0) throw new PreviewSourceFailureError(failures);
+    return { rows: [], schema: {}, warnings: [] };
+  }
+
+  const warnings = response.previews
+    .filter((preview) => preview.status === "failed")
+    .map(sourceFailure);
 
   const schema: Record<string, string> = {};
   for (const column of source.schema) {
     schema[column.name] = column.dtype;
   }
-  return { rows: source.sample, schema };
+  return { rows: source.sample, schema, warnings };
 }
 
 /**
@@ -63,7 +94,7 @@ function transformPreviewResponse(response: PreviewResponse): PreviewResult {
  */
 export async function previewBuild(spec: BuildSpec, signal?: AbortSignal): Promise<PreviewResult> {
   if (!isRealBuilderEnabled()) {
-    return { rows: MOCK_ROWS, schema: MOCK_SCHEMA };
+    return { rows: MOCK_ROWS, schema: MOCK_SCHEMA, warnings: [] };
   }
 
   const response = await builderApi.preview(serializeSpec(spec), signal);

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -242,6 +242,7 @@ interface PreviewState {
   status: "idle" | "loading" | "loaded" | "error";
   rows: Record<string, unknown>[];
   schema: Record<string, string>;
+  warnings: string[];
   error?: string;
 }
 
@@ -289,7 +290,7 @@ export function NewBuildPage() {
   const isEditMode = !!buildId && build !== null;
 
   const [step, setStep] = useState(0);
-  const [preview, setPreview] = useState<PreviewState>({ status: "idle", rows: [], schema: {} });
+  const [preview, setPreview] = useState<PreviewState>({ status: "idle", rows: [], schema: {}, warnings: [] });
   const [validation, setValidation] = useState<ValidationState>({
     status: "idle",
     isValid: false,
@@ -375,7 +376,7 @@ export function NewBuildPage() {
     if (!isEditMode || !build || buildLoading) return;
     setBaseSpec(build.spec);
     reset(toFormValues(build.spec));
-    setPreview({ status: "idle", rows: [], schema: {} });
+    setPreview({ status: "idle", rows: [], schema: {}, warnings: [] });
     setValidation({ status: "idle", isValid: false, errors: [] });
     validatedSnapshotRef.current = null;
     setStep(1); // 템플릿 단계를 건너뛰고 기본 정보부터 시작
@@ -389,7 +390,7 @@ export function NewBuildPage() {
     reset(template.values);
     // 템플릿으로 새로 시작하므로 편집 중이던 원본 스펙의 잔여 소스/메타데이터를 버린다.
     setBaseSpec(null);
-    setPreview({ status: "idle", rows: [], schema: {} });
+    setPreview({ status: "idle", rows: [], schema: {}, warnings: [] });
     setValidation({ status: "idle", isValid: false, errors: [] });
     validatedSnapshotRef.current = null;
     setStep(1);
@@ -440,18 +441,24 @@ export function NewBuildPage() {
   async function runPreview() {
     const next = toBuildSpec(getValues(), baseSpec);
     if (next.error || !next.spec) {
-      setPreview({ status: "error", rows: [], schema: {}, error: next.error });
+      setPreview({ status: "error", rows: [], schema: {}, warnings: [], error: next.error });
       return;
     }
-    setPreview({ status: "loading", rows: [], schema: {} });
+    setPreview({ status: "loading", rows: [], schema: {}, warnings: [] });
     try {
       const result = await previewBuild(next.spec);
-      setPreview({ status: "loaded", rows: result.rows, schema: result.schema });
+      setPreview({
+        status: "loaded",
+        rows: result.rows,
+        schema: result.schema,
+        warnings: result.warnings.map((warning) => `${warning.sourceKey}: ${warning.error}`),
+      });
     } catch (cause) {
       setPreview({
         status: "error",
         rows: [],
         schema: {},
+        warnings: [],
         error: cause instanceof Error ? cause.message : "미리보기에 실패했습니다.",
       });
     }
@@ -735,6 +742,19 @@ export function NewBuildPage() {
                   title="조건에 맞는 데이터가 없습니다"
                   description="날짜 범위나 지역 조건을 조정한 뒤 '미리보기 새로고침'을 눌러 다시 시도하세요."
                 />
+              ) : null}
+              {preview.status === "loaded" && preview.warnings.length > 0 ? (
+                <ul className="space-y-2">
+                  {preview.warnings.map((warning) => (
+                    <li
+                      key={warning}
+                      role="alert"
+                      className="rounded-2xl border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200"
+                    >
+                      {warning}
+                    </li>
+                  ))}
+                </ul>
               ) : null}
               {preview.status === "loaded" && preview.rows.length > 0 ? (
                 <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- throw a source-keyed preview error when every Builder /preview source fails inside an HTTP 200 response
- preserve failed-source warnings when at least one source preview succeeds
- show mixed-source warnings in the New Build preview step without replacing successful rows with the empty-data state

Closes #235

## Verification
- npm test -- --run __tests__/previewApi.test.ts __tests__/newBuildWizard.test.tsx
- npm run typecheck
- npm run lint
- npm test
- npm run build
- GIT_MASTER=1 git diff --check
- Playwright smoke: intercepted mixed /preview response, verified sample summary + datago.air warning render and empty-data message stays hidden