### PR TITLE
feat: HTML IA 기반 App Shell·Navigation 재구성 (#247)

### DIFF
--- a/__tests__/headerCta.test.tsx
+++ b/__tests__/headerCta.test.tsx
@@ -15,7 +15,13 @@ function renderLayoutAt(path: string) {
 describe("Layout header CTA (#49)", () => {
   beforeEach(() => {
     // jsdom에 matchMedia가 없으므로 system 분기를 피하도록 light로 고정한다.
-    act(() => useUIStore.setState({ theme: "light", isMobileSidebarOpen: false }));
+    act(() =>
+      useUIStore.setState({
+        theme: "light",
+        isMobileSidebarOpen: false,
+        isKubiDrawerOpen: false,
+      }),
+    );
   });
 
   it("links to New Build from the dashboard", () => {

--- a/__tests__/headerCta.test.tsx
+++ b/__tests__/headerCta.test.tsx
@@ -15,7 +15,7 @@ function renderLayoutAt(path: string) {
 describe("Layout header CTA (#49)", () => {
   beforeEach(() => {
     // jsdom에 matchMedia가 없으므로 system 분기를 피하도록 light로 고정한다.
-    act(() => useUIStore.setState({ theme: "light", isSidebarOpen: false }));
+    act(() => useUIStore.setState({ theme: "light", isMobileSidebarOpen: false }));
   });
 
   it("links to New Build from the dashboard", () => {

--- a/__tests__/kubiContext.test.ts
+++ b/__tests__/kubiContext.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveKubiRouteContext } from "@/features/kubi/context";
+
+describe("resolveKubiRouteContext (#247)", () => {
+  it("labels the home route", () => {
+    expect(resolveKubiRouteContext("/").pageLabel).toBe("Home");
+  });
+
+  it("labels each top-level IA route", () => {
+    expect(resolveKubiRouteContext("/discover").pageLabel).toBe("Discover");
+    expect(resolveKubiRouteContext("/workspace").pageLabel).toBe("Workspace");
+    expect(resolveKubiRouteContext("/add").pageLabel).toBe("Add Data");
+    expect(resolveKubiRouteContext("/quality").pageLabel).toBe("Quality");
+    expect(resolveKubiRouteContext("/kubi").pageLabel).toBe("Kubi");
+    expect(resolveKubiRouteContext("/reports").pageLabel).toBe("Reports");
+    expect(resolveKubiRouteContext("/provider").pageLabel).toBe("Provider");
+    expect(resolveKubiRouteContext("/monitoring").pageLabel).toBe("Monitoring");
+  });
+
+  it("extracts datasetId from a dataset detail route", () => {
+    const context = resolveKubiRouteContext("/datasets/air-quality");
+    expect(context.pageLabel).toBe("Dataset 상세");
+    expect(context.datasetId).toBe("air-quality");
+  });
+
+  it("does not treat the dataset catalog itself as a dataset id", () => {
+    const context = resolveKubiRouteContext("/datasets");
+    expect(context.pageLabel).toBe("Dataset Catalog");
+    expect(context.datasetId).toBeUndefined();
+  });
+
+  it("extracts buildId from build-scoped routes but not from /builds/new", () => {
+    expect(resolveKubiRouteContext("/builds/run-1").buildId).toBe("run-1");
+    expect(resolveKubiRouteContext("/builds/run-1/run").buildId).toBe("run-1");
+    expect(resolveKubiRouteContext("/builds/new").buildId).toBeUndefined();
+    expect(resolveKubiRouteContext("/builds").buildId).toBeUndefined();
+  });
+});

--- a/__tests__/kubiDrawer.test.tsx
+++ b/__tests__/kubiDrawer.test.tsx
@@ -52,8 +52,8 @@ describe("global Kubi drawer (#247)", () => {
     openButton.focus();
     fireEvent.click(openButton);
 
-    const closeButtons = screen.getAllByRole("button", { name: "Kubi 닫기" });
-    const drawerCloseButton = closeButtons[1];
+    // overlay는 접근성 트리에서 제외되므로 header X 버튼이 유일한 "Kubi 닫기"다.
+    const drawerCloseButton = screen.getByRole("button", { name: "Kubi 닫기" });
     expect(drawerCloseButton).toHaveFocus();
 
     fireEvent.keyDown(document, { key: "Tab" });
@@ -63,14 +63,18 @@ describe("global Kubi drawer (#247)", () => {
     expect(openButton).toHaveFocus();
   });
 
-  it("closes via the close button (overlay + header X share the same label)", () => {
+  it("closes via the click-only overlay and the header close button", () => {
     renderLayoutAt("/");
 
     fireEvent.click(screen.getByRole("button", { name: "Kubi 열기" }));
-    const closeButtons = screen.getAllByRole("button", { name: "Kubi 닫기" });
-    expect(closeButtons).toHaveLength(2); // overlay button + header X 버튼
+    // overlay는 aria-hidden이라 role 질의에 잡히지 않는다.
+    expect(screen.queryAllByRole("button", { name: "Kubi 닫기" })).toHaveLength(1);
 
-    fireEvent.click(closeButtons[0]);
+    fireEvent.click(screen.getByTestId("kubi-drawer-overlay"));
+    expect(screen.queryByRole("dialog", { name: "Kubi AI Assistant" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Kubi 열기" }));
+    fireEvent.click(screen.getByRole("button", { name: "Kubi 닫기" }));
     expect(screen.queryByRole("dialog", { name: "Kubi AI Assistant" })).not.toBeInTheDocument();
   });
 

--- a/__tests__/kubiDrawer.test.tsx
+++ b/__tests__/kubiDrawer.test.tsx
@@ -1,0 +1,85 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+import { Layout } from "@/app/Layout";
+import { useUIStore } from "@/shared/hooks/useUIStore";
+
+function renderLayoutAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Layout />
+    </MemoryRouter>,
+  );
+}
+
+describe("global Kubi drawer (#247)", () => {
+  beforeEach(() => {
+    // jsdom에는 matchMedia가 없으므로 system 테마 분기를 피하도록 light로 고정한다.
+    act(() =>
+      useUIStore.setState({ theme: "light", isSidebarOpen: false, isKubiDrawerOpen: false }),
+    );
+  });
+
+  it("is closed by default and opens from the topbar Kubi button", () => {
+    renderLayoutAt("/");
+    expect(screen.queryByRole("dialog", { name: "Kubi AI Assistant" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Kubi 열기" }));
+
+    expect(screen.getByRole("dialog", { name: "Kubi AI Assistant" })).toBeInTheDocument();
+  });
+
+  it("shows the current screen's context label", () => {
+    renderLayoutAt("/quality");
+    fireEvent.click(screen.getByRole("button", { name: "Kubi 열기" }));
+
+    expect(screen.getByText("Quality 화면 문맥")).toBeInTheDocument();
+  });
+
+  it("closes on Escape", () => {
+    renderLayoutAt("/");
+    fireEvent.click(screen.getByRole("button", { name: "Kubi 열기" }));
+    expect(screen.getByRole("dialog", { name: "Kubi AI Assistant" })).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog", { name: "Kubi AI Assistant" })).not.toBeInTheDocument();
+  });
+
+  it("traps keyboard focus and restores it to the opener when closed", () => {
+    renderLayoutAt("/");
+    const openButton = screen.getByRole("button", { name: "Kubi 열기" });
+    openButton.focus();
+    fireEvent.click(openButton);
+
+    const closeButtons = screen.getAllByRole("button", { name: "Kubi 닫기" });
+    const drawerCloseButton = closeButtons[1];
+    expect(drawerCloseButton).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(drawerCloseButton).toHaveFocus();
+
+    fireEvent.click(drawerCloseButton);
+    expect(openButton).toHaveFocus();
+  });
+
+  it("closes via the close button (overlay + header X share the same label)", () => {
+    renderLayoutAt("/");
+
+    fireEvent.click(screen.getByRole("button", { name: "Kubi 열기" }));
+    const closeButtons = screen.getAllByRole("button", { name: "Kubi 닫기" });
+    expect(closeButtons).toHaveLength(2); // overlay button + header X 버튼
+
+    fireEvent.click(closeButtons[0]);
+    expect(screen.queryByRole("dialog", { name: "Kubi AI Assistant" })).not.toBeInTheDocument();
+  });
+
+  it("opens the drawer when the topbar search is submitted", () => {
+    renderLayoutAt("/");
+    const searchInput = screen.getByLabelText("Kubi에게 자연어로 데이터 물어보기");
+    fireEvent.change(searchInput, { target: { value: "서울 대기오염 데이터셋 찾아줘" } });
+    fireEvent.submit(searchInput.closest("form")!);
+
+    expect(screen.getByRole("dialog", { name: "Kubi AI Assistant" })).toBeInTheDocument();
+  });
+});

--- a/__tests__/kubiDrawer.test.tsx
+++ b/__tests__/kubiDrawer.test.tsx
@@ -16,7 +16,7 @@ describe("global Kubi drawer (#247)", () => {
   beforeEach(() => {
     // jsdom에는 matchMedia가 없으므로 system 테마 분기를 피하도록 light로 고정한다.
     act(() =>
-      useUIStore.setState({ theme: "light", isSidebarOpen: false, isKubiDrawerOpen: false }),
+      useUIStore.setState({ theme: "light", isMobileSidebarOpen: false, isKubiDrawerOpen: false }),
     );
   });
 

--- a/__tests__/layout.test.tsx
+++ b/__tests__/layout.test.tsx
@@ -110,7 +110,13 @@ describe("Layout desktop sidebar collapse (#247)", () => {
     expect(aside.className).not.toContain("lg:w-72");
     // 사이드바 링크는 collapsed 상태에서도 여전히 접근 가능해야 한다(텍스트는 시각적으로만 숨김).
     const nav = screen.getByRole("navigation");
-    expect(within(nav).getByRole("link", { name: "Home (홈)" })).toBeInTheDocument();
+    const homeLink = within(nav).getByRole("link", { name: "Home (홈)" });
+    const homeIcon = within(homeLink).getByTestId("nav-icon-home");
+
+    expect(homeLink).toBeInTheDocument();
+    expect(homeIcon).toBeVisible();
+    expect(homeIcon).not.toHaveClass("lg:sr-only");
+    expect(homeIcon).toHaveAttribute("aria-hidden", "true");
   });
 
   it("restores the expanded width after collapsing then expanding again", () => {

--- a/__tests__/layout.test.tsx
+++ b/__tests__/layout.test.tsx
@@ -20,6 +20,7 @@ describe("Layout sidebar accessibility", () => {
         theme: "light",
         isMobileSidebarOpen: false,
         isDesktopSidebarCollapsed: false,
+        isKubiDrawerOpen: false,
       }),
     );
   });
@@ -56,6 +57,7 @@ describe("Layout desktop sidebar collapse (#247)", () => {
         theme: "light",
         isMobileSidebarOpen: false,
         isDesktopSidebarCollapsed: false,
+        isKubiDrawerOpen: false,
       }),
     );
   });

--- a/__tests__/layout.test.tsx
+++ b/__tests__/layout.test.tsx
@@ -1,28 +1,141 @@
-import { act, fireEvent, render } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it } from "vitest";
 import { Layout } from "@/app/Layout";
 import { useUIStore } from "@/shared/hooks/useUIStore";
 
+function renderLayout() {
+  return render(
+    <MemoryRouter>
+      <Layout />
+    </MemoryRouter>,
+  );
+}
+
 describe("Layout sidebar accessibility", () => {
   beforeEach(() => {
     // jsdom에는 matchMedia가 없으므로 system 테마 분기를 피하도록 light로 고정한다.
-    act(() => useUIStore.setState({ theme: "light", isSidebarOpen: false }));
+    act(() =>
+      useUIStore.setState({
+        theme: "light",
+        isMobileSidebarOpen: false,
+        isDesktopSidebarCollapsed: false,
+      }),
+    );
   });
 
-  it("closes the open sidebar when Escape is pressed", () => {
-    render(
-      <MemoryRouter>
-        <Layout />
-      </MemoryRouter>,
-    );
+  it("closes the open mobile sidebar when Escape is pressed", () => {
+    renderLayout();
 
-    // 마운트 시 closeSidebar가 호출되므로, ESC 동작을 검증하기 위해 다시 연다.
-    act(() => useUIStore.setState({ isSidebarOpen: true }));
-    expect(useUIStore.getState().isSidebarOpen).toBe(true);
+    // 마운트 시 closeMobileSidebar가 호출되므로, ESC 동작을 검증하기 위해 다시 연다.
+    act(() => useUIStore.setState({ isMobileSidebarOpen: true }));
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(true);
 
     fireEvent.keyDown(document, { key: "Escape" });
 
-    expect(useUIStore.getState().isSidebarOpen).toBe(false);
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(false);
+  });
+
+  it("does not react to Escape when the mobile sidebar is already closed", () => {
+    renderLayout();
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(false);
+
+    // desktop collapse가 켜져 있어도 ESC는 모바일 오버레이 전용이라 아무 영향이 없어야 한다.
+    act(() => useUIStore.setState({ isDesktopSidebarCollapsed: true }));
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(false);
+    expect(useUIStore.getState().isDesktopSidebarCollapsed).toBe(true);
+  });
+});
+
+describe("Layout desktop sidebar collapse (#247)", () => {
+  beforeEach(() => {
+    act(() =>
+      useUIStore.setState({
+        theme: "light",
+        isMobileSidebarOpen: false,
+        isDesktopSidebarCollapsed: false,
+      }),
+    );
+  });
+
+  it("starts expanded by default and exposes a desktop toggle distinct from the mobile one", () => {
+    renderLayout();
+
+    // 데스크톱 토글은 lg 이상에서만 보이는 버튼이지만 항상 DOM에 존재해 접근 가능해야 한다.
+    expect(screen.getByRole("button", { name: "사이드바 접기" })).toBeInTheDocument();
+    // 모바일 오버레이 토글과는 별개의 버튼이다.
+    expect(screen.getByRole("button", { name: "사이드바 열기/닫기" })).toBeInTheDocument();
+  });
+
+  it("collapses on toggle click and can be expanded again", () => {
+    renderLayout();
+
+    fireEvent.click(screen.getByRole("button", { name: "사이드바 접기" }));
+    expect(useUIStore.getState().isDesktopSidebarCollapsed).toBe(true);
+    expect(screen.getByRole("button", { name: "사이드바 펼치기" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "사이드바 펼치기" }));
+    expect(useUIStore.getState().isDesktopSidebarCollapsed).toBe(false);
+    expect(screen.getByRole("button", { name: "사이드바 접기" })).toBeInTheDocument();
+  });
+
+  it("is a focusable native <button> so Enter/Space activate it via the browser's default keyboard handling", () => {
+    renderLayout();
+    const toggle = screen.getByRole("button", { name: "사이드바 접기" });
+
+    // 다른 사이드바/헤더 버튼과 동일한 패턴: 커스텀 key 핸들러 없이 네이티브 <button>의 활성화
+    // 동작(Enter/Space → click)에 의존한다. 실제 활성화 이벤트는 fireEvent.click으로 검증한다.
+    expect(toggle.tagName).toBe("BUTTON");
+    expect(toggle).toHaveAttribute("type", "button");
+    expect(toggle).not.toHaveAttribute("tabindex", "-1");
+
+    toggle.focus();
+    expect(toggle).toHaveFocus();
+
+    fireEvent.click(toggle);
+    expect(useUIStore.getState().isDesktopSidebarCollapsed).toBe(true);
+  });
+
+  it("shrinks the sidebar's own width and keeps the toggle reachable when collapsed", () => {
+    renderLayout();
+    const aside = screen.getByRole("navigation").closest("aside")!;
+
+    expect(aside.className).toContain("lg:w-72");
+
+    fireEvent.click(screen.getByRole("button", { name: "사이드바 접기" }));
+
+    expect(aside.className).toContain("lg:w-20");
+    expect(aside.className).not.toContain("lg:w-72");
+    // 사이드바 링크는 collapsed 상태에서도 여전히 접근 가능해야 한다(텍스트는 시각적으로만 숨김).
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).getByRole("link", { name: "Home (홈)" })).toBeInTheDocument();
+  });
+
+  it("restores the expanded width after collapsing then expanding again", () => {
+    renderLayout();
+    const aside = screen.getByRole("navigation").closest("aside")!;
+
+    fireEvent.click(screen.getByRole("button", { name: "사이드바 접기" }));
+    expect(aside.className).toContain("lg:w-20");
+
+    fireEvent.click(screen.getByRole("button", { name: "사이드바 펼치기" }));
+    expect(aside.className).toContain("lg:w-72");
+    expect(aside.className).not.toContain("lg:w-20");
+  });
+
+  it("keeps mobile overlay state independent from desktop collapse state", () => {
+    renderLayout();
+
+    // 데스크톱 collapse를 켜도 모바일 오버레이는 열리지 않는다.
+    fireEvent.click(screen.getByRole("button", { name: "사이드바 접기" }));
+    expect(useUIStore.getState().isDesktopSidebarCollapsed).toBe(true);
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(false);
+
+    // 모바일 오버레이를 열어도 데스크톱 collapse 상태는 그대로 유지된다.
+    fireEvent.click(screen.getByRole("button", { name: "사이드바 열기/닫기" }));
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(true);
+    expect(useUIStore.getState().isDesktopSidebarCollapsed).toBe(true);
   });
 });

--- a/__tests__/legacyDeepLinks.test.tsx
+++ b/__tests__/legacyDeepLinks.test.tsx
@@ -18,7 +18,7 @@ async function navigateTo(path: string) {
 describe("router 딥링크 회귀 (#247)", () => {
   beforeEach(() => {
     // jsdom에는 matchMedia가 없으므로 system 테마 분기를 피하도록 light로 고정한다.
-    act(() => useUIStore.setState({ theme: "light", isSidebarOpen: false }));
+    act(() => useUIStore.setState({ theme: "light", isMobileSidebarOpen: false }));
   });
 
   it("legacy /validate, /preview, /artifacts 단독 라우트는 계속 동작한다", async () => {

--- a/__tests__/legacyDeepLinks.test.tsx
+++ b/__tests__/legacyDeepLinks.test.tsx
@@ -18,7 +18,13 @@ async function navigateTo(path: string) {
 describe("router 딥링크 회귀 (#247)", () => {
   beforeEach(() => {
     // jsdom에는 matchMedia가 없으므로 system 테마 분기를 피하도록 light로 고정한다.
-    act(() => useUIStore.setState({ theme: "light", isMobileSidebarOpen: false }));
+    act(() =>
+      useUIStore.setState({
+        theme: "light",
+        isMobileSidebarOpen: false,
+        isKubiDrawerOpen: false,
+      }),
+    );
   });
 
   it("legacy /validate, /preview, /artifacts 단독 라우트는 계속 동작한다", async () => {

--- a/__tests__/legacyDeepLinks.test.tsx
+++ b/__tests__/legacyDeepLinks.test.tsx
@@ -1,0 +1,69 @@
+import { act, render, screen } from "@testing-library/react";
+import { RouterProvider } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+import { router } from "@/app/router";
+import { useUIStore } from "@/shared/hooks/useUIStore";
+
+/**
+ * App Shell 재구성(#247) 이후에도 실제 `router.tsx` 설정을 통해 레거시 딥링크와 새 IA 라우트가
+ * 모두 정상적으로 화면을 렌더하는지 확인한다. 개별 페이지를 직접 렌더하는 다른 테스트와 달리,
+ * 여기서는 브라우저 라우터 전체(basename 포함)를 통해 실제 route 매칭을 검증한다.
+ */
+async function navigateTo(path: string) {
+  await act(async () => {
+    await router.navigate(path);
+  });
+}
+
+describe("router 딥링크 회귀 (#247)", () => {
+  beforeEach(() => {
+    // jsdom에는 matchMedia가 없으므로 system 테마 분기를 피하도록 light로 고정한다.
+    act(() => useUIStore.setState({ theme: "light", isSidebarOpen: false }));
+  });
+
+  it("legacy /validate, /preview, /artifacts 단독 라우트는 계속 동작한다", async () => {
+    render(<RouterProvider router={router} />);
+
+    await navigateTo("/validate");
+    expect(screen.getByRole("heading", { name: "검증 결과" })).toBeInTheDocument();
+
+    await navigateTo("/preview");
+    expect(screen.getByRole("heading", { name: "데이터 미리보기" })).toBeInTheDocument();
+
+    await navigateTo("/artifacts");
+    expect(screen.getByRole("heading", { name: "생성된 결과물" })).toBeInTheDocument();
+  });
+
+  it("기존 build 단위 딥링크(:buildId/*)는 그대로 유지된다", async () => {
+    render(<RouterProvider router={router} />);
+
+    await navigateTo("/builds/abc/run");
+    expect(screen.getByText("진행 단계")).toBeInTheDocument();
+
+    await navigateTo("/builds/abc/artifacts");
+    expect(await screen.findByText("Manifest 요약")).toBeInTheDocument();
+
+    await navigateTo("/builds/abc/publish");
+    expect(screen.getByText("HuggingFace Dataset")).toBeInTheDocument();
+  });
+
+  it("새 IA route(#247)도 셸 안에서 정상적으로 렌더된다", async () => {
+    render(<RouterProvider router={router} />);
+
+    await navigateTo("/discover");
+    expect(screen.getByRole("heading", { name: "데이터 탐색" })).toBeInTheDocument();
+
+    await navigateTo("/quality");
+    expect(screen.getByRole("heading", { name: "품질 센터" })).toBeInTheDocument();
+
+    await navigateTo("/datasets/air-quality");
+    expect(screen.getByRole("heading", { name: "데이터셋: air-quality" })).toBeInTheDocument();
+  });
+
+  it("존재하지 않는 화면은 관련 없는 기존 화면을 재사용하지 않고 오류 폴백으로 처리한다", async () => {
+    render(<RouterProvider router={router} />);
+
+    await navigateTo("/no-such-route-xyz");
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+});

--- a/__tests__/navigation.test.tsx
+++ b/__tests__/navigation.test.tsx
@@ -15,7 +15,13 @@ function renderLayoutAt(path: string) {
 describe("grouped sidebar navigation (#247)", () => {
   beforeEach(() => {
     // jsdom에는 matchMedia가 없으므로 system 테마 분기를 피하도록 light로 고정한다.
-    act(() => useUIStore.setState({ theme: "light", isSidebarOpen: false }));
+    act(() =>
+      useUIStore.setState({
+        theme: "light",
+        isMobileSidebarOpen: false,
+        isDesktopSidebarCollapsed: false,
+      }),
+    );
   });
 
   it("renders the WORKSPACE/DATA/AI/SYSTEM groups from the HTML prototype IA", () => {
@@ -75,13 +81,13 @@ describe("grouped sidebar navigation (#247)", () => {
 
   it("closes the mobile sidebar when a nav link is clicked", () => {
     renderLayoutAt("/");
-    act(() => useUIStore.setState({ isSidebarOpen: true }));
-    expect(useUIStore.getState().isSidebarOpen).toBe(true);
+    act(() => useUIStore.setState({ isMobileSidebarOpen: true }));
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(true);
 
     const nav = screen.getByRole("navigation");
     fireEvent.click(within(nav).getByRole("link", { name: "Discover (탐색)" }));
 
-    expect(useUIStore.getState().isSidebarOpen).toBe(false);
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(false);
   });
 
   it("opens and closes the mobile sidebar overlay", () => {
@@ -89,10 +95,22 @@ describe("grouped sidebar navigation (#247)", () => {
     expect(screen.queryByRole("button", { name: "내비게이션 닫기" })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "사이드바 열기/닫기" }));
-    expect(useUIStore.getState().isSidebarOpen).toBe(true);
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(true);
     expect(screen.getByRole("button", { name: "내비게이션 닫기" })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "내비게이션 닫기" }));
-    expect(useUIStore.getState().isSidebarOpen).toBe(false);
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(false);
+  });
+
+  it("keeps every IA route link accessible while the desktop sidebar is collapsed (#247)", () => {
+    act(() => useUIStore.setState({ isDesktopSidebarCollapsed: true }));
+    renderLayoutAt("/");
+    const nav = screen.getByRole("navigation");
+
+    expect(within(nav).getByRole("link", { name: "Home (홈)" })).toHaveAttribute("href", "/");
+    expect(within(nav).getByRole("link", { name: "Quality (품질)" })).toHaveAttribute(
+      "href",
+      "/quality",
+    );
   });
 });

--- a/__tests__/navigation.test.tsx
+++ b/__tests__/navigation.test.tsx
@@ -20,6 +20,7 @@ describe("grouped sidebar navigation (#247)", () => {
         theme: "light",
         isMobileSidebarOpen: false,
         isDesktopSidebarCollapsed: false,
+        isKubiDrawerOpen: false,
       }),
     );
   });

--- a/__tests__/navigation.test.tsx
+++ b/__tests__/navigation.test.tsx
@@ -1,0 +1,98 @@
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+import { Layout } from "@/app/Layout";
+import { useUIStore } from "@/shared/hooks/useUIStore";
+
+function renderLayoutAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Layout />
+    </MemoryRouter>,
+  );
+}
+
+describe("grouped sidebar navigation (#247)", () => {
+  beforeEach(() => {
+    // jsdom에는 matchMedia가 없으므로 system 테마 분기를 피하도록 light로 고정한다.
+    act(() => useUIStore.setState({ theme: "light", isSidebarOpen: false }));
+  });
+
+  it("renders the WORKSPACE/DATA/AI/SYSTEM groups from the HTML prototype IA", () => {
+    renderLayoutAt("/");
+
+    for (const group of ["WORKSPACE", "DATA", "AI", "SYSTEM"]) {
+      expect(screen.getByText(group)).toBeInTheDocument();
+    }
+  });
+
+  it("exposes every IA route as a sidebar link", () => {
+    renderLayoutAt("/");
+    const nav = screen.getByRole("navigation");
+
+    const expectedLinks: Record<string, string> = {
+      "Home (홈)": "/",
+      "Discover (탐색)": "/discover",
+      "Workspace (작업대)": "/workspace",
+      "Add Data (데이터 추가)": "/add",
+      "Dataset Catalog (데이터셋)": "/datasets",
+      "Builds / Runs (빌드)": "/builds",
+      "Quality (품질)": "/quality",
+      Kubi: "/kubi",
+      "Reports (리포트)": "/reports",
+      "Provider (제공기관)": "/provider",
+      "Monitoring (모니터링)": "/monitoring",
+      "Settings (설정)": "/settings",
+    };
+
+    for (const [label, href] of Object.entries(expectedLinks)) {
+      expect(within(nav).getByRole("link", { name: label })).toHaveAttribute("href", href);
+    }
+  });
+
+  it("marks the current route as active via aria-current", () => {
+    renderLayoutAt("/quality");
+    const nav = screen.getByRole("navigation");
+
+    expect(within(nav).getByRole("link", { name: "Quality (품질)" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(within(nav).getByRole("link", { name: "Home (홈)" })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
+  it("marks only Home active at the root path (end match)", () => {
+    renderLayoutAt("/");
+    const nav = screen.getByRole("navigation");
+
+    expect(within(nav).getByRole("link", { name: "Home (홈)" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("closes the mobile sidebar when a nav link is clicked", () => {
+    renderLayoutAt("/");
+    act(() => useUIStore.setState({ isSidebarOpen: true }));
+    expect(useUIStore.getState().isSidebarOpen).toBe(true);
+
+    const nav = screen.getByRole("navigation");
+    fireEvent.click(within(nav).getByRole("link", { name: "Discover (탐색)" }));
+
+    expect(useUIStore.getState().isSidebarOpen).toBe(false);
+  });
+
+  it("opens and closes the mobile sidebar overlay", () => {
+    renderLayoutAt("/");
+    expect(screen.queryByRole("button", { name: "내비게이션 닫기" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "사이드바 열기/닫기" }));
+    expect(useUIStore.getState().isSidebarOpen).toBe(true);
+    expect(screen.getByRole("button", { name: "내비게이션 닫기" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "내비게이션 닫기" }));
+    expect(useUIStore.getState().isSidebarOpen).toBe(false);
+  });
+});

--- a/__tests__/newIaPages.test.tsx
+++ b/__tests__/newIaPages.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { AddDataPage } from "@/pages/AddDataPage";
+import { DatasetCatalogPage } from "@/pages/DatasetCatalogPage";
+import { DatasetDetailPage } from "@/pages/DatasetDetailPage";
+import { DiscoverPage } from "@/pages/DiscoverPage";
+import { KubiPage } from "@/pages/KubiPage";
+import { MonitoringPage } from "@/pages/MonitoringPage";
+import { ProviderPage } from "@/pages/ProviderPage";
+import { QualityPage } from "@/pages/QualityPage";
+import { ReportsPage } from "@/pages/ReportsPage";
+import { WorkspacePage } from "@/pages/WorkspacePage";
+
+function renderPage(element: ReactNode) {
+  return render(<MemoryRouter>{element}</MemoryRouter>);
+}
+
+describe("새 IA placeholder 화면 (#247)", () => {
+  it.each([
+    [<DiscoverPage />, "데이터 탐색"],
+    [<WorkspacePage />, "작업대"],
+    [<AddDataPage />, "데이터 추가"],
+    [<DatasetCatalogPage />, "데이터셋 카탈로그"],
+    [<QualityPage />, "품질 센터"],
+    [<KubiPage />, "Kubi AI Assistant"],
+    [<ReportsPage />, "리포트"],
+    [<ProviderPage />, "Provider"],
+    [<MonitoringPage />, "모니터링"],
+  ])("renders its title and a 준비 중 안내 without crashing", (element, title) => {
+    renderPage(element);
+    expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
+    expect(screen.getByText("아직 준비 중인 화면입니다")).toBeInTheDocument();
+  });
+
+  it("Add Data placeholder links back to the working New Build wizard", () => {
+    renderPage(<AddDataPage />);
+    expect(screen.getByRole("link", { name: "새 빌드 만들기" })).toHaveAttribute(
+      "href",
+      "/builds/new",
+    );
+  });
+
+  it("Dataset Detail shows the datasetId from the route param", () => {
+    render(
+      <MemoryRouter initialEntries={["/datasets/air-quality"]}>
+        <Routes>
+          <Route path="/datasets/:datasetId" element={<DatasetDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "데이터셋: air-quality" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/themeEffect.test.tsx
+++ b/__tests__/themeEffect.test.tsx
@@ -12,7 +12,7 @@ import { useUIStore } from "@/shared/hooks/useUIStore";
 beforeEach(() => {
   localStorage.clear();
   document.documentElement.removeAttribute("data-theme");
-  useUIStore.setState({ theme: "system", isSidebarOpen: false });
+  useUIStore.setState({ theme: "system", isMobileSidebarOpen: false });
   // jsdom에는 matchMedia가 없으므로 system 모드 구독용으로 스텁한다.
   vi.stubGlobal(
     "matchMedia",

--- a/__tests__/useUIStore.test.ts
+++ b/__tests__/useUIStore.test.ts
@@ -4,24 +4,61 @@ import { useUIStore } from "@/shared/hooks/useUIStore";
 describe("useUIStore", () => {
   beforeEach(() => {
     localStorage.clear();
-    useUIStore.setState({ isSidebarOpen: false, theme: "system" });
+    useUIStore.setState({
+      isMobileSidebarOpen: false,
+      isDesktopSidebarCollapsed: false,
+      theme: "system",
+    });
   });
 
-  it("toggles the sidebar state", () => {
-    useUIStore.getState().toggleSidebar();
-    expect(useUIStore.getState().isSidebarOpen).toBe(true);
+  it("toggles the mobile sidebar overlay state", () => {
+    useUIStore.getState().toggleMobileSidebar();
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(true);
 
-    useUIStore.getState().toggleSidebar();
-    expect(useUIStore.getState().isSidebarOpen).toBe(false);
+    useUIStore.getState().toggleMobileSidebar();
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(false);
   });
 
-  it("persists only the theme to localStorage (#83)", () => {
+  it("toggles the desktop sidebar collapsed state", () => {
+    useUIStore.getState().toggleDesktopSidebarCollapsed();
+    expect(useUIStore.getState().isDesktopSidebarCollapsed).toBe(true);
+
+    useUIStore.getState().toggleDesktopSidebarCollapsed();
+    expect(useUIStore.getState().isDesktopSidebarCollapsed).toBe(false);
+  });
+
+  it("keeps mobile overlay and desktop collapse state independent of each other (#247)", () => {
+    useUIStore.getState().openMobileSidebar();
+    useUIStore.getState().toggleDesktopSidebarCollapsed();
+
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(true);
+    expect(useUIStore.getState().isDesktopSidebarCollapsed).toBe(true);
+
+    // 모바일 오버레이를 닫아도 데스크톱 collapse 선호는 영향받지 않는다.
+    useUIStore.getState().closeMobileSidebar();
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(false);
+    expect(useUIStore.getState().isDesktopSidebarCollapsed).toBe(true);
+
+    // 데스크톱을 다시 펼쳐도 모바일 오버레이는 열리지 않는다.
+    useUIStore.getState().toggleDesktopSidebarCollapsed();
+    expect(useUIStore.getState().isDesktopSidebarCollapsed).toBe(false);
+    expect(useUIStore.getState().isMobileSidebarOpen).toBe(false);
+  });
+
+  it("persists the theme and desktop collapse preference to localStorage (#83, #247)", () => {
     useUIStore.getState().setTheme("dark");
-    useUIStore.getState().openSidebar();
+    useUIStore.getState().toggleDesktopSidebarCollapsed();
 
     const persisted = JSON.parse(localStorage.getItem("kpubdata-studio:ui") ?? "{}");
     expect(persisted.state.theme).toBe("dark");
-    // 사이드바 상태는 저장하지 않는다(데스크톱에서 모바일 드로어 부활 방지).
-    expect(persisted.state.isSidebarOpen).toBeUndefined();
+    expect(persisted.state.isDesktopSidebarCollapsed).toBe(true);
+  });
+
+  it("never persists the mobile overlay open state (#247)", () => {
+    useUIStore.getState().openMobileSidebar();
+
+    const persisted = JSON.parse(localStorage.getItem("kpubdata-studio:ui") ?? "{}");
+    // 사이드바 오버레이 상태는 저장하지 않는다(새로고침 후 모바일 메뉴가 열린 채 복원되는 것 방지).
+    expect(persisted.state.isMobileSidebarOpen).toBeUndefined();
   });
 });

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -136,12 +136,16 @@ function avatarInitial(email: string | null): string {
  * @returns 사이드바, 헤더, 본문 슬롯, 전역 Kubi drawer를 포함한 전체 레이아웃.
  */
 export function Layout() {
-  const closeSidebar = useUIStore((state) => state.closeSidebar);
-  const isSidebarOpen = useUIStore((state) => state.isSidebarOpen);
+  const closeMobileSidebar = useUIStore((state) => state.closeMobileSidebar);
+  const isMobileSidebarOpen = useUIStore((state) => state.isMobileSidebarOpen);
+  const isDesktopSidebarCollapsed = useUIStore((state) => state.isDesktopSidebarCollapsed);
   const openKubiDrawer = useUIStore((state) => state.openKubiDrawer);
   const setTheme = useUIStore((state) => state.setTheme);
   const theme = useUIStore((state) => state.theme);
-  const toggleSidebar = useUIStore((state) => state.toggleSidebar);
+  const toggleMobileSidebar = useUIStore((state) => state.toggleMobileSidebar);
+  const toggleDesktopSidebarCollapsed = useUIStore(
+    (state) => state.toggleDesktopSidebarCollapsed,
+  );
   const email = useAuthStore((state) => state.email);
   const { pathname } = useLocation();
   const headerCta = headerCtaFor(pathname);
@@ -151,66 +155,94 @@ export function Layout() {
   }, [theme]);
 
   useEffect(() => {
-    closeSidebar();
-  }, [closeSidebar]);
+    closeMobileSidebar();
+  }, [closeMobileSidebar]);
 
   // 모바일 사이드바가 열려 있을 때 ESC로 닫을 수 있게 한다(접근성, 제안 §12.2).
+  // 데스크톱 collapse는 오버레이가 아니므로 ESC 대상이 아니다 — 이 핸들러는 모바일 상태만 본다.
   // Kubi drawer의 ESC 처리는 drawer 자신이 열려 있을 때만 담당한다(KubiDrawer 참고).
   useEffect(() => {
-    if (!isSidebarOpen) return;
+    if (!isMobileSidebarOpen) return;
     function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") closeSidebar();
+      if (event.key === "Escape") closeMobileSidebar();
     }
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [isSidebarOpen, closeSidebar]);
+  }, [isMobileSidebarOpen, closeMobileSidebar]);
 
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="flex min-h-screen">
-        {isSidebarOpen ? (
+        {isMobileSidebarOpen ? (
           <button
             aria-label="내비게이션 닫기"
             className="fixed inset-0 z-30 bg-zinc-950/45 lg:hidden"
-            onClick={closeSidebar}
+            onClick={closeMobileSidebar}
             type="button"
           />
         ) : null}
 
         <aside
           className={[
-            "fixed inset-y-0 left-0 z-40 flex w-72 flex-col overflow-y-auto border-r border-border bg-card px-4 py-5 transition-transform lg:static lg:translate-x-0",
-            isSidebarOpen ? "translate-x-0" : "-translate-x-full",
+            "fixed inset-y-0 left-0 z-40 flex w-72 flex-col overflow-y-auto border-r border-border bg-card px-4 py-5 transition-all lg:static lg:translate-x-0",
+            isMobileSidebarOpen ? "translate-x-0" : "-translate-x-full",
+            isDesktopSidebarCollapsed ? "lg:w-20 lg:px-2" : "lg:w-72",
           ].join(" ")}
         >
           <div className="flex items-start justify-between gap-3 pb-5">
             <div>
               <div className="flex items-center gap-2">
-                <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent text-sm font-bold text-accent-foreground">
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-accent text-sm font-bold text-accent-foreground">
                   K
                 </span>
-                <Link className="text-base font-semibold tracking-tight" to="/">
+                <Link
+                  className={[
+                    "text-base font-semibold tracking-tight",
+                    isDesktopSidebarCollapsed ? "lg:sr-only" : "",
+                  ].join(" ")}
+                  to="/"
+                >
                   KPubData Studio
                 </Link>
               </div>
-              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              <p
+                className={[
+                  "mt-3 text-sm leading-relaxed text-muted-foreground",
+                  isDesktopSidebarCollapsed ? "lg:sr-only" : "",
+                ].join(" ")}
+              >
                 데이터 탐색부터 빌드, 품질, Kubi 분석까지 한 흐름으로 진행하세요.
               </p>
             </div>
             <button
               aria-label="사이드바 닫기"
               className="rounded-lg border border-border p-1.5 text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background lg:hidden"
-              onClick={closeSidebar}
+              onClick={closeMobileSidebar}
               type="button"
             >
               ✕
+            </button>
+            {/* 데스크톱 전용 접기/펼치기 토글 — 모바일 닫기 버튼과 반대로 lg 이상에서만 노출되어
+                항상 접근 가능하다(#247). collapsed 상태에서도 이 버튼 자체는 숨지 않는다. */}
+            <button
+              aria-label={isDesktopSidebarCollapsed ? "사이드바 펼치기" : "사이드바 접기"}
+              className="hidden shrink-0 rounded-lg border border-border p-1.5 text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background lg:inline-flex"
+              onClick={toggleDesktopSidebarCollapsed}
+              type="button"
+            >
+              {isDesktopSidebarCollapsed ? "»" : "«"}
             </button>
           </div>
 
           <nav className="mt-2 flex flex-1 flex-col gap-5">
             {navGroups.map((group) => (
               <div key={group.label}>
-                <p className="px-3 pb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                <p
+                  className={[
+                    "px-3 pb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground",
+                    isDesktopSidebarCollapsed ? "lg:sr-only" : "",
+                  ].join(" ")}
+                >
                   {group.label}
                 </p>
                 <div className="space-y-1">
@@ -219,11 +251,13 @@ export function Layout() {
                       className={navigationClassName}
                       end={item.end}
                       key={item.to}
-                      onClick={closeSidebar}
+                      onClick={closeMobileSidebar}
                       title={item.description}
                       to={item.to}
                     >
-                      {item.label}
+                      <span className={isDesktopSidebarCollapsed ? "lg:sr-only" : undefined}>
+                        {item.label}
+                      </span>
                     </NavLink>
                   ))}
                 </div>
@@ -233,16 +267,23 @@ export function Layout() {
             <div className="mt-auto space-y-1 border-t border-border pt-3">
               <NavLink
                 className={navigationClassName}
-                onClick={closeSidebar}
+                onClick={closeMobileSidebar}
                 title="Studio 환경설정"
                 to="/settings"
               >
-                Settings (설정)
+                <span className={isDesktopSidebarCollapsed ? "lg:sr-only" : undefined}>
+                  Settings (설정)
+                </span>
               </NavLink>
             </div>
           </nav>
 
-          <div className="mt-4 rounded-lg border border-border bg-muted p-3">
+          <div
+            className={[
+              "mt-4 rounded-lg border border-border bg-muted p-3",
+              isDesktopSidebarCollapsed ? "lg:sr-only" : "",
+            ].join(" ")}
+          >
             <div className="flex items-center justify-between gap-3">
               <p className="text-sm font-medium">테마</p>
               <select
@@ -266,7 +307,7 @@ export function Layout() {
                 <button
                   aria-label="사이드바 열기/닫기"
                   className="inline-flex rounded-lg border border-border bg-card p-2 text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background lg:hidden"
-                  onClick={toggleSidebar}
+                  onClick={toggleMobileSidebar}
                   type="button"
                 >
                   ☰

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -5,7 +5,7 @@
  * 전역 Kubi drawer mount를 한곳에서 관리하며 실제 라우트 콘텐츠는 `Outlet`을 통해 주입한다.
  * 메뉴 구성은 `kpubdata_ui_prototype_v1.html` IA(WORKSPACE/DATA/AI/SYSTEM)를 따른다(#247).
  */
-import { useEffect } from "react";
+import { useEffect, type ReactNode } from "react";
 import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
 import { useAuthStore } from "@/features/auth/store";
 import { KubiDrawer } from "@/features/kubi/KubiDrawer";
@@ -36,8 +36,40 @@ interface NavItem {
   label: string;
   /** 링크 title(hover 설명) */
   description: string;
+  /** collapsed 상태에서도 메뉴를 식별할 수 있게 항상 표시하는 아이콘 */
+  icon: ReactNode;
   /** index 라우트처럼 정확히 일치할 때만 active로 표시할지 여부 */
   end?: boolean;
+}
+
+interface SidebarIconProps {
+  /** 테스트와 디버깅에서 아이콘을 식별할 이름 */
+  name: string;
+  /** 아이콘을 그리는 SVG 요소 */
+  children: ReactNode;
+}
+
+/** 새 아이콘 의존성 없이 사이드바에서 공통으로 쓰는 선형 SVG 아이콘이다. */
+function SidebarIcon({ name, children }: SidebarIconProps) {
+  return (
+    <span
+      aria-hidden="true"
+      className="flex h-5 w-5 shrink-0 items-center justify-center"
+      data-testid={`nav-icon-${name}`}
+    >
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.75"
+        viewBox="0 0 24 24"
+      >
+        {children}
+      </svg>
+    </span>
+  );
 }
 
 interface NavGroup {
@@ -53,32 +85,141 @@ const navGroups: NavGroup[] = [
   {
     label: "WORKSPACE",
     items: [
-      { to: "/", label: "Home (홈)", description: "최근 작업 요약과 빠른 시작", end: true },
-      { to: "/discover", label: "Discover (탐색)", description: "Provider·데이터셋 탐색" },
-      { to: "/workspace", label: "Workspace (작업대)", description: "최근 작업과 저장한 BuildSpec" },
+      {
+        to: "/",
+        label: "Home (홈)",
+        description: "최근 작업 요약과 빠른 시작",
+        end: true,
+        icon: (
+          <SidebarIcon name="home">
+            <path d="m3 11 9-8 9 8" />
+            <path d="M5 10v10h14V10M9 20v-6h6v6" />
+          </SidebarIcon>
+        ),
+      },
+      {
+        to: "/discover",
+        label: "Discover (탐색)",
+        description: "Provider·데이터셋 탐색",
+        icon: (
+          <SidebarIcon name="discover">
+            <circle cx="12" cy="12" r="9" />
+            <path d="m15 9-2 4-4 2 2-4 4-2Z" />
+          </SidebarIcon>
+        ),
+      },
+      {
+        to: "/workspace",
+        label: "Workspace (작업대)",
+        description: "최근 작업과 저장한 BuildSpec",
+        icon: (
+          <SidebarIcon name="workspace">
+            <rect width="16" height="14" x="4" y="6" rx="2" />
+            <path d="M9 6V4h6v2M4 11h16" />
+          </SidebarIcon>
+        ),
+      },
     ],
   },
   {
     label: "DATA",
     items: [
-      { to: "/add", label: "Add Data (데이터 추가)", description: "Public API·File·URL로 데이터 추가" },
-      { to: "/datasets", label: "Dataset Catalog (데이터셋)", description: "발행된 데이터셋 검색" },
-      { to: "/builds", label: "Builds / Runs (빌드)", description: "빌드와 실행 이력" },
-      { to: "/quality", label: "Quality (품질)", description: "빌드·데이터셋 품질 결과" },
+      {
+        to: "/add",
+        label: "Add Data (데이터 추가)",
+        description: "Public API·File·URL로 데이터 추가",
+        icon: (
+          <SidebarIcon name="add">
+            <circle cx="12" cy="12" r="9" />
+            <path d="M12 8v8M8 12h8" />
+          </SidebarIcon>
+        ),
+      },
+      {
+        to: "/datasets",
+        label: "Dataset Catalog (데이터셋)",
+        description: "발행된 데이터셋 검색",
+        icon: (
+          <SidebarIcon name="datasets">
+            <ellipse cx="12" cy="5" rx="7" ry="3" />
+            <path d="M5 5v6c0 1.7 3.1 3 7 3s7-1.3 7-3V5M5 11v6c0 1.7 3.1 3 7 3s7-1.3 7-3v-6" />
+          </SidebarIcon>
+        ),
+      },
+      {
+        to: "/builds",
+        label: "Builds / Runs (빌드)",
+        description: "빌드와 실행 이력",
+        icon: (
+          <SidebarIcon name="builds">
+            <circle cx="12" cy="12" r="9" />
+            <path d="m10 8 6 4-6 4V8Z" />
+          </SidebarIcon>
+        ),
+      },
+      {
+        to: "/quality",
+        label: "Quality (품질)",
+        description: "빌드·데이터셋 품질 결과",
+        icon: (
+          <SidebarIcon name="quality">
+            <circle cx="12" cy="12" r="9" />
+            <path d="m8 12 3 3 5-6" />
+          </SidebarIcon>
+        ),
+      },
     ],
   },
   {
     label: "AI",
     items: [
-      { to: "/kubi", label: "Kubi", description: "Context-aware AI 어시스턴트" },
-      { to: "/reports", label: "Reports (리포트)", description: "분석 리포트 생성·열람" },
+      {
+        to: "/kubi",
+        label: "Kubi",
+        description: "Context-aware AI 어시스턴트",
+        icon: (
+          <SidebarIcon name="kubi">
+            <rect width="14" height="12" x="5" y="7" rx="3" />
+            <path d="M12 3v4M9 12h.01M15 12h.01M9 16h6" />
+          </SidebarIcon>
+        ),
+      },
+      {
+        to: "/reports",
+        label: "Reports (리포트)",
+        description: "분석 리포트 생성·열람",
+        icon: (
+          <SidebarIcon name="reports">
+            <path d="M6 3h9l3 3v15H6V3Z" />
+            <path d="M14 3v4h4M9 12h6M9 16h6" />
+          </SidebarIcon>
+        ),
+      },
     ],
   },
   {
     label: "SYSTEM",
     items: [
-      { to: "/provider", label: "Provider (제공기관)", description: "Provider 연결·자격 증명" },
-      { to: "/monitoring", label: "Monitoring (모니터링)", description: "실행·시스템 모니터링" },
+      {
+        to: "/provider",
+        label: "Provider (제공기관)",
+        description: "Provider 연결·자격 증명",
+        icon: (
+          <SidebarIcon name="provider">
+            <path d="M4 21V7l8-4 8 4v14M8 10h.01M12 10h.01M16 10h.01M8 14h.01M12 14h.01M16 14h.01" />
+          </SidebarIcon>
+        ),
+      },
+      {
+        to: "/monitoring",
+        label: "Monitoring (모니터링)",
+        description: "실행·시스템 모니터링",
+        icon: (
+          <SidebarIcon name="monitoring">
+            <path d="M3 12h4l2-5 4 10 2-5h6" />
+          </SidebarIcon>
+        ),
+      },
     ],
   },
 ];
@@ -255,6 +396,7 @@ export function Layout() {
                       title={item.description}
                       to={item.to}
                     >
+                      {item.icon}
                       <span className={isDesktopSidebarCollapsed ? "lg:sr-only" : undefined}>
                         {item.label}
                       </span>
@@ -271,6 +413,10 @@ export function Layout() {
                 title="Studio 환경설정"
                 to="/settings"
               >
+                <SidebarIcon name="settings">
+                  <circle cx="12" cy="12" r="3" />
+                  <path d="M19 12a7 7 0 0 0-.1-1l2-1.5-2-3.4-2.3 1A7 7 0 0 0 15 6l-.3-2.5h-4L10.4 6a7 7 0 0 0-1.7 1L6.5 6 4.5 9.5 6.5 11a7 7 0 0 0 0 2l-2 1.5 2 3.4 2.3-1A7 7 0 0 0 10.4 18l.3 2.5h4L15 18a7 7 0 0 0 1.7-1l2.3 1 2-3.4-2-1.5a7 7 0 0 0 .1-1Z" />
+                </SidebarIcon>
                 <span className={isDesktopSidebarCollapsed ? "lg:sr-only" : undefined}>
                   Settings (설정)
                 </span>

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -1,18 +1,23 @@
 /**
  * Studio의 공통 앱 셸과 내비게이션 레이아웃을 정의하는 파일.
  *
- * 좌측 사이드바, 상단 헤더, 테마 전환, 모바일 오버레이를 한곳에서 관리하며
- * 실제 라우트 콘텐츠는 `Outlet`을 통해 주입한다.
+ * 좌측 grouped 사이드바, 상단 헤더(Kubi 검색·Kubi 버튼·avatar), 테마 전환, 모바일 오버레이,
+ * 전역 Kubi drawer mount를 한곳에서 관리하며 실제 라우트 콘텐츠는 `Outlet`을 통해 주입한다.
+ * 메뉴 구성은 `kpubdata_ui_prototype_v1.html` IA(WORKSPACE/DATA/AI/SYSTEM)를 따른다(#247).
  */
 import { useEffect } from "react";
 import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
+import { useAuthStore } from "@/features/auth/store";
+import { KubiDrawer } from "@/features/kubi/KubiDrawer";
+import { KubiSearchInput } from "@/features/kubi/KubiSearchInput";
 import { useUIStore } from "@/shared/hooks/useUIStore";
 
 /**
  * 현재 라우트에 맞는 헤더 CTA(라벨/이동 경로)를 고른다(제안 §6.4).
  *
  * 새 빌드 작성 화면에서는 중복되는 '새 빌드 만들기' 대신 '빌드 목록'으로 안내하고,
- * 그 외 화면에서는 새 빌드 작성으로 유도한다.
+ * 그 외 화면에서는 새 빌드 작성으로 유도한다. 새 IA의 Discover/Add Data/Quality 등 신규
+ * placeholder 화면은 이 조건들과 겹치지 않으므로 그대로 기본값(새 빌드 만들기)을 받는다(#247).
  *
  * @param pathname - 현재 경로.
  * @returns 헤더 CTA의 라벨과 이동 경로.
@@ -24,15 +29,59 @@ function headerCtaFor(pathname: string): { to: string; label: string } {
   return { to: "/builds/new", label: "새 빌드 만들기" };
 }
 
-// 내비게이션은 Build 중심으로 단순화한다(제안 §6.3). Validate/Preview는 독립 메뉴에서
-// 제거하고 New Build Wizard 내부 패널로 통합한다(§5.3/§5.4).
-const primaryNavItems = [
-  { to: "/", label: "대시보드", description: "최근 빌드와 빠른 시작", end: true },
-  { to: "/builds", label: "빌드", description: "전체 빌드와 실행 이력", end: false },
-  { to: "/builds/new", label: "새 빌드 (New Build)", description: "새 스펙 만들기", end: false },
-  { to: "/artifacts", label: "결과물 (Artifacts)", description: "생성된 산출물", end: false },
-  { to: "/settings", label: "설정 (Settings)", description: "Studio 환경설정", end: false },
-] as const;
+interface NavItem {
+  /** 이동 경로 */
+  to: string;
+  /** 사이드바에 표시할 라벨 */
+  label: string;
+  /** 링크 title(hover 설명) */
+  description: string;
+  /** index 라우트처럼 정확히 일치할 때만 active로 표시할지 여부 */
+  end?: boolean;
+}
+
+interface NavGroup {
+  /** 그룹 헤더 라벨(대문자 표기, 프로토타입 IA와 동일) */
+  label: string;
+  items: NavItem[];
+}
+
+// 최종 IA(WORKSPACE/DATA/AI/SYSTEM)를 그대로 반영한 grouped nav model이다(#247).
+// New Build Wizard(`/builds/new`)는 메뉴에서 제거됐지만 route와 헤더 CTA에서는 계속 쓰인다 —
+// Add Data Workbench(#250)가 이를 흡수하기 전까지는 유일한 실제 빌드 생성 흐름이기 때문이다.
+const navGroups: NavGroup[] = [
+  {
+    label: "WORKSPACE",
+    items: [
+      { to: "/", label: "Home (홈)", description: "최근 작업 요약과 빠른 시작", end: true },
+      { to: "/discover", label: "Discover (탐색)", description: "Provider·데이터셋 탐색" },
+      { to: "/workspace", label: "Workspace (작업대)", description: "최근 작업과 저장한 BuildSpec" },
+    ],
+  },
+  {
+    label: "DATA",
+    items: [
+      { to: "/add", label: "Add Data (데이터 추가)", description: "Public API·File·URL로 데이터 추가" },
+      { to: "/datasets", label: "Dataset Catalog (데이터셋)", description: "발행된 데이터셋 검색" },
+      { to: "/builds", label: "Builds / Runs (빌드)", description: "빌드와 실행 이력" },
+      { to: "/quality", label: "Quality (품질)", description: "빌드·데이터셋 품질 결과" },
+    ],
+  },
+  {
+    label: "AI",
+    items: [
+      { to: "/kubi", label: "Kubi", description: "Context-aware AI 어시스턴트" },
+      { to: "/reports", label: "Reports (리포트)", description: "분석 리포트 생성·열람" },
+    ],
+  },
+  {
+    label: "SYSTEM",
+    items: [
+      { to: "/provider", label: "Provider (제공기관)", description: "Provider 연결·자격 증명" },
+      { to: "/monitoring", label: "Monitoring (모니터링)", description: "실행·시스템 모니터링" },
+    ],
+  },
+];
 
 /**
  * 현재 테마 모드에 대응하는 DOM 테마 값.
@@ -69,16 +118,31 @@ function navigationClassName({ isActive }: { isActive: boolean }) {
 }
 
 /**
+ * 로그인된 이메일에서 avatar에 표시할 이니셜 한 글자를 뽑는다.
+ *
+ * 로그인 전이거나 이메일이 없으면 물음표를 보여줘 "아직 로그인하지 않음"을 드러낸다.
+ * 실제 avatar 메뉴/프로필 화면은 #263(Email/Password Auth)에서 이 상태를 이어받는다.
+ *
+ * @param email - 로그인된 사용자 이메일(없으면 `null`).
+ * @returns avatar에 표시할 한 글자.
+ */
+function avatarInitial(email: string | null): string {
+  return email ? email.charAt(0).toUpperCase() : "?";
+}
+
+/**
  * Studio 모든 페이지에 공통으로 적용되는 앱 셸 컴포넌트.
  *
- * @returns 사이드바, 헤더, 본문 슬롯을 포함한 전체 레이아웃.
+ * @returns 사이드바, 헤더, 본문 슬롯, 전역 Kubi drawer를 포함한 전체 레이아웃.
  */
 export function Layout() {
   const closeSidebar = useUIStore((state) => state.closeSidebar);
   const isSidebarOpen = useUIStore((state) => state.isSidebarOpen);
+  const openKubiDrawer = useUIStore((state) => state.openKubiDrawer);
   const setTheme = useUIStore((state) => state.setTheme);
   const theme = useUIStore((state) => state.theme);
   const toggleSidebar = useUIStore((state) => state.toggleSidebar);
+  const email = useAuthStore((state) => state.email);
   const { pathname } = useLocation();
   const headerCta = headerCtaFor(pathname);
 
@@ -91,6 +155,7 @@ export function Layout() {
   }, [closeSidebar]);
 
   // 모바일 사이드바가 열려 있을 때 ESC로 닫을 수 있게 한다(접근성, 제안 §12.2).
+  // Kubi drawer의 ESC 처리는 drawer 자신이 열려 있을 때만 담당한다(KubiDrawer 참고).
   useEffect(() => {
     if (!isSidebarOpen) return;
     function onKeyDown(event: KeyboardEvent) {
@@ -114,7 +179,7 @@ export function Layout() {
 
         <aside
           className={[
-            "fixed inset-y-0 left-0 z-40 flex w-72 flex-col border-r border-border bg-card px-4 py-5 transition-transform lg:static lg:translate-x-0",
+            "fixed inset-y-0 left-0 z-40 flex w-72 flex-col overflow-y-auto border-r border-border bg-card px-4 py-5 transition-transform lg:static lg:translate-x-0",
             isSidebarOpen ? "translate-x-0" : "-translate-x-full",
           ].join(" ")}
         >
@@ -129,7 +194,7 @@ export function Layout() {
                 </Link>
               </div>
               <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-                데이터 소스 선택부터 미리보기, 검증, 결과물까지 한 흐름으로 진행하세요.
+                데이터 탐색부터 빌드, 품질, Kubi 분석까지 한 흐름으로 진행하세요.
               </p>
             </div>
             <button
@@ -142,23 +207,38 @@ export function Layout() {
             </button>
           </div>
 
-          <nav className="mt-2 flex flex-1 flex-col">
-            <p className="px-3 pb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              메뉴
-            </p>
-            <div className="space-y-1">
-              {primaryNavItems.map((item) => (
-                <NavLink
-                  className={navigationClassName}
-                  end={item.end}
-                  key={item.to}
-                  onClick={closeSidebar}
-                  to={item.to}
-                  title={item.description}
-                >
-                  {item.label}
-                </NavLink>
-              ))}
+          <nav className="mt-2 flex flex-1 flex-col gap-5">
+            {navGroups.map((group) => (
+              <div key={group.label}>
+                <p className="px-3 pb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  {group.label}
+                </p>
+                <div className="space-y-1">
+                  {group.items.map((item) => (
+                    <NavLink
+                      className={navigationClassName}
+                      end={item.end}
+                      key={item.to}
+                      onClick={closeSidebar}
+                      title={item.description}
+                      to={item.to}
+                    >
+                      {item.label}
+                    </NavLink>
+                  ))}
+                </div>
+              </div>
+            ))}
+
+            <div className="mt-auto space-y-1 border-t border-border pt-3">
+              <NavLink
+                className={navigationClassName}
+                onClick={closeSidebar}
+                title="Studio 환경설정"
+                to="/settings"
+              >
+                Settings (설정)
+              </NavLink>
             </div>
           </nav>
 
@@ -181,8 +261,8 @@ export function Layout() {
 
         <div className="flex min-h-screen flex-1 flex-col lg:pl-0">
           <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur">
-            <div className="flex items-center justify-between gap-4 px-5 py-3.5 sm:px-8">
-              <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-3.5 sm:px-8">
+              <div className="flex min-w-0 items-center gap-3">
                 <button
                   aria-label="사이드바 열기/닫기"
                   className="inline-flex rounded-lg border border-border bg-card p-2 text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background lg:hidden"
@@ -191,28 +271,55 @@ export function Layout() {
                 >
                   ☰
                 </button>
-                <div>
+                <div className="min-w-0">
                   <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                    Builder 제어 화면
+                    KPubData Studio
                   </p>
-                  <h1 className="text-base font-semibold tracking-tight">
-                    학생과 메인테이너를 위한 공공데이터 빌드 워크플로
+                  <h1 className="truncate text-base font-semibold tracking-tight">
+                    공공데이터 탐색·빌드·품질·Kubi 워크플로
                   </h1>
                 </div>
               </div>
 
-              <Link
-                className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground shadow-sm transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                to={headerCta.to}
-              >
-                {headerCta.label}
-              </Link>
+              <div className="flex min-w-0 flex-1 items-center justify-end gap-2 sm:gap-3">
+                <KubiSearchInput />
+
+                <button
+                  aria-haspopup="dialog"
+                  aria-label="Kubi 열기"
+                  className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  onClick={openKubiDrawer}
+                  type="button"
+                >
+                  <span aria-hidden="true">✨</span>
+                  <span className="hidden sm:inline">Kubi</span>
+                </button>
+
+                <Link
+                  className="hidden rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground shadow-sm transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background md:inline-flex"
+                  to={headerCta.to}
+                >
+                  {headerCta.label}
+                </Link>
+
+                {/* avatar 진입점 — #263에서 실제 프로필/로그아웃 메뉴로 확장될 구조(#247). */}
+                <Link
+                  aria-label={email ? `${email} 계정 메뉴로 이동` : "로그인이 필요합니다 — 설정으로 이동"}
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border bg-muted text-sm font-semibold text-foreground hover:bg-accent-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  title={email ?? "로그인이 필요합니다"}
+                  to="/settings"
+                >
+                  {avatarInitial(email)}
+                </Link>
+              </div>
             </div>
           </header>
 
           <Outlet />
         </div>
       </div>
+
+      <KubiDrawer />
     </div>
   );
 }

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -491,7 +491,7 @@ export function Layout() {
 
                 {/* avatar 진입점 — #263에서 실제 프로필/로그아웃 메뉴로 확장될 구조(#247). */}
                 <Link
-                  aria-label={email ? `${email} 계정 메뉴로 이동` : "로그인이 필요합니다 — 설정으로 이동"}
+                  aria-label={email ? `${email} 설정으로 이동` : "로그인이 필요합니다 — 설정으로 이동"}
                   className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border bg-muted text-sm font-semibold text-foreground hover:bg-accent-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   title={email ?? "로그인이 필요합니다"}
                   to="/settings"

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -7,17 +7,27 @@ import type { ReactElement } from "react";
 import { createBrowserRouter } from "react-router-dom";
 import { FeatureErrorBoundary, RouteErrorBoundary } from "@/app/ErrorBoundary";
 import { Layout } from "@/app/Layout";
+import { AddDataPage } from "@/pages/AddDataPage";
 import { ArtifactsPage } from "@/pages/ArtifactsPage";
 import { BuildArtifactsPage } from "@/pages/BuildArtifactsPage";
 import { BuildDetailPage } from "@/pages/BuildDetailPage";
 import { BuildPublishPage } from "@/pages/BuildPublishPage";
 import { BuildRunPage } from "@/pages/BuildRunPage";
 import { BuildsPage } from "@/pages/BuildsPage";
+import { DatasetCatalogPage } from "@/pages/DatasetCatalogPage";
+import { DatasetDetailPage } from "@/pages/DatasetDetailPage";
+import { DiscoverPage } from "@/pages/DiscoverPage";
 import { HomePage } from "@/pages/HomePage";
+import { KubiPage } from "@/pages/KubiPage";
+import { MonitoringPage } from "@/pages/MonitoringPage";
 import { NewBuildPage } from "@/pages/NewBuildPage";
 import { PreviewPage } from "@/pages/PreviewPage";
+import { ProviderPage } from "@/pages/ProviderPage";
+import { QualityPage } from "@/pages/QualityPage";
+import { ReportsPage } from "@/pages/ReportsPage";
 import { SettingsPage } from "@/pages/SettingsPage";
 import { ValidatePage } from "@/pages/ValidatePage";
+import { WorkspacePage } from "@/pages/WorkspacePage";
 
 /**
  * 페이지 요소를 feature 단위 ErrorBoundary로 감싼다 (#97).
@@ -49,6 +59,29 @@ export const router = createBrowserRouter([
         index: true,
         element: withFeatureBoundary("홈", <HomePage />),
       },
+      // 새 IA(#247)의 WORKSPACE 그룹. Discover/Workspace는 아직 placeholder이며
+      // #249/#260에서 실제 화면으로 교체된다.
+      {
+        path: "discover",
+        element: withFeatureBoundary("Discover", <DiscoverPage />),
+      },
+      {
+        path: "workspace",
+        element: withFeatureBoundary("Workspace", <WorkspacePage />),
+      },
+      // 새 IA의 DATA 그룹. Add Data/Dataset Catalog/Quality는 #250/#253/#254에서 구현된다.
+      {
+        path: "add",
+        element: withFeatureBoundary("Add Data", <AddDataPage />),
+      },
+      {
+        path: "datasets",
+        element: withFeatureBoundary("Dataset Catalog", <DatasetCatalogPage />),
+      },
+      {
+        path: "datasets/:datasetId",
+        element: withFeatureBoundary("Dataset 상세", <DatasetDetailPage />),
+      },
       {
         path: "builds",
         element: withFeatureBoundary("빌드 목록", <BuildsPage />),
@@ -56,6 +89,10 @@ export const router = createBrowserRouter([
       {
         path: "builds/new",
         element: withFeatureBoundary("새 빌드 만들기", <NewBuildPage />),
+      },
+      {
+        path: "quality",
+        element: withFeatureBoundary("Quality", <QualityPage />),
       },
       // Build 단위 중심 라우트 (제안 §3.3): 상세 → 편집/실행/결과물/게시.
       {
@@ -79,8 +116,28 @@ export const router = createBrowserRouter([
         path: "builds/:buildId/publish",
         element: withFeatureBoundary("게시", <BuildPublishPage />),
       },
-      // 레거시 단독 라우트: 내비게이션에서는 제거됐지만 딥링크 호환을 위해 유지한다.
-      // Validate/Preview는 New Build Wizard 내부 패널로 통합 예정(§5.3/§5.4).
+      // 새 IA의 AI 그룹(#256에서 실제 기능 구현). 전역 Kubi drawer는
+      // `src/features/kubi/KubiDrawer.tsx`로 Layout 수준에서 별도 mount된다.
+      {
+        path: "kubi",
+        element: withFeatureBoundary("Kubi", <KubiPage />),
+      },
+      {
+        path: "reports",
+        element: withFeatureBoundary("Reports", <ReportsPage />),
+      },
+      // 새 IA의 SYSTEM 그룹(#259/#264에서 실제 기능 구현).
+      {
+        path: "provider",
+        element: withFeatureBoundary("Provider", <ProviderPage />),
+      },
+      {
+        path: "monitoring",
+        element: withFeatureBoundary("Monitoring", <MonitoringPage />),
+      },
+      // 레거시 단독 라우트: 내비게이션에서는 제거됐지만 딥링크 호환을 위해 유지한다(#247 결정:
+      // 새 IA로 리다이렉트하지 않고 그대로 유지 — Validate/Preview/Artifacts는 New Build
+      // Wizard 내부 패널로 통합 예정이며, 통합 시점까지는 기존 화면이 fallback 역할을 한다).
       {
         path: "validate",
         element: withFeatureBoundary("검증", <ValidatePage />),

--- a/src/features/kubi/KubiDrawer.tsx
+++ b/src/features/kubi/KubiDrawer.tsx
@@ -71,10 +71,14 @@ export function KubiDrawer() {
 
   return (
     <>
+      {/* 클릭 전용 overlay — 탭 순서/접근성 트리에서 제외(ESC·닫기 버튼이 AT 대안).
+          aria-hidden이므로 라벨을 넣지 않는다. */}
       <button
-        aria-label="Kubi 닫기"
+        aria-hidden="true"
         className="fixed inset-0 z-40 bg-zinc-950/45"
+        data-testid="kubi-drawer-overlay"
         onClick={closeKubiDrawer}
+        tabIndex={-1}
         type="button"
       />
       <aside

--- a/src/features/kubi/KubiDrawer.tsx
+++ b/src/features/kubi/KubiDrawer.tsx
@@ -1,0 +1,115 @@
+/**
+ * 전역 Kubi drawer (#247).
+ *
+ * `Layout`에서 한 번만 mount되어 어느 화면에서도 동일한 Kubi UI가 열리도록 한다(page별 중복
+ * 렌더 금지). 실제 LLM 연동, 자연어 탐색, Evidence/Generated SQL, Suggested Action은
+ * #256에서 구현하며, 여기서는 현재 라우트 context를 반영하는 shell만 제공한다.
+ *
+ * context는 `resolveKubiRouteContext`로 매 렌더마다 현재 pathname에서 다시 계산하므로,
+ * drawer를 연 채로 다른 화면으로 이동해도 표시되는 화면 이름이 항상 최신 상태를 따라간다.
+ */
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
+import { useUIStore } from "@/shared/hooks/useUIStore";
+import { resolveKubiRouteContext } from "./context";
+
+/**
+ * 어디서나 열리는 전역 Kubi drawer.
+ *
+ * @returns drawer가 닫혀 있으면 `null`, 열려 있으면 현재 화면 context를 보여주는 패널.
+ */
+export function KubiDrawer() {
+  const isOpen = useUIStore((state) => state.isKubiDrawerOpen);
+  const closeKubiDrawer = useUIStore((state) => state.closeKubiDrawer);
+  const { pathname } = useLocation();
+  const context = resolveKubiRouteContext(pathname);
+  const dialogRef = useRef<HTMLElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+
+  // 열리는 순간 닫기 버튼으로 포커스를 옮기고, 모달 안에서 포커스를 순환시킨다.
+  // 닫히면 drawer를 열었던 요소로 포커스를 되돌린다(접근성).
+  useEffect(() => {
+    if (!isOpen) return;
+    returnFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    closeButtonRef.current?.focus();
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeKubiDrawer();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusableElements = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (!focusableElements?.length) return;
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      returnFocusRef.current?.focus();
+      returnFocusRef.current = null;
+    };
+  }, [isOpen, closeKubiDrawer]);
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <button
+        aria-label="Kubi 닫기"
+        className="fixed inset-0 z-40 bg-zinc-950/45"
+        onClick={closeKubiDrawer}
+        type="button"
+      />
+      <aside
+        ref={dialogRef}
+        aria-label="Kubi AI Assistant"
+        aria-modal="true"
+        role="dialog"
+        className="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-border bg-card px-5 py-5 shadow-xl sm:w-96"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Kubi AI Assistant
+            </p>
+            <p className="mt-1 text-sm text-foreground">{context.pageLabel} 화면 문맥</p>
+          </div>
+          <button
+            ref={closeButtonRef}
+            aria-label="Kubi 닫기"
+            className="rounded-lg border border-border p-1.5 text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            onClick={closeKubiDrawer}
+            type="button"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="mt-6 flex flex-1 flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border px-4 py-10 text-center">
+          <p className="text-sm font-medium text-foreground">Kubi는 아직 준비 중입니다</p>
+          <p className="max-w-xs text-sm leading-6 text-muted-foreground">
+            자연어 탐색, 품질/실패 분석, Generated SQL, Suggested Action은 #256에서 이 drawer에
+            연결됩니다.
+          </p>
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/src/features/kubi/KubiSearchInput.tsx
+++ b/src/features/kubi/KubiSearchInput.tsx
@@ -1,0 +1,41 @@
+/**
+ * 상단 Kubi 자연어 검색 입력 (#247).
+ *
+ * 검색어를 Builder Kubi backend로 보내 후보를 추천받는 실제 연동은 #256에서 구현한다.
+ * App Shell 단계에서는 제출 시 전역 Kubi drawer를 여는 진입점 역할만 한다 — hallucinated
+ * dataset을 만들어내지 않도록 여기서 어떤 결과도 임의 생성하지 않는다.
+ */
+import { useState, type FormEvent } from "react";
+import { useUIStore } from "@/shared/hooks/useUIStore";
+
+export function KubiSearchInput() {
+  const [query, setQuery] = useState("");
+  const openKubiDrawer = useUIStore((state) => state.openKubiDrawer);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    // 실제 검색/추천은 #256에서 연결된다. 지금은 drawer를 여는 진입점만 제공한다.
+    openKubiDrawer();
+  }
+
+  return (
+    <form
+      role="search"
+      onSubmit={handleSubmit}
+      className="hidden min-w-0 max-w-md flex-1 items-center gap-2 rounded-lg border border-input bg-card px-3 py-2 text-sm text-muted-foreground focus-within:ring-2 focus-within:ring-ring sm:flex"
+    >
+      <span aria-hidden="true">🔍</span>
+      <label className="sr-only" htmlFor="kubi-search">
+        Kubi에게 자연어로 데이터 물어보기
+      </label>
+      <input
+        className="w-full min-w-0 bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
+        id="kubi-search"
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder="Kubi에게 데이터에 대해 물어보세요…"
+        type="search"
+        value={query}
+      />
+    </form>
+  );
+}

--- a/src/features/kubi/context.ts
+++ b/src/features/kubi/context.ts
@@ -1,0 +1,61 @@
+/**
+ * 현재 라우트를 전역 Kubi drawer가 표시할 최소 context로 변환한다 (#247).
+ *
+ * 전체 `KubiContext`(page/datasetId/runId/stage/qualityResultIds/provider)와 실제 서버 연동은
+ * #256에서 구현한다. App Shell 단계에서는 "지금 어느 화면의 Kubi를 열었는지"를 drawer 헤더에
+ * 보여주기 위한 최소 정보(화면 이름 + route param)만 계산한다.
+ */
+
+/** App Shell 수준에서 필요한 최소 Kubi route context. */
+export interface KubiRouteContext {
+  /** drawer 헤더에 표시할, 사람이 읽는 현재 화면 이름 */
+  pageLabel: string;
+  /** 현재 경로 */
+  pathname: string;
+  /** 경로에서 추출한 datasetId (Dataset Detail 등에서만 존재) */
+  datasetId?: string;
+  /** 경로에서 추출한 buildId (Build 상세/실행/결과물/게시 등에서만 존재) */
+  buildId?: string;
+}
+
+const ROUTE_LABELS: { test: RegExp; label: string }[] = [
+  { test: /^\/discover(\/|$)/, label: "Discover" },
+  { test: /^\/workspace(\/|$)/, label: "Workspace" },
+  { test: /^\/add(\/|$)/, label: "Add Data" },
+  { test: /^\/datasets\/[^/]+/, label: "Dataset 상세" },
+  { test: /^\/datasets(\/|$)/, label: "Dataset Catalog" },
+  { test: /^\/builds\/new(\/|$)/, label: "새 빌드" },
+  { test: /^\/builds\/[^/]+\/run(\/|$)/, label: "빌드 실행" },
+  { test: /^\/builds\/[^/]+\/artifacts(\/|$)/, label: "빌드 결과물" },
+  { test: /^\/builds\/[^/]+\/publish(\/|$)/, label: "빌드 게시" },
+  { test: /^\/builds\/[^/]+\/edit(\/|$)/, label: "빌드 편집" },
+  { test: /^\/builds\/[^/]+(\/|$)/, label: "빌드 상세" },
+  { test: /^\/builds(\/|$)/, label: "Builds / Runs" },
+  { test: /^\/quality(\/|$)/, label: "Quality" },
+  { test: /^\/kubi(\/|$)/, label: "Kubi" },
+  { test: /^\/reports(\/|$)/, label: "Reports" },
+  { test: /^\/provider(\/|$)/, label: "Provider" },
+  { test: /^\/monitoring(\/|$)/, label: "Monitoring" },
+  { test: /^\/settings(\/|$)/, label: "Settings" },
+  { test: /^\/$/, label: "Home" },
+];
+
+/**
+ * 현재 pathname을 Kubi drawer가 표시할 화면 이름과 관련 route param으로 변환한다.
+ *
+ * @param pathname - 현재 경로 (예: `/datasets/abc`).
+ * @returns 화면 이름, datasetId, buildId를 담은 최소 context.
+ */
+export function resolveKubiRouteContext(pathname: string): KubiRouteContext {
+  const matched = ROUTE_LABELS.find((entry) => entry.test.test(pathname));
+  const datasetMatch = pathname.match(/^\/datasets\/([^/]+)/);
+  const buildMatch = pathname.match(/^\/builds\/([^/]+)/);
+  const buildId = buildMatch && buildMatch[1] !== "new" ? buildMatch[1] : undefined;
+
+  return {
+    pageLabel: matched?.label ?? pathname,
+    pathname,
+    datasetId: datasetMatch?.[1],
+    buildId,
+  };
+}

--- a/src/pages/AddDataPage.tsx
+++ b/src/pages/AddDataPage.tsx
@@ -1,0 +1,28 @@
+/**
+ * Add Data Workbench 화면 (`/add`) — placeholder (#247).
+ *
+ * Public API·File·URL을 하나의 워크벤치에서 BuildSpec + Preview/Validation으로 이어주는
+ * 실제 흐름은 #250에서 구현한다. 기존 새 빌드 작성 흐름(`/builds/new`)은 계속 동작하며,
+ * 이 화면이 완성되면 그 흐름을 대체/흡수할 예정이다.
+ */
+import { Link } from "react-router-dom";
+import { PlaceholderPage } from "@/shared/ui";
+
+export function AddDataPage() {
+  return (
+    <PlaceholderPage
+      eyebrow="Add Data"
+      title="데이터 추가"
+      description="Public API, File, URL 중 하나로 새 데이터 소스를 연결하고 BuildSpec을 만듭니다."
+      note={
+        <>
+          Add Data Workbench는 #250에서 구현됩니다. 지금 바로 빌드를 시작하려면{" "}
+          <Link to="/builds/new" className="text-accent-subtle-foreground underline">
+            새 빌드 만들기
+          </Link>
+          를 이용하세요.
+        </>
+      }
+    />
+  );
+}

--- a/src/pages/DatasetCatalogPage.tsx
+++ b/src/pages/DatasetCatalogPage.tsx
@@ -1,0 +1,17 @@
+/**
+ * Dataset Catalog 화면 (`/datasets`) — placeholder (#247).
+ *
+ * 발행된 데이터셋 검색·목록 P0 구현은 #253에서 진행한다.
+ */
+import { PlaceholderPage } from "@/shared/ui";
+
+export function DatasetCatalogPage() {
+  return (
+    <PlaceholderPage
+      eyebrow="Dataset Catalog"
+      title="데이터셋 카탈로그"
+      description="발행된 데이터셋을 검색하고 상세 화면으로 이동합니다."
+      note="Dataset Catalog·Dataset Detail 화면은 #253에서 구현됩니다."
+    />
+  );
+}

--- a/src/pages/DatasetDetailPage.tsx
+++ b/src/pages/DatasetDetailPage.tsx
@@ -1,0 +1,21 @@
+/**
+ * Dataset Detail 화면 (`/datasets/:datasetId`) — placeholder (#247).
+ *
+ * Quality/Kubi/Reports/Publish 탭을 포함한 실제 구현은 #253(P0)과 #253의 Publish 확장(P1)에서
+ * 진행한다. 여기서는 route param을 받아 어떤 데이터셋인지만 안내한다.
+ */
+import { useParams } from "react-router-dom";
+import { PlaceholderPage } from "@/shared/ui";
+
+export function DatasetDetailPage() {
+  const { datasetId } = useParams<{ datasetId: string }>();
+
+  return (
+    <PlaceholderPage
+      eyebrow="Dataset"
+      title={datasetId ? `데이터셋: ${datasetId}` : "데이터셋 상세"}
+      description="스키마, Quality, Kubi 분석, Reports, Publish 탭을 한 화면에서 제공합니다."
+      note="Dataset Detail 화면은 #253에서 구현됩니다."
+    />
+  );
+}

--- a/src/pages/DiscoverPage.tsx
+++ b/src/pages/DiscoverPage.tsx
@@ -1,0 +1,18 @@
+/**
+ * Discover 화면 (`/discover`) — placeholder (#247).
+ *
+ * 정확 검색과 Provider 탐색 UI는 #249에서 구현한다. App Shell 단계에서는 새 IA의 route와
+ * 내비게이션이 먼저 존재해야 하므로 명시적인 placeholder를 둔다.
+ */
+import { PlaceholderPage } from "@/shared/ui";
+
+export function DiscoverPage() {
+  return (
+    <PlaceholderPage
+      eyebrow="Discover"
+      title="데이터 탐색"
+      description="Provider와 데이터셋을 정확 검색하고 후보를 추천받습니다."
+      note="정확 검색·Provider 탐색 UI는 #249에서 구현됩니다."
+    />
+  );
+}

--- a/src/pages/KubiPage.tsx
+++ b/src/pages/KubiPage.tsx
@@ -1,0 +1,19 @@
+/**
+ * Kubi 전용 화면 (`/kubi`) — placeholder (#247).
+ *
+ * Context-aware Kubi(탐색·분석·Action·Generated SQL)의 실제 구현은 #256에서 진행한다.
+ * App Shell 단계에서는 전역 Kubi drawer(`src/features/kubi/KubiDrawer.tsx`)의 shell만
+ * 준비되어 있다 — 상단 Kubi 버튼으로 어디서나 열 수 있다.
+ */
+import { PlaceholderPage } from "@/shared/ui";
+
+export function KubiPage() {
+  return (
+    <PlaceholderPage
+      eyebrow="Kubi"
+      title="Kubi AI Assistant"
+      description="자연어로 데이터를 탐색하고, 품질/실패를 분석하며, Generated SQL로 결과를 확인합니다."
+      note="Kubi 전용 화면과 대화형 기능은 #256에서 구현됩니다. 상단 Kubi 버튼으로 여는 drawer는 지금도 어느 화면에서나 열 수 있습니다."
+    />
+  );
+}

--- a/src/pages/MonitoringPage.tsx
+++ b/src/pages/MonitoringPage.tsx
@@ -1,0 +1,17 @@
+/**
+ * Monitoring 화면 (`/monitoring`) — placeholder (#247).
+ *
+ * 실행 이력/시스템 상태 모니터링의 실제 구현은 #264에서 진행한다.
+ */
+import { PlaceholderPage } from "@/shared/ui";
+
+export function MonitoringPage() {
+  return (
+    <PlaceholderPage
+      eyebrow="Monitoring"
+      title="모니터링"
+      description="실행 이력과 시스템 상태를 모니터링합니다."
+      note="Monitoring 화면은 #264에서 구현됩니다."
+    />
+  );
+}

--- a/src/pages/ProviderPage.tsx
+++ b/src/pages/ProviderPage.tsx
@@ -1,0 +1,17 @@
+/**
+ * Provider 화면 (`/provider`) — placeholder (#247).
+ *
+ * Provider 연결/자격 증명 관리의 실제 구현은 #259에서 진행한다.
+ */
+import { PlaceholderPage } from "@/shared/ui";
+
+export function ProviderPage() {
+  return (
+    <PlaceholderPage
+      eyebrow="Provider"
+      title="Provider"
+      description="데이터 제공 기관 연결과 자격 증명(credential)을 관리합니다."
+      note="Provider 연결·자격 증명 관리는 #259에서 구현됩니다."
+    />
+  );
+}

--- a/src/pages/QualityPage.tsx
+++ b/src/pages/QualityPage.tsx
@@ -1,0 +1,18 @@
+/**
+ * Quality Center 화면 (`/quality`) — placeholder (#247).
+ *
+ * 실제 Quality Center 구현은 #254에서 진행한다. Studio는 PASS/WARN/FAIL 결과를 임의로
+ * 생성하지 않고 Builder 결과를 그대로 드러낸다는 원칙(#246)을 유지한다.
+ */
+import { PlaceholderPage } from "@/shared/ui";
+
+export function QualityPage() {
+  return (
+    <PlaceholderPage
+      eyebrow="Quality"
+      title="품질 센터"
+      description="빌드·데이터셋의 품질 결과(PASS/WARN/FAIL)를 한 곳에서 확인합니다."
+      note="Quality Center는 #254에서 구현됩니다."
+    />
+  );
+}

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -1,0 +1,17 @@
+/**
+ * Reports 화면 (`/reports`) — placeholder (#247).
+ *
+ * 실제 리포트 생성/열람 구현은 #258에서 진행한다.
+ */
+import { PlaceholderPage } from "@/shared/ui";
+
+export function ReportsPage() {
+  return (
+    <PlaceholderPage
+      eyebrow="Reports"
+      title="리포트"
+      description="Kubi 분석 결과와 인사이트를 리포트로 기록하고 공유합니다."
+      note="Reports 화면은 #258에서 구현됩니다."
+    />
+  );
+}

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -1,0 +1,19 @@
+/**
+ * Workspace 화면 (`/workspace`) — placeholder (#247).
+ *
+ * Recent Work와 저장된 BuildSpec 작업대는 #260에서 구현한다. 기존 `features/workspace`의
+ * 개인/팀 워크스페이스 전환(Settings)과는 별개 개념이다 — 여기서는 새 IA의 "작업대" 화면을
+ * 가리킨다.
+ */
+import { PlaceholderPage } from "@/shared/ui";
+
+export function WorkspacePage() {
+  return (
+    <PlaceholderPage
+      eyebrow="Workspace"
+      title="작업대"
+      description="최근 작업(Recent Work)과 저장한 BuildSpec을 한 곳에서 관리합니다."
+      note="Workspace / Saved BuildSpecs 화면은 #260에서 구현됩니다."
+    />
+  );
+}

--- a/src/shared/hooks/useUIStore.ts
+++ b/src/shared/hooks/useUIStore.ts
@@ -1,10 +1,14 @@
 /**
  * 앱 셸 전반에서 재사용하는 UI 전역 상태 스토어.
  *
- * 사이드바 열림 여부, 전역 Kubi drawer 열림 여부, 테마 선택처럼 페이지를 넘나들며 유지해야
- * 하는 시각 상태를 관리한다. 테마는 `persist` 미들웨어로 localStorage에 저장해 새로고침해도
- * 유지된다(#83). 사이드바와 Kubi drawer는 페이지를 새로고침할 때마다 되살리지 않도록
- * 의도적으로 저장하지 않는다(항상 닫힌 상태로 시작, #247).
+ * 모바일 사이드바 오버레이 열림 여부, 데스크톱 사이드바 접힘 여부, 전역 Kubi drawer 열림 여부,
+ * 테마 선택처럼 페이지를 넘나들며 유지해야 하는 시각 상태를 관리한다. 모바일 오버레이와 데스크톱
+ * collapse는 서로 다른 레이아웃 개념이라 상태를 분리한다 — 모바일에서 열어둔 오버레이가 데스크톱
+ * collapse에 영향을 주거나, 그 반대가 되어서는 안 된다(#247).
+ *
+ * `persist` 미들웨어로 localStorage에 저장하는 값은 테마(#83)와 데스크톱 collapse 선호(#247)뿐이다.
+ * 모바일 오버레이 열림 상태는 의도적으로 저장하지 않아, 새로고침 후 모바일 메뉴가 열린 채로
+ * 되살아나지 않는다(항상 닫힌 상태로 시작).
  */
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
@@ -13,18 +17,22 @@ import { persist } from "zustand/middleware";
 export type ThemeMode = "system" | "light" | "dark";
 
 interface UIState {
-  /** 모바일/태블릿 레이아웃에서 사이드바가 열려 있는지 여부 */
-  isSidebarOpen: boolean;
+  /** 모바일/태블릿 레이아웃에서 사이드바 오버레이가 열려 있는지 여부 (persist 안 함) */
+  isMobileSidebarOpen: boolean;
+  /** 데스크톱 레이아웃에서 사이드바가 접혀 있는지 여부 (persist 가능, #247) */
+  isDesktopSidebarCollapsed: boolean;
   /** 전역 Kubi drawer가 열려 있는지 여부 (#247) */
   isKubiDrawerOpen: boolean;
   /** 사용자가 선택한 테마 모드 */
   theme: ThemeMode;
-  /** 사이드바 열림/닫힘 상태를 뒤집는 액션 */
-  toggleSidebar: () => void;
-  /** 사이드바를 강제로 여는 액션 */
-  openSidebar: () => void;
-  /** 사이드바를 강제로 닫는 액션 */
-  closeSidebar: () => void;
+  /** 모바일 사이드바 오버레이 열림/닫힘 상태를 뒤집는 액션 */
+  toggleMobileSidebar: () => void;
+  /** 모바일 사이드바 오버레이를 강제로 여는 액션 */
+  openMobileSidebar: () => void;
+  /** 모바일 사이드바 오버레이를 강제로 닫는 액션 */
+  closeMobileSidebar: () => void;
+  /** 데스크톱 사이드바 접힘/펼침 상태를 뒤집는 액션 */
+  toggleDesktopSidebarCollapsed: () => void;
   /** Kubi drawer를 여는 액션 */
   openKubiDrawer: () => void;
   /** Kubi drawer를 닫는 액션 */
@@ -43,12 +51,16 @@ interface UIState {
 export const useUIStore = create<UIState>()(
   persist(
     (set) => ({
-      isSidebarOpen: false,
+      isMobileSidebarOpen: false,
+      isDesktopSidebarCollapsed: false,
       isKubiDrawerOpen: false,
       theme: "system",
-      toggleSidebar: () => set((state) => ({ isSidebarOpen: !state.isSidebarOpen })),
-      openSidebar: () => set({ isSidebarOpen: true }),
-      closeSidebar: () => set({ isSidebarOpen: false }),
+      toggleMobileSidebar: () =>
+        set((state) => ({ isMobileSidebarOpen: !state.isMobileSidebarOpen })),
+      openMobileSidebar: () => set({ isMobileSidebarOpen: true }),
+      closeMobileSidebar: () => set({ isMobileSidebarOpen: false }),
+      toggleDesktopSidebarCollapsed: () =>
+        set((state) => ({ isDesktopSidebarCollapsed: !state.isDesktopSidebarCollapsed })),
       openKubiDrawer: () => set({ isKubiDrawerOpen: true }),
       closeKubiDrawer: () => set({ isKubiDrawerOpen: false }),
       toggleKubiDrawer: () => set((state) => ({ isKubiDrawerOpen: !state.isKubiDrawerOpen })),
@@ -56,8 +68,12 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "kpubdata-studio:ui",
-      // 테마만 저장한다. 사이드바 열림 상태는 저장하지 않아 새로고침 시 항상 닫힌 채 시작한다.
-      partialize: (state) => ({ theme: state.theme }),
+      // 테마와 데스크톱 collapse 선호만 저장한다. 모바일 오버레이 열림 상태는 저장하지 않아
+      // 새로고침 시 항상 닫힌 채 시작한다(데스크톱 collapse 복원과는 독립적으로 동작해야 함).
+      partialize: (state) => ({
+        theme: state.theme,
+        isDesktopSidebarCollapsed: state.isDesktopSidebarCollapsed,
+      }),
     },
   ),
 );

--- a/src/shared/hooks/useUIStore.ts
+++ b/src/shared/hooks/useUIStore.ts
@@ -1,9 +1,10 @@
 /**
  * 앱 셸 전반에서 재사용하는 UI 전역 상태 스토어.
  *
- * 사이드바 열림 여부와 테마 선택처럼 페이지를 넘나들며 유지해야 하는 시각 상태를 관리한다.
- * 테마는 `persist` 미들웨어로 localStorage에 저장해 새로고침해도 유지된다(#83). 사이드바는
- * 데스크톱에서 모바일 드로어를 되살리지 않도록 의도적으로 저장하지 않는다(항상 닫힌 상태로 시작).
+ * 사이드바 열림 여부, 전역 Kubi drawer 열림 여부, 테마 선택처럼 페이지를 넘나들며 유지해야
+ * 하는 시각 상태를 관리한다. 테마는 `persist` 미들웨어로 localStorage에 저장해 새로고침해도
+ * 유지된다(#83). 사이드바와 Kubi drawer는 페이지를 새로고침할 때마다 되살리지 않도록
+ * 의도적으로 저장하지 않는다(항상 닫힌 상태로 시작, #247).
  */
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
@@ -14,6 +15,8 @@ export type ThemeMode = "system" | "light" | "dark";
 interface UIState {
   /** 모바일/태블릿 레이아웃에서 사이드바가 열려 있는지 여부 */
   isSidebarOpen: boolean;
+  /** 전역 Kubi drawer가 열려 있는지 여부 (#247) */
+  isKubiDrawerOpen: boolean;
   /** 사용자가 선택한 테마 모드 */
   theme: ThemeMode;
   /** 사이드바 열림/닫힘 상태를 뒤집는 액션 */
@@ -22,6 +25,12 @@ interface UIState {
   openSidebar: () => void;
   /** 사이드바를 강제로 닫는 액션 */
   closeSidebar: () => void;
+  /** Kubi drawer를 여는 액션 */
+  openKubiDrawer: () => void;
+  /** Kubi drawer를 닫는 액션 */
+  closeKubiDrawer: () => void;
+  /** Kubi drawer 열림/닫힘 상태를 뒤집는 액션 */
+  toggleKubiDrawer: () => void;
   /** 테마 모드를 새 값으로 갱신하는 액션 */
   setTheme: (theme: ThemeMode) => void;
 }
@@ -35,10 +44,14 @@ export const useUIStore = create<UIState>()(
   persist(
     (set) => ({
       isSidebarOpen: false,
+      isKubiDrawerOpen: false,
       theme: "system",
       toggleSidebar: () => set((state) => ({ isSidebarOpen: !state.isSidebarOpen })),
       openSidebar: () => set({ isSidebarOpen: true }),
       closeSidebar: () => set({ isSidebarOpen: false }),
+      openKubiDrawer: () => set({ isKubiDrawerOpen: true }),
+      closeKubiDrawer: () => set({ isKubiDrawerOpen: false }),
+      toggleKubiDrawer: () => set((state) => ({ isKubiDrawerOpen: !state.isKubiDrawerOpen })),
       setTheme: (theme) => set({ theme }),
     }),
     {

--- a/src/shared/ui/PlaceholderPage.tsx
+++ b/src/shared/ui/PlaceholderPage.tsx
@@ -1,0 +1,39 @@
+/**
+ * 아직 실제 화면이 연결되지 않은 route를 위한 공통 placeholder (#247).
+ *
+ * Epic #246의 새 IA는 하위 이슈 단위로 순차 구현된다. App Shell/Navigation(#247) 단계에서
+ * route와 메뉴가 먼저 존재해야 이후 화면 이슈들이 동일한 layout에서 이어받을 수 있으므로,
+ * 아직 구현되지 않은 화면은 관련 없는 기존 화면을 재사용하는 대신 명시적인 placeholder를 보여준다.
+ */
+import type { ReactNode } from "react";
+import { Card } from "./Card";
+import { PageHeader } from "./PageHeader";
+
+export interface PlaceholderPageProps {
+  /** PageHeader 상단 라벨 */
+  eyebrow: string;
+  /** 페이지 제목 */
+  title: string;
+  /** 이 화면이 최종적으로 어떤 역할을 하는지에 대한 설명 */
+  description: string;
+  /** 어떤 이슈에서 실제로 구현되는지 안내하는 문구 */
+  note: ReactNode;
+}
+
+/**
+ * 제목/설명과 함께 "아직 준비 중" 안내를 보여주는 placeholder 페이지.
+ *
+ * @param props - eyebrow/title/description/note.
+ * @returns placeholder 화면 엘리먼트.
+ */
+export function PlaceholderPage({ eyebrow, title, description, note }: PlaceholderPageProps) {
+  return (
+    <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+      <PageHeader eyebrow={eyebrow} title={title} description={description} />
+      <Card variant="dashed" className="flex flex-col items-center gap-2 py-16 text-center">
+        <p className="text-lg font-medium tracking-tight">아직 준비 중인 화면입니다</p>
+        <p className="mx-auto max-w-xl text-sm leading-6 text-muted-foreground">{note}</p>
+      </Card>
+    </main>
+  );
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -8,6 +8,7 @@ export { LinkButton, type LinkButtonProps } from "./LinkButton";
 export { buttonClassName } from "./buttonStyles";
 export { Card, type CardProps, type CardVariant } from "./Card";
 export { PageHeader, type PageHeaderProps } from "./PageHeader";
+export { PlaceholderPage, type PlaceholderPageProps } from "./PlaceholderPage";
 export { EmptyState, type EmptyStateProps } from "./EmptyState";
 export { StatusBadge, type StatusBadgeProps, type StatusValue } from "./StatusBadge";
 export { Stepper, type StepperProps, type StepItem, type StepState } from "./Stepper";


### PR DESCRIPTION
## 개요

Closes #247

HTML 프로토타입의 정보구조를 기준으로 Studio 전역 App Shell과 Navigation을 재구성합니다.

후속 Dataset, Quality, Kubi, Provider 등의 화면을 동일한 route/navigation 구조에서 구현할 수 있도록 기본 셸과 placeholder route를 추가합니다.

## 주요 변경사항

- 사이드바를 WORKSPACE / DATA / AI / SYSTEM 그룹 구조로 재구성
- 신규 IA route 추가
  - `/discover`
  - `/workspace`
  - `/add`
  - `/datasets`
  - `/datasets/:datasetId`
  - `/quality`
  - `/kubi`
  - `/reports`
  - `/provider`
  - `/monitoring`
- 미구현 화면은 명시적인 placeholder 페이지로 구성
- 기존 build route 유지
  - `/builds`
  - `/builds/new`
  - `/builds/:buildId`
  - edit / run / artifacts / publish
- legacy `/validate`, `/preview`, `/artifacts` deep link 유지
- 상단 Kubi 자연어 입력 및 Kubi 버튼 추가
- Layout 수준의 전역 Kubi drawer 추가
  - 현재 route context 반영
  - overlay / ESC 닫기
  - keyboard focus trap 및 닫은 뒤 focus 복귀
- avatar를 기존 auth user state와 연결 가능한 구조로 구성
- 기존 light/dark theme 및 mobile sidebar 동작 유지

## 범위 제외

- 신규 페이지의 실제 API 연동 및 상세 기능
- Kubi LLM / Evidence / Generated SQL / Action 구현 (#256)
- Login / Signup 구현 (#263)
- 기존 Build 기능 재작성

## 검증

- typecheck 통과
- lint 통과
- production build 통과
- #247 관련 테스트: 5 files, 32/32 통과
- `legacyDeepLinks.test.tsx`: standalone 4/4 통과
- `newBuildDraft.test.tsx`: standalone 2/2 통과
- `newBuildRun.test.tsx`: standalone 2/2 통과

전체 test suite 병렬 실행에서는 일부 테스트가 기존 5초 제한을 간헐적으로 초과했으나,
실패 항목은 standalone 실행에서 모두 통과했으며 assertion/runtime failure는 확인되지 않았습니다.

## ui 결과
1. 사이드바 전체 화면
<img width="1842" height="1304" alt="image" src="https://github.com/user-attachments/assets/71b662fd-a3f3-4a06-977d-5af9cfa4e717" />

2. Kubi drawer 열린 화면
<img width="1851" height="1300" alt="image" src="https://github.com/user-attachments/assets/a8ae4d68-4e87-43ce-8384-7989291e7e43" />
