### PR TITLE
fix: assistant 공통 egress 스크러빙과 시크릿 왕복 완결 (#273, #274)

### DIFF
--- a/__tests__/assistant.test.ts
+++ b/__tests__/assistant.test.ts
@@ -18,15 +18,24 @@ import { scrubSecrets, restoreSecrets, isSecretKey, looksLikeSecret } from "@/fe
 
 function mockProvider(responses: string[]): AssistProvider {
   let idx = 0;
-  return {
+  const provider = {
     isConfigured: true,
+    exchange(messages: AssistMessage[]) {
+      return {
+        output: provider.stream(messages),
+        displayOutput: provider.stream(messages),
+        hadSecrets: false,
+        restoreText: (text: string) => text,
+      };
+    },
     async *stream(_messages: AssistMessage[]): AsyncIterable<string> {
       const resp = responses[idx++] ?? responses[responses.length - 1];
       for (const char of resp) {
         yield char;
       }
     },
-  };
+  } as unknown as AssistProvider;
+  return provider;
 }
 
 describe("generateBuildSpec (ST-A7, #210)", () => {
@@ -85,6 +94,55 @@ describe("generateBuildSpec (ST-A7, #210)", () => {
     expect(result.status).toBe("error");
     expect(result.spec).toBeNull();
     expect(result.remaining_problems[0]).toContain("mock");
+  });
+
+  it("검증을 통과한 구조화 출력의 요청별 시크릿을 복원한다", async () => {
+    const placeholder = "__SCRUBBED_request-a_0__";
+    const provider = {
+      isConfigured: true,
+      exchange: () => ({
+        output: (async function* () {
+          yield `sources:\n  - params:\n      serviceKey: ${placeholder}`;
+        })(),
+        displayOutput: (async function* () {})(),
+        hadSecrets: true,
+        restoreText: (text: string) => text.replace(placeholder, "original-service-key"),
+      }),
+      stream: async function* () {},
+    } as unknown as AssistProvider;
+
+    const result = await generateBuildSpec(provider, "기존 스펙을 수정해줘", {
+      validateFn: vi.fn().mockResolvedValue({ valid: true }),
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.spec).toContain("serviceKey: original-service-key");
+    expect(result.spec).not.toContain("__SCRUBBED_");
+  });
+
+  it("알 수 없는 플레이스홀더가 남은 출력은 error로 처리한다", async () => {
+    const provider = {
+      isConfigured: true,
+      exchange: () => ({
+        output: (async function* () {
+          yield "serviceKey: __SCRUBBED_another-request_0__";
+        })(),
+        displayOutput: (async function* () {})(),
+        hadSecrets: true,
+        restoreText: () => {
+          throw new Error("알 수 없는 시크릿 플레이스홀더가 포함되어 있습니다.");
+        },
+      }),
+      stream: async function* () {},
+    } as unknown as AssistProvider;
+
+    const result = await generateBuildSpec(provider, "기존 스펙을 수정해줘", {
+      validateFn: vi.fn().mockResolvedValue({ valid: true }),
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.spec).toBeNull();
+    expect(result.remaining_problems[0]).toContain("알 수 없는 시크릿");
   });
 });
 

--- a/src/features/assistant/AssistantChat.tsx
+++ b/src/features/assistant/AssistantChat.tsx
@@ -8,14 +8,13 @@ import { useCallback, useRef, useState } from "react";
 import { Button, Card, Textarea } from "@/shared/ui";
 import { useAssistConfig } from "./config";
 import { createProvider, type AssistMessage } from "./provider";
-import { scrubSecrets } from "./scrub";
 
 interface ChatMessage {
   role: "user" | "assistant";
   content: string;
 }
 
-export function AssistantChat({ contextSpec }: { contextSpec?: string }) {
+export function AssistantChat({ contextSpec }: { contextSpec?: unknown }) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
@@ -33,17 +32,13 @@ export function AssistantChat({ contextSpec }: { contextSpec?: string }) {
     setInput("");
     setIsStreaming(true);
 
-    // 시크릿 스크러빙 (#206)
-    const scrubbed = contextSpec ? scrubSecrets(contextSpec) : null;
-    const safeSpec = scrubbed ? JSON.stringify(scrubbed.scrubbed) : contextSpec;
-
     const systemPrompt = `당신은 한국 공공데이터 빌드 스펙(BuildSpec) 전문가입니다.
 사용자의 질문에 한국어로 답변하세요.
-${safeSpec ? `현재 스펙:\n${safeSpec}\n` : ""}
+${contextSpec ? "현재 스펙은 첨부된 구조화 컨텍스트를 참고하세요.\n" : ""}
 오류가 있으면 수정 제안을 하세요.`;
 
     const apiMessages: AssistMessage[] = [
-      { role: "system", content: systemPrompt },
+      { role: "system", content: systemPrompt, structuredContent: contextSpec },
       ...[...messages, userMsg].map((m) => ({ role: m.role, content: m.content }) as AssistMessage),
     ];
 

--- a/src/features/assistant/columnMeaning.test.ts
+++ b/src/features/assistant/columnMeaning.test.ts
@@ -21,11 +21,11 @@ describe("buildColumnMeaningPrompt — 스크러빙 (#228, SEC-2 선행)", () =>
       { OPNSFTEAM_CODE: "3000001", serviceKey: SECRET_KEY },
     ];
 
-    const { messages, scrubbed } = buildColumnMeaningPrompt(columns, rows);
+    const { messages } = buildColumnMeaningPrompt(columns, rows);
 
-    expect(scrubbed).toBe(true);
     const promptText = messages.map((m) => m.content).join("\n");
     expect(promptText).not.toContain(SECRET_KEY);
+    expect(messages.find((message) => message.structuredContent)).toBeDefined();
   });
 
   it("컬럼 목록이 프롬프트에 포함된다", () => {
@@ -40,10 +40,10 @@ describe("buildColumnMeaningPrompt — 스크러빙 (#228, SEC-2 선행)", () =>
     expect(userMsg?.content).toContain("BUDGET_CRNTAM");
   });
 
-  it("시크릿이 없으면 scrubbed=false", () => {
+  it("샘플 행은 공통 egress가 처리할 structured content로 유지한다", () => {
     const columns = [{ name: "region", dtype: "String" }];
     const rows = [{ region: "서울" }];
-    const { scrubbed } = buildColumnMeaningPrompt(columns, rows);
-    expect(scrubbed).toBe(false);
+    const { messages } = buildColumnMeaningPrompt(columns, rows);
+    expect(messages.find((message) => message.structuredContent)?.structuredContent).toEqual(rows);
   });
 });

--- a/src/features/assistant/columnMeaning.ts
+++ b/src/features/assistant/columnMeaning.ts
@@ -2,10 +2,9 @@
  * 컬럼 의미 해독 — dataset card 보강 (AI-1, #228).
  *
  * 한국 공공데이터 컬럼명(MTHDT, BSNS_LCNS_NO, OPNSFTEAM_CODE 등)의 한국어
- * 설명 초안을 LLM으로 생성한다. 샘플 값은 scrubSecrets 를 반드시 통과한다
- * (SEC-2 선행). 승인 전에는 metadata 에 반영되지 않는다.
+ * 설명 초안을 LLM으로 생성한다. 샘플 값은 structured content로 공통 provider
+ * egress에 전달되어 직렬화 전에 스크러빙된다. 승인 전에는 metadata에 반영되지 않는다.
  */
-import { scrubSecrets } from "./scrub";
 import type { AssistProvider, AssistMessage } from "./provider";
 
 /** 컬럼 설명 초안 결과. */
@@ -24,21 +23,16 @@ export interface ColumnMeta {
 /**
  * 컬럼 목록과 샘플 행에서 LLM 프롬프트를 구성한다 (#228).
  *
- * 샘플 행은 scrubSecrets 로 시크릿을 마스킹한 뒤 프롬프트에 포함한다.
- * LLM 에 전송되는 페이로드에 원본 시크릿이 노출되지 않는다.
+ * 샘플 행은 문자열로 미리 직렬화하지 않고 structured content로 유지한다.
+ * 공통 provider egress가 key-aware 스크러빙한 뒤 최종 payload를 만든다.
  */
 export function buildColumnMeaningPrompt(
   columns: ColumnMeta[],
   sampleRows: Record<string, unknown>[],
-): { messages: AssistMessage[]; scrubbed: boolean } {
-  const { scrubbed, placeholders } = scrubSecrets(sampleRows);
-  const hasPlaceholders = placeholders.size > 0;
-
+): { messages: AssistMessage[] } {
   const colList = columns
     .map((c) => `  - ${c.name} (${c.dtype})`)
     .join("\n");
-
-  const sampleStr = JSON.stringify(scrubbed, null, 2).slice(0, 2000);
 
   const systemPrompt = `당신은 한국 공공데이터 컬럼명 해독 전문가입니다.
 각 컬럼의 이름, dtype, 샘플 값을 근거로 한국어 설명을 작성하세요.
@@ -48,17 +42,15 @@ export function buildColumnMeaningPrompt(
   const userPrompt = `컬럼 목록:
 ${colList}
 
-샘플 데이터 (최대 5행, 시크릿 마스킹됨):
-${sampleStr}
+샘플 데이터는 첨부된 구조화 컨텍스트를 참고하세요.
 
 각 컬럼에 대한 한국어 설명을 JSON으로 출력하세요.`;
 
   return {
     messages: [
       { role: "system", content: systemPrompt },
-      { role: "user", content: userPrompt },
+      { role: "user", content: userPrompt, structuredContent: sampleRows.slice(0, 5) },
     ],
-    scrubbed: hasPlaceholders,
   };
 }
 
@@ -67,7 +59,7 @@ ${sampleStr}
  *
  * @param provider LLM provider (BYOK).
  * @param columns 컬럼 메타데이터.
- * @param sampleRows 샘플 행 (scrubSecrets 통과 후 LLM 전송).
+ * @param sampleRows 샘플 행 (공통 provider egress에서 스크러빙 후 LLM 전송).
  * @param signal 취소 신호.
  * @returns 컬럼명 → 한국어 설명 매핑. LLM 미설정 시 status="error".
  */
@@ -77,10 +69,11 @@ export async function generateColumnMeanings(
   sampleRows: Record<string, unknown>[],
   signal?: AbortSignal,
 ): Promise<ColumnMeaningResult> {
-  const { messages, scrubbed } = buildColumnMeaningPrompt(columns, sampleRows);
+  const { messages } = buildColumnMeaningPrompt(columns, sampleRows);
 
+  const exchange = provider.exchange(messages, signal);
   let rawOutput = "";
-  for await (const chunk of provider.stream(messages, signal)) {
+  for await (const chunk of exchange.displayOutput) {
     rawOutput += chunk;
   }
 
@@ -91,8 +84,8 @@ export async function generateColumnMeanings(
 
   try {
     const parsed = JSON.parse(jsonStr) as Record<string, string>;
-    return { descriptions: parsed, status: "ok", scrubbed };
+    return { descriptions: parsed, status: "ok", scrubbed: exchange.hadSecrets };
   } catch {
-    return { descriptions: {}, status: "error", scrubbed };
+    return { descriptions: {}, status: "error", scrubbed: exchange.hadSecrets };
   }
 }

--- a/src/features/assistant/generate.ts
+++ b/src/features/assistant/generate.ts
@@ -61,8 +61,9 @@ YAML만 출력하세요. 설명은 출력하지 마세요.`;
       });
     }
 
+    const exchange = provider.exchange(messages, options.signal);
     let rawOutput = "";
-    for await (const chunk of provider.stream(messages, options.signal)) {
+    for await (const chunk of exchange.output) {
       rawOutput += chunk;
     }
 
@@ -79,7 +80,23 @@ YAML만 출력하세요. 설명은 출력하지 마세요.`;
     if (options.validateFn) {
       const result = await options.validateFn(spec);
       if (result.valid) {
-        return { spec, status: "ok", attempts, remaining_problems: [] };
+        try {
+          return {
+            spec: exchange.restoreText(spec),
+            status: "ok",
+            attempts,
+            remaining_problems: [],
+          };
+        } catch (error) {
+          return {
+            spec: null,
+            status: "error",
+            attempts,
+            remaining_problems: [
+              error instanceof Error ? error.message : "시크릿 복원에 실패했습니다.",
+            ],
+          };
+        }
       }
       lastProblems = result.problems ?? ["검증 실패"];
       continue;

--- a/src/features/assistant/provider.test.ts
+++ b/src/features/assistant/provider.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createProvider } from "./provider";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("assistant safe egress (#273)", () => {
+  it("최종 HTTP body에서 text와 structured content의 시크릿을 제거한다", async () => {
+    const textSecret = "xJ7kL9mN2pQ4rT6vW8yB3cD5eF7gH9j";
+    const structuredSecret = "low-entropy-key";
+    let requestBody = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        requestBody = String(init?.body);
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n',
+          { status: 200 },
+        );
+      }),
+    );
+
+    const provider = createProvider({
+      apiKey: "byok-key",
+      model: "test-model",
+      baseUrl: "https://llm.example.com/v1",
+    });
+    const chunks: string[] = [];
+    for await (const chunk of provider.stream([
+      { role: "user", content: `분석 ${textSecret}` },
+      {
+        role: "system",
+        content: "현재 스펙",
+        structuredContent: { sources: [{ params: { serviceKey: structuredSecret } }] },
+      },
+    ])) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.join("")).toBe("ok");
+    expect(requestBody).not.toContain(textSecret);
+    expect(requestBody).not.toContain(structuredSecret);
+    expect(requestBody).toContain("__SCRUBBED_");
+  });
+
+  it("일반 chat 응답에는 시크릿이나 플레이스홀더를 노출하지 않는다", async () => {
+    const secret = "low-entropy-key";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          'data: {"choices":[{"delta":{"content":"__SCRUB"}}]}\n\n' +
+            'data: {"choices":[{"delta":{"content":"BED_fake_0__"}}]}\n\n',
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const provider = createProvider({
+      apiKey: "byok-key",
+      model: "test-model",
+      baseUrl: "https://llm.example.com/v1",
+    });
+    let output = "";
+    for await (const chunk of provider.stream([
+      { role: "user", content: "분석", structuredContent: { serviceKey: secret } },
+    ])) {
+      output += chunk;
+    }
+
+    expect(output).toBe("[REDACTED]");
+    expect(output).not.toContain(secret);
+  });
+});

--- a/src/features/assistant/provider.ts
+++ b/src/features/assistant/provider.ts
@@ -6,13 +6,26 @@
  *
  * **공용 키를 VITE_*로 주입하는 것은 절대 금지** — 번들에 평문으로 박힌다.
  */
+import { createSecretScrubber, type SecretScrubber } from "./scrub";
 
 export interface AssistMessage {
   role: "system" | "user" | "assistant";
   content: string;
+  structuredContent?: unknown;
 }
 
+export interface AssistExchange {
+  readonly output: AsyncIterable<string>;
+  readonly displayOutput: AsyncIterable<string>;
+  readonly hadSecrets: boolean;
+  restoreText(text: string): string;
+}
+
+const SAFE_PROVIDER: unique symbol = Symbol("safe-assist-provider");
+
 export interface AssistProvider {
+  readonly [SAFE_PROVIDER]: true;
+  exchange(messages: AssistMessage[], signal?: AbortSignal): AssistExchange;
   stream(messages: AssistMessage[], signal?: AbortSignal): AsyncIterable<string>;
   readonly isConfigured: boolean;
 }
@@ -26,7 +39,12 @@ export interface AssistConfig {
 const DEFAULT_MODEL = "gpt-4o-mini";
 const DEFAULT_BASE_URL = "https://api.openai.com/v1";
 
-export class ByokProvider implements AssistProvider {
+interface AssistTransport {
+  stream(messages: AssistMessage[], signal?: AbortSignal): AsyncIterable<string>;
+  readonly isConfigured: boolean;
+}
+
+class ByokTransport implements AssistTransport {
   constructor(private config: AssistConfig) {}
 
   get isConfigured(): boolean {
@@ -82,10 +100,82 @@ export class ByokProvider implements AssistProvider {
   }
 }
 
-export function createProvider(config: AssistConfig): AssistProvider {
-  return new ByokProvider({
-    ...config,
-    model: config.model || DEFAULT_MODEL,
-    baseUrl: config.baseUrl || DEFAULT_BASE_URL,
+function prepareMessages(messages: AssistMessage[], scrubber: SecretScrubber): AssistMessage[] {
+  return messages.map(({ role, content, structuredContent }) => {
+    const safeText = scrubber.scrubText(content);
+    if (structuredContent === undefined) return { role, content: safeText };
+    const safeStructured = scrubber.scrub(structuredContent);
+    return { role, content: `${safeText}\n${JSON.stringify(safeStructured, null, 2)}` };
   });
+}
+
+const PLACEHOLDER_PREFIX = "__SCRUBBED_";
+const COMPLETE_PLACEHOLDER = /^__SCRUBBED_[A-Za-z0-9-]+_\d+__/;
+
+async function* redactDisplayOutput(output: AsyncIterable<string>): AsyncIterable<string> {
+  let pending = "";
+  for await (const chunk of output) {
+    pending += chunk;
+    while (pending) {
+      const marker = pending.indexOf(PLACEHOLDER_PREFIX);
+      if (marker < 0) {
+        const safeLength = Math.max(0, pending.length - (PLACEHOLDER_PREFIX.length - 1));
+        if (safeLength > 0) {
+          yield pending.slice(0, safeLength);
+          pending = pending.slice(safeLength);
+        }
+        break;
+      }
+      if (marker > 0) {
+        yield pending.slice(0, marker);
+        pending = pending.slice(marker);
+      }
+      const placeholder = pending.match(COMPLETE_PLACEHOLDER)?.[0];
+      if (!placeholder) break;
+      yield "[REDACTED]";
+      pending = pending.slice(placeholder.length);
+    }
+  }
+
+  if (pending.startsWith(PLACEHOLDER_PREFIX)) {
+    yield pending.replace(/^__SCRUBBED_\S*/, "[REDACTED]");
+  } else if (pending) {
+    yield pending;
+  }
+}
+
+class SafeAssistProvider implements AssistProvider {
+  readonly [SAFE_PROVIDER] = true;
+
+  constructor(private transport: AssistTransport) {}
+
+  get isConfigured(): boolean {
+    return this.transport.isConfigured;
+  }
+
+  exchange(messages: AssistMessage[], signal?: AbortSignal): AssistExchange {
+    const scrubber = createSecretScrubber();
+    const safeMessages = prepareMessages(messages, scrubber);
+    const output = this.transport.stream(safeMessages, signal);
+    return {
+      output,
+      displayOutput: redactDisplayOutput(output),
+      hadSecrets: scrubber.placeholders.size > 0,
+      restoreText: (text) => scrubber.restoreText(text),
+    };
+  }
+
+  async *stream(messages: AssistMessage[], signal?: AbortSignal): AsyncIterable<string> {
+    yield* this.exchange(messages, signal).displayOutput;
+  }
+}
+
+export function createProvider(config: AssistConfig): AssistProvider {
+  return new SafeAssistProvider(
+    new ByokTransport({
+      ...config,
+      model: config.model || DEFAULT_MODEL,
+      baseUrl: config.baseUrl || DEFAULT_BASE_URL,
+    }),
+  );
 }

--- a/src/features/assistant/scrub.test.ts
+++ b/src/features/assistant/scrub.test.ts
@@ -8,7 +8,13 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { looksLikeSecret, restoreSecrets, scrubSecrets } from "./scrub";
+import {
+  createSecretScrubber,
+  hasSecretPlaceholder,
+  looksLikeSecret,
+  restoreSecrets,
+  scrubSecrets,
+} from "./scrub";
 
 const SAMPLE_SERVICE_KEY =
   "9dF8kQ2mZ7xV3nL1pR4wY6tB0hJ5sC8gU2iE7oA9bN3cM6dP4qK1rS8tU0vW3xY5z";
@@ -67,6 +73,31 @@ describe("restoreSecrets — 배열 왕복 회귀 (#226 결함 c)", () => {
     const { scrubbed, placeholders } = scrubSecrets(original);
     const restored = restoreSecrets(scrubbed, placeholders);
     expect(restored).toEqual(original);
+  });
+
+  it("다른 요청이 만든 플레이스홀더를 복원하지 않는다", () => {
+    const requestA = createSecretScrubber("request-a");
+    const requestB = createSecretScrubber("request-b");
+    const scrubbed = requestA.scrub({ serviceKey: "test-key" }) as {
+      serviceKey: string;
+    };
+
+    expect(() => requestB.restore(scrubbed)).toThrow("알 수 없는 시크릿");
+  });
+
+  it("문자열 응답의 알려진 플레이스홀더만 복원한다", () => {
+    const scrubber = createSecretScrubber("request-a");
+    const scrubbed = scrubber.scrub({ serviceKey: "test-key" }) as {
+      serviceKey: string;
+    };
+
+    expect(scrubber.restoreText(`serviceKey: ${scrubbed.serviceKey}`)).toBe(
+      "serviceKey: test-key",
+    );
+    expect(() => scrubber.restoreText("__SCRUBBED_request-b_0__")).toThrow(
+      "알 수 없는 시크릿",
+    );
+    expect(hasSecretPlaceholder(scrubbed)).toBe(true);
   });
 });
 

--- a/src/features/assistant/scrub.ts
+++ b/src/features/assistant/scrub.ts
@@ -48,21 +48,39 @@ export function looksLikeSecret(value: string): boolean {
 }
 
 const SCRUBBED_PREFIX = "__SCRUBBED_";
+const SCRUBBED_PATTERN = /__SCRUBBED_[A-Za-z0-9-]+_\d+__/g;
+const SCRUBBED_TEST_PATTERN = /__SCRUBBED_[A-Za-z0-9-]+_\d+__/;
 
 export interface ScrubResult {
   scrubbed: unknown;
   placeholders: Map<string, string>;
 }
 
-export function scrubSecrets(data: unknown): ScrubResult {
+export interface SecretScrubber {
+  scrub(data: unknown): unknown;
+  scrubText(text: string): string;
+  restore(data: unknown): unknown;
+  restoreText(text: string): string;
+  readonly placeholders: ReadonlyMap<string, string>;
+}
+
+function requestId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+}
+
+export function createSecretScrubber(id = requestId()): SecretScrubber {
   const placeholders = new Map<string, string>();
   let counter = 0;
 
+  function replace(value: string): string {
+    const placeholder = `${SCRUBBED_PREFIX}${id}_${counter++}__`;
+    placeholders.set(placeholder, value);
+    return placeholder;
+  }
+
   function scrubValue(key: string, value: unknown): unknown {
     if (typeof value === "string" && (isSecretKey(key) || looksLikeSecret(value))) {
-      const placeholder = `${SCRUBBED_PREFIX}${counter++}__`;
-      placeholders.set(placeholder, value);
-      return placeholder;
+      return replace(value);
     }
     // 배열도 순회한다 (#226 결함 a). BuildSpec.sources 가 배열이라
     // !Array.isArray(value) 분기가 재귀를 끊어 sources[].params.serviceKey 에
@@ -81,13 +99,56 @@ export function scrubSecrets(data: unknown): ScrubResult {
     return value;
   }
 
-  const scrubbed = scrubValue("root", data);
-  return { scrubbed, placeholders };
+  function scrubText(text: string): string {
+    const assignmentPattern = /\b([\w-]*(?:servicekey|api[_-]?key|token|secret))([ \t]*[:=][ \t]*)([^\s,}\]]+)/gi;
+    const assigned = text.replace(assignmentPattern, (_match, key: string, separator: string, value: string) => {
+      const quote = value.startsWith("\"") || value.startsWith("'") ? value[0] : "";
+      const raw = quote ? value.slice(1, value.endsWith(quote) ? -1 : undefined) : value;
+      return `${key}${separator}${quote}${replace(raw)}${quote}`;
+    });
+
+    return assigned.replace(/\S{24,}/g, (token) => {
+      if (token.startsWith(SCRUBBED_PREFIX) || !looksLikeSecret(token)) return token;
+      return replace(token);
+    });
+  }
+
+  function restore(data: unknown): unknown {
+    if (typeof data === "string" && data.startsWith(SCRUBBED_PREFIX)) {
+      const value = placeholders.get(data);
+      if (value === undefined) throw new Error("알 수 없는 시크릿 플레이스홀더가 포함되어 있습니다.");
+      return value;
+    }
+    if (Array.isArray(data)) return data.map(restore);
+    if (data && typeof data === "object") {
+      return Object.fromEntries(
+        Object.entries(data as Record<string, unknown>).map(([key, value]) => [key, restore(value)]),
+      );
+    }
+    return data;
+  }
+
+  function restoreText(text: string): string {
+    return text.replace(SCRUBBED_PATTERN, (placeholder) => {
+      const value = placeholders.get(placeholder);
+      if (value === undefined) throw new Error("알 수 없는 시크릿 플레이스홀더가 포함되어 있습니다.");
+      return value;
+    });
+  }
+
+  return { scrub: (data) => scrubValue("root", data), scrubText, restore, restoreText, placeholders };
+}
+
+export function scrubSecrets(data: unknown): ScrubResult {
+  const scrubber = createSecretScrubber();
+  return { scrubbed: scrubber.scrub(data), placeholders: new Map(scrubber.placeholders) };
 }
 
 export function restoreSecrets(data: unknown, placeholders: Map<string, string>): unknown {
   if (typeof data === "string" && data.startsWith(SCRUBBED_PREFIX)) {
-    return placeholders.get(data) ?? data;
+    const value = placeholders.get(data);
+    if (value === undefined) throw new Error("알 수 없는 시크릿 플레이스홀더가 포함되어 있습니다.");
+    return value;
   }
   // 배열 왕복 복원 (#226 결함 c). scrub 가 배열을 순회하므로 restore 도 같이.
   if (Array.isArray(data)) {
@@ -102,4 +163,13 @@ export function restoreSecrets(data: unknown, placeholders: Map<string, string>)
     return result;
   }
   return data;
+}
+
+export function hasSecretPlaceholder(data: unknown): boolean {
+  if (typeof data === "string") return SCRUBBED_TEST_PATTERN.test(data);
+  if (Array.isArray(data)) return data.some(hasSecretPlaceholder);
+  if (data && typeof data === "object") {
+    return Object.values(data as Record<string, unknown>).some(hasSecretPlaceholder);
+  }
+  return false;
 }


### PR DESCRIPTION
## 개요

Closes #273
Closes #274

Assistant의 모든 outbound message를 private BYOK transport 앞의 공통 safe provider에서 처리합니다. structured content는 직렬화 전에 key-aware 스크러빙하고, 자유 텍스트는 secret-key assignment와 고엔트로피 token을 방어적으로 마스킹합니다.

## 주요 변경

- raw `ByokTransport`를 비공개로 전환하고 `createProvider()`만 safe provider를 반환
- opaque provider brand로 외부의 우발적인 raw provider 구현 차단
- 요청별 random namespace를 가진 placeholder ledger 도입
- `AssistantChat`, BuildSpec generation/repair, column meaning을 공통 exchange 경로로 통합
- 일반 chat/설명 출력은 placeholder를 chunk 경계와 무관하게 `[REDACTED]` 처리
- 검증을 통과한 구조화 BuildSpec 출력만 request ledger로 복원
- 다른 요청/LLM이 만든 unknown placeholder는 명확한 error로 fail-closed
- 최종 HTTP body 및 scrub→response→restore 회귀 테스트 추가

## 검증

- `npm test`: 55 files, 353 tests 통과
- `npm run typecheck`: 통과
- `npm run lint`: 통과
- `npm run build`: 통과

## 병합 순서

이 PR을 #277보다 먼저 병합해야 합니다. #277이 같은 `provider.ts`/`scrub.ts`를 수정하므로, 병합 후 #277은 이 safe egress를 재사용하도록 rebase하고 Kubi의 caller-level 중복 scrub을 제거해야 합니다.