### PR TITLE
fix: Assistant 카탈로그 대조와 필수 validate 게이트 구현 (#275, #276)

### DIFF
--- a/__tests__/assistant.test.ts
+++ b/__tests__/assistant.test.ts
@@ -13,8 +13,32 @@ vi.mock("@/shared/lib/builderApi", () => ({
 }));
 
 import { generateBuildSpec } from "@/features/assistant/generate";
+import type { GenerationOptions } from "@/features/assistant/generate";
 import type { AssistProvider, AssistMessage } from "@/features/assistant/provider";
 import { scrubSecrets, restoreSecrets, isSecretKey, looksLikeSecret } from "@/features/assistant/scrub";
+
+const catalog = {
+  providers: [
+    {
+      name: "datago",
+      datasets: [
+        { name: "village_fcst", title: "단기예보", requires_service_key: true },
+      ],
+    },
+  ],
+};
+
+const validYaml = `dataset_id: test
+title: Test
+description: desc
+sources:
+  - key: s
+    provider: datago
+    dataset: village_fcst
+exports:
+  - kind: markdown
+    output_path: out.md
+`;
 
 function mockProvider(responses: string[]): AssistProvider {
   let idx = 0;
@@ -40,13 +64,16 @@ function mockProvider(responses: string[]): AssistProvider {
 
 describe("generateBuildSpec (ST-A7, #210)", () => {
   it("returns valid spec when validate passes on first try", async () => {
-    const yaml = "dataset_id: test\ntitle: Test\ndescription: desc\nsources:\n  - key: s\n    provider: datago\n    dataset: village_fcst\nexports:\n  - kind: markdown\n    output_path: out.md\n";
-    const provider = mockProvider([yaml]);
-    const validateFn = vi.fn().mockResolvedValue({ valid: true });
+    const provider = mockProvider([validYaml]);
+    const validateFn = vi.fn().mockResolvedValue({
+      status: "valid",
+      dataset_id: "test",
+      api_version: "1.7.0",
+    });
 
     const result = await generateBuildSpec(provider, "weather data", {
       validateFn,
-      catalogContext: "datago: village_fcst",
+      catalog,
     });
 
     expect(result.status).toBe("ok");
@@ -56,27 +83,29 @@ describe("generateBuildSpec (ST-A7, #210)", () => {
   });
 
   it("retries when validate fails, succeeds on second attempt", async () => {
-    const badYaml = "invalid";
-    const goodYaml = "dataset_id: test\ntitle: Test\ndescription: desc\n";
-    const provider = mockProvider([badYaml, goodYaml]);
+    const provider = mockProvider([validYaml, validYaml]);
     const validateFn = vi
       .fn()
-      .mockResolvedValueOnce({ valid: false, problems: ["dataset_id is empty"] })
-      .mockResolvedValueOnce({ valid: true });
+      .mockResolvedValueOnce({ status: "invalid", problems: ["dataset_id is empty"] })
+      .mockResolvedValueOnce({
+        status: "valid",
+        dataset_id: "test",
+        api_version: "1.7.0",
+      });
 
-    const result = await generateBuildSpec(provider, "test", { validateFn });
+    const result = await generateBuildSpec(provider, "test", { catalog, validateFn });
 
     expect(result.status).toBe("ok");
     expect(result.attempts).toBe(2);
   });
 
   it("returns partial after max retries exhausted", async () => {
-    const provider = mockProvider(["bad1", "bad2", "bad3"]);
+    const provider = mockProvider([validYaml, validYaml, validYaml]);
     const validateFn = vi
       .fn()
-      .mockResolvedValue({ valid: false, problems: ["always fails"] });
+      .mockResolvedValue({ status: "invalid", problems: ["always fails"] });
 
-    const result = await generateBuildSpec(provider, "test", { validateFn });
+    const result = await generateBuildSpec(provider, "test", { catalog, validateFn });
 
     expect(result.status).toBe("partial");
     expect(result.attempts).toBe(3);
@@ -87,7 +116,12 @@ describe("generateBuildSpec (ST-A7, #210)", () => {
     mockState.realBuilderEnabled = false;
     const provider = mockProvider(["should not be called"]);
     const result = await generateBuildSpec(provider, "test", {
-      validateFn: vi.fn().mockResolvedValue({ valid: true }),
+      catalog,
+      validateFn: vi.fn().mockResolvedValue({
+        status: "valid",
+        dataset_id: "test",
+        api_version: "1.7.0",
+      }),
     });
     mockState.realBuilderEnabled = true;
 
@@ -102,7 +136,10 @@ describe("generateBuildSpec (ST-A7, #210)", () => {
       isConfigured: true,
       exchange: () => ({
         output: (async function* () {
-          yield `sources:\n  - params:\n      serviceKey: ${placeholder}`;
+          yield validYaml.replace(
+            "    dataset: village_fcst",
+            `    dataset: village_fcst\n    params:\n      serviceKey: ${placeholder}`,
+          );
         })(),
         displayOutput: (async function* () {})(),
         hadSecrets: true,
@@ -112,7 +149,12 @@ describe("generateBuildSpec (ST-A7, #210)", () => {
     } as unknown as AssistProvider;
 
     const result = await generateBuildSpec(provider, "기존 스펙을 수정해줘", {
-      validateFn: vi.fn().mockResolvedValue({ valid: true }),
+      catalog,
+      validateFn: vi.fn().mockResolvedValue({
+        status: "valid",
+        dataset_id: "test",
+        api_version: "1.7.0",
+      }),
     });
 
     expect(result.status).toBe("ok");
@@ -125,7 +167,10 @@ describe("generateBuildSpec (ST-A7, #210)", () => {
       isConfigured: true,
       exchange: () => ({
         output: (async function* () {
-          yield "serviceKey: __SCRUBBED_another-request_0__";
+          yield validYaml.replace(
+            "    dataset: village_fcst",
+            "    dataset: village_fcst\n    params:\n      serviceKey: __SCRUBBED_another-request_0__",
+          );
         })(),
         displayOutput: (async function* () {})(),
         hadSecrets: true,
@@ -137,12 +182,112 @@ describe("generateBuildSpec (ST-A7, #210)", () => {
     } as unknown as AssistProvider;
 
     const result = await generateBuildSpec(provider, "기존 스펙을 수정해줘", {
-      validateFn: vi.fn().mockResolvedValue({ valid: true }),
+      catalog,
+      validateFn: vi.fn().mockResolvedValue({
+        status: "valid",
+        dataset_id: "test",
+        api_version: "1.7.0",
+      }),
     });
 
     expect(result.status).toBe("error");
     expect(result.spec).toBeNull();
     expect(result.remaining_problems[0]).toContain("알 수 없는 시크릿");
+  });
+
+  it("카탈로그에 없는 provider는 repair 후 partial 처리한다", async () => {
+    const unknownProvider = validYaml.replace("provider: datago", "provider: invented");
+    const provider = mockProvider([unknownProvider, unknownProvider, unknownProvider]);
+    const validateFn = vi.fn();
+
+    const result = await generateBuildSpec(provider, "test", { catalog, validateFn });
+
+    expect(result.status).toBe("partial");
+    expect(result.remaining_problems[0]).toContain("카탈로그에 없는 provider");
+    expect(validateFn).not.toHaveBeenCalled();
+  });
+
+  it("provider에 속하지 않은 dataset은 Builder 검증 전에 차단한다", async () => {
+    const unknownDataset = validYaml.replace("dataset: village_fcst", "dataset: invented");
+    const provider = mockProvider([unknownDataset, unknownDataset, unknownDataset]);
+    const validateFn = vi.fn();
+
+    const result = await generateBuildSpec(provider, "test", { catalog, validateFn });
+
+    expect(result.status).toBe("partial");
+    expect(result.remaining_problems[0]).toContain("provider 'datago'에 없는 dataset");
+    expect(validateFn).not.toHaveBeenCalled();
+  });
+
+  it("빈 카탈로그에서는 LLM을 호출하지 않고 fail-closed한다", async () => {
+    const provider = mockProvider([validYaml]);
+    const validateFn = vi.fn();
+
+    const result = await generateBuildSpec(provider, "test", {
+      catalog: { providers: [] },
+      validateFn,
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.attempts).toBe(0);
+    expect(result.remaining_problems[0]).toContain("카탈로그를 조회할 수 없어");
+    expect(validateFn).not.toHaveBeenCalled();
+  });
+
+  it("Builder error는 repair problem으로 바꾸지 않고 즉시 error 처리한다", async () => {
+    const provider = mockProvider([validYaml]);
+    const result = await generateBuildSpec(provider, "test", {
+      catalog,
+      validateFn: vi.fn().mockResolvedValue({ status: "error", error: "service unavailable" }),
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.attempts).toBe(1);
+    expect(result.remaining_problems).toEqual(["service unavailable"]);
+  });
+
+  it("validation transport 실패는 repair하지 않고 즉시 error 처리한다", async () => {
+    const provider = mockProvider([validYaml, validYaml]);
+    const result = await generateBuildSpec(provider, "test", {
+      catalog,
+      validateFn: vi.fn().mockRejectedValue(new Error("Builder API에 연결하지 못했습니다.")),
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.attempts).toBe(1);
+    expect(result.remaining_problems[0]).toContain("연결하지 못했습니다");
+  });
+
+  it("런타임에서 validator가 누락되어도 ok를 반환하지 않는다", async () => {
+    const callWithoutValidator = generateBuildSpec as unknown as (
+      provider: AssistProvider,
+      prompt: string,
+      options: Partial<GenerationOptions>,
+    ) => ReturnType<typeof generateBuildSpec>;
+
+    const result = await callWithoutValidator(mockProvider([validYaml]), "test", { catalog });
+
+    expect(result.status).toBe("error");
+    expect(result.attempts).toBe(0);
+    expect(result.remaining_problems[0]).toContain("/validate 연결이 없어");
+  });
+
+  it("validation에 AbortSignal을 전달한다", async () => {
+    const provider = mockProvider([validYaml]);
+    const controller = new AbortController();
+    const validateFn = vi.fn().mockResolvedValue({
+      status: "valid",
+      dataset_id: "test",
+      api_version: "1.7.0",
+    });
+
+    await generateBuildSpec(provider, "test", {
+      catalog,
+      validateFn,
+      signal: controller.signal,
+    });
+
+    expect(validateFn).toHaveBeenCalledWith(validYaml.trim(), controller.signal);
   });
 });
 

--- a/__tests__/assistant.test.ts
+++ b/__tests__/assistant.test.ts
@@ -18,15 +18,24 @@ import { scrubSecrets, restoreSecrets, isSecretKey, looksLikeSecret } from "@/fe
 
 function mockProvider(responses: string[]): AssistProvider {
   let idx = 0;
-  return {
+  const provider = {
     isConfigured: true,
+    exchange(messages: AssistMessage[]) {
+      return {
+        output: provider.stream(messages),
+        displayOutput: provider.stream(messages),
+        hadSecrets: false,
+        restoreText: (text: string) => text,
+      };
+    },
     async *stream(_messages: AssistMessage[]): AsyncIterable<string> {
       const resp = responses[idx++] ?? responses[responses.length - 1];
       for (const char of resp) {
         yield char;
       }
     },
-  };
+  } as unknown as AssistProvider;
+  return provider;
 }
 
 describe("generateBuildSpec (ST-A7, #210)", () => {
@@ -85,6 +94,55 @@ describe("generateBuildSpec (ST-A7, #210)", () => {
     expect(result.status).toBe("error");
     expect(result.spec).toBeNull();
     expect(result.remaining_problems[0]).toContain("mock");
+  });
+
+  it("검증을 통과한 구조화 출력의 요청별 시크릿을 복원한다", async () => {
+    const placeholder = "__SCRUBBED_request-a_0__";
+    const provider = {
+      isConfigured: true,
+      exchange: () => ({
+        output: (async function* () {
+          yield `sources:\n  - params:\n      serviceKey: ${placeholder}`;
+        })(),
+        displayOutput: (async function* () {})(),
+        hadSecrets: true,
+        restoreText: (text: string) => text.replace(placeholder, "original-service-key"),
+      }),
+      stream: async function* () {},
+    } as unknown as AssistProvider;
+
+    const result = await generateBuildSpec(provider, "기존 스펙을 수정해줘", {
+      validateFn: vi.fn().mockResolvedValue({ valid: true }),
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.spec).toContain("serviceKey: original-service-key");
+    expect(result.spec).not.toContain("__SCRUBBED_");
+  });
+
+  it("알 수 없는 플레이스홀더가 남은 출력은 error로 처리한다", async () => {
+    const provider = {
+      isConfigured: true,
+      exchange: () => ({
+        output: (async function* () {
+          yield "serviceKey: __SCRUBBED_another-request_0__";
+        })(),
+        displayOutput: (async function* () {})(),
+        hadSecrets: true,
+        restoreText: () => {
+          throw new Error("알 수 없는 시크릿 플레이스홀더가 포함되어 있습니다.");
+        },
+      }),
+      stream: async function* () {},
+    } as unknown as AssistProvider;
+
+    const result = await generateBuildSpec(provider, "기존 스펙을 수정해줘", {
+      validateFn: vi.fn().mockResolvedValue({ valid: true }),
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.spec).toBeNull();
+    expect(result.remaining_problems[0]).toContain("알 수 없는 시크릿");
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "react-dom": "19.2.8",
         "react-hook-form": "^7.85.0",
         "react-router-dom": "^7.18.2",
+        "yaml": "^2.9.0",
         "zod": "^4.4.3",
         "zustand": "^5.0.14"
       },
@@ -4704,6 +4705,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "19.2.8",
     "react-hook-form": "^7.85.0",
     "react-router-dom": "^7.18.2",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3",
     "zustand": "^5.0.14"
   },

--- a/src/features/assistant/AssistantChat.tsx
+++ b/src/features/assistant/AssistantChat.tsx
@@ -8,14 +8,13 @@ import { useCallback, useRef, useState } from "react";
 import { Button, Card, Textarea } from "@/shared/ui";
 import { useAssistConfig } from "./config";
 import { createProvider, type AssistMessage } from "./provider";
-import { scrubSecrets } from "./scrub";
 
 interface ChatMessage {
   role: "user" | "assistant";
   content: string;
 }
 
-export function AssistantChat({ contextSpec }: { contextSpec?: string }) {
+export function AssistantChat({ contextSpec }: { contextSpec?: unknown }) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
@@ -33,17 +32,13 @@ export function AssistantChat({ contextSpec }: { contextSpec?: string }) {
     setInput("");
     setIsStreaming(true);
 
-    // 시크릿 스크러빙 (#206)
-    const scrubbed = contextSpec ? scrubSecrets(contextSpec) : null;
-    const safeSpec = scrubbed ? JSON.stringify(scrubbed.scrubbed) : contextSpec;
-
     const systemPrompt = `당신은 한국 공공데이터 빌드 스펙(BuildSpec) 전문가입니다.
 사용자의 질문에 한국어로 답변하세요.
-${safeSpec ? `현재 스펙:\n${safeSpec}\n` : ""}
+${contextSpec ? "현재 스펙은 첨부된 구조화 컨텍스트를 참고하세요.\n" : ""}
 오류가 있으면 수정 제안을 하세요.`;
 
     const apiMessages: AssistMessage[] = [
-      { role: "system", content: systemPrompt },
+      { role: "system", content: systemPrompt, structuredContent: contextSpec },
       ...[...messages, userMsg].map((m) => ({ role: m.role, content: m.content }) as AssistMessage),
     ];
 

--- a/src/features/assistant/columnMeaning.test.ts
+++ b/src/features/assistant/columnMeaning.test.ts
@@ -21,11 +21,11 @@ describe("buildColumnMeaningPrompt — 스크러빙 (#228, SEC-2 선행)", () =>
       { OPNSFTEAM_CODE: "3000001", serviceKey: SECRET_KEY },
     ];
 
-    const { messages, scrubbed } = buildColumnMeaningPrompt(columns, rows);
+    const { messages } = buildColumnMeaningPrompt(columns, rows);
 
-    expect(scrubbed).toBe(true);
     const promptText = messages.map((m) => m.content).join("\n");
     expect(promptText).not.toContain(SECRET_KEY);
+    expect(messages.find((message) => message.structuredContent)).toBeDefined();
   });
 
   it("컬럼 목록이 프롬프트에 포함된다", () => {
@@ -40,10 +40,10 @@ describe("buildColumnMeaningPrompt — 스크러빙 (#228, SEC-2 선행)", () =>
     expect(userMsg?.content).toContain("BUDGET_CRNTAM");
   });
 
-  it("시크릿이 없으면 scrubbed=false", () => {
+  it("샘플 행은 공통 egress가 처리할 structured content로 유지한다", () => {
     const columns = [{ name: "region", dtype: "String" }];
     const rows = [{ region: "서울" }];
-    const { scrubbed } = buildColumnMeaningPrompt(columns, rows);
-    expect(scrubbed).toBe(false);
+    const { messages } = buildColumnMeaningPrompt(columns, rows);
+    expect(messages.find((message) => message.structuredContent)?.structuredContent).toEqual(rows);
   });
 });

--- a/src/features/assistant/columnMeaning.ts
+++ b/src/features/assistant/columnMeaning.ts
@@ -2,10 +2,9 @@
  * 컬럼 의미 해독 — dataset card 보강 (AI-1, #228).
  *
  * 한국 공공데이터 컬럼명(MTHDT, BSNS_LCNS_NO, OPNSFTEAM_CODE 등)의 한국어
- * 설명 초안을 LLM으로 생성한다. 샘플 값은 scrubSecrets 를 반드시 통과한다
- * (SEC-2 선행). 승인 전에는 metadata 에 반영되지 않는다.
+ * 설명 초안을 LLM으로 생성한다. 샘플 값은 structured content로 공통 provider
+ * egress에 전달되어 직렬화 전에 스크러빙된다. 승인 전에는 metadata에 반영되지 않는다.
  */
-import { scrubSecrets } from "./scrub";
 import type { AssistProvider, AssistMessage } from "./provider";
 
 /** 컬럼 설명 초안 결과. */
@@ -24,21 +23,16 @@ export interface ColumnMeta {
 /**
  * 컬럼 목록과 샘플 행에서 LLM 프롬프트를 구성한다 (#228).
  *
- * 샘플 행은 scrubSecrets 로 시크릿을 마스킹한 뒤 프롬프트에 포함한다.
- * LLM 에 전송되는 페이로드에 원본 시크릿이 노출되지 않는다.
+ * 샘플 행은 문자열로 미리 직렬화하지 않고 structured content로 유지한다.
+ * 공통 provider egress가 key-aware 스크러빙한 뒤 최종 payload를 만든다.
  */
 export function buildColumnMeaningPrompt(
   columns: ColumnMeta[],
   sampleRows: Record<string, unknown>[],
-): { messages: AssistMessage[]; scrubbed: boolean } {
-  const { scrubbed, placeholders } = scrubSecrets(sampleRows);
-  const hasPlaceholders = placeholders.size > 0;
-
+): { messages: AssistMessage[] } {
   const colList = columns
     .map((c) => `  - ${c.name} (${c.dtype})`)
     .join("\n");
-
-  const sampleStr = JSON.stringify(scrubbed, null, 2).slice(0, 2000);
 
   const systemPrompt = `당신은 한국 공공데이터 컬럼명 해독 전문가입니다.
 각 컬럼의 이름, dtype, 샘플 값을 근거로 한국어 설명을 작성하세요.
@@ -48,17 +42,15 @@ export function buildColumnMeaningPrompt(
   const userPrompt = `컬럼 목록:
 ${colList}
 
-샘플 데이터 (최대 5행, 시크릿 마스킹됨):
-${sampleStr}
+샘플 데이터는 첨부된 구조화 컨텍스트를 참고하세요.
 
 각 컬럼에 대한 한국어 설명을 JSON으로 출력하세요.`;
 
   return {
     messages: [
       { role: "system", content: systemPrompt },
-      { role: "user", content: userPrompt },
+      { role: "user", content: userPrompt, structuredContent: sampleRows.slice(0, 5) },
     ],
-    scrubbed: hasPlaceholders,
   };
 }
 
@@ -67,7 +59,7 @@ ${sampleStr}
  *
  * @param provider LLM provider (BYOK).
  * @param columns 컬럼 메타데이터.
- * @param sampleRows 샘플 행 (scrubSecrets 통과 후 LLM 전송).
+ * @param sampleRows 샘플 행 (공통 provider egress에서 스크러빙 후 LLM 전송).
  * @param signal 취소 신호.
  * @returns 컬럼명 → 한국어 설명 매핑. LLM 미설정 시 status="error".
  */
@@ -77,10 +69,11 @@ export async function generateColumnMeanings(
   sampleRows: Record<string, unknown>[],
   signal?: AbortSignal,
 ): Promise<ColumnMeaningResult> {
-  const { messages, scrubbed } = buildColumnMeaningPrompt(columns, sampleRows);
+  const { messages } = buildColumnMeaningPrompt(columns, sampleRows);
 
+  const exchange = provider.exchange(messages, signal);
   let rawOutput = "";
-  for await (const chunk of provider.stream(messages, signal)) {
+  for await (const chunk of exchange.displayOutput) {
     rawOutput += chunk;
   }
 
@@ -91,8 +84,8 @@ export async function generateColumnMeanings(
 
   try {
     const parsed = JSON.parse(jsonStr) as Record<string, string>;
-    return { descriptions: parsed, status: "ok", scrubbed };
+    return { descriptions: parsed, status: "ok", scrubbed: exchange.hadSecrets };
   } catch {
-    return { descriptions: {}, status: "error", scrubbed };
+    return { descriptions: {}, status: "error", scrubbed: exchange.hadSecrets };
   }
 }

--- a/src/features/assistant/generate.ts
+++ b/src/features/assistant/generate.ts
@@ -61,8 +61,9 @@ YAML만 출력하세요. 설명은 출력하지 마세요.`;
       });
     }
 
+    const exchange = provider.exchange(messages, options.signal);
     let rawOutput = "";
-    for await (const chunk of provider.stream(messages, options.signal)) {
+    for await (const chunk of exchange.output) {
       rawOutput += chunk;
     }
 
@@ -79,7 +80,23 @@ YAML만 출력하세요. 설명은 출력하지 마세요.`;
     if (options.validateFn) {
       const result = await options.validateFn(spec);
       if (result.valid) {
-        return { spec, status: "ok", attempts, remaining_problems: [] };
+        try {
+          return {
+            spec: exchange.restoreText(spec),
+            status: "ok",
+            attempts,
+            remaining_problems: [],
+          };
+        } catch (error) {
+          return {
+            spec: null,
+            status: "error",
+            attempts,
+            remaining_problems: [
+              error instanceof Error ? error.message : "시크릿 복원에 실패했습니다.",
+            ],
+          };
+        }
       }
       lastProblems = result.problems ?? ["검증 실패"];
       continue;

--- a/src/features/assistant/generate.ts
+++ b/src/features/assistant/generate.ts
@@ -8,6 +8,9 @@
  */
 import type { AssistProvider, AssistMessage } from "./provider";
 import { isRealBuilderEnabled } from "@/shared/lib/builderApi";
+import type { CatalogResponse, ValidateResponse } from "@/shared/lib/builderApi";
+import { parse } from "yaml";
+import { z } from "zod";
 
 export interface GenerationResult {
   spec: string | null;
@@ -18,14 +21,74 @@ export interface GenerationResult {
 
 const MAX_REPAIR_ATTEMPTS = 2;
 
+const generatedBuildSpecSchema = z.object({
+  dataset_id: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  sources: z.array(
+    z.object({
+      provider: z.string().min(1),
+      dataset: z.string().min(1),
+    }).passthrough(),
+  ).min(1),
+}).passthrough();
+
+export interface GenerationOptions {
+  catalog: CatalogResponse;
+  validateFn: (spec: string, signal?: AbortSignal) => Promise<ValidateResponse>;
+  signal?: AbortSignal;
+}
+
+function catalogProblems(
+  spec: z.infer<typeof generatedBuildSpecSchema>,
+  catalog: CatalogResponse,
+): string[] {
+  const providers = new Map(
+    catalog.providers.map((provider) => [
+      provider.name,
+      new Set(provider.datasets.map((dataset) => dataset.name)),
+    ]),
+  );
+  const problems: string[] = [];
+  spec.sources.forEach((source, index) => {
+    const datasets = providers.get(source.provider);
+    if (!datasets) {
+      problems.push(`sources[${index}].provider: 카탈로그에 없는 provider '${source.provider}'입니다.`);
+    } else if (!datasets.has(source.dataset)) {
+      problems.push(
+        `sources[${index}].dataset: provider '${source.provider}'에 없는 dataset '${source.dataset}'입니다.`,
+      );
+    }
+  });
+  return problems;
+}
+
+function parseGeneratedSpec(spec: string) {
+  try {
+    return generatedBuildSpecSchema.safeParse(parse(spec, { maxAliasCount: 10 }));
+  } catch (error) {
+    return {
+      success: false as const,
+      error: new z.ZodError([
+        {
+          code: "custom",
+          path: [],
+          message: error instanceof Error ? error.message : "YAML을 파싱하지 못했습니다.",
+        },
+      ]),
+    };
+  }
+}
+
+function extractYaml(rawOutput: string): string {
+  const fenced = rawOutput.match(/```(?:yaml|yml)\s*\n([\s\S]*?)\n```/i);
+  return (fenced?.[1] ?? rawOutput).trim();
+}
+
 export async function generateBuildSpec(
   provider: AssistProvider,
   userPrompt: string,
-  options: {
-    catalogContext?: string;
-    validateFn?: (spec: string) => Promise<{ valid: boolean; problems?: string[] }>;
-    signal?: AbortSignal;
-  } = {},
+  options: GenerationOptions,
 ): Promise<GenerationResult> {
   if (!isRealBuilderEnabled()) {
     return {
@@ -36,9 +99,33 @@ export async function generateBuildSpec(
     };
   }
 
+  if (!options?.validateFn) {
+    return {
+      spec: null,
+      status: "error",
+      attempts: 0,
+      remaining_problems: ["Builder /validate 연결이 없어 BuildSpec 생성을 중단했습니다."],
+    };
+  }
+
+  const availableCatalog = options.catalog.providers
+    .filter((provider) => provider.datasets.length > 0);
+  if (availableCatalog.length === 0) {
+    return {
+      spec: null,
+      status: "error",
+      attempts: 0,
+      remaining_problems: ["카탈로그를 조회할 수 없어 BuildSpec 생성을 중단했습니다."],
+    };
+  }
+
+  const catalogContext = availableCatalog
+    .map((provider) => `${provider.name}: ${provider.datasets.map((dataset) => dataset.name).join(", ")}`)
+    .join("\n");
+
   const systemPrompt = `당신은 한국 공공데이터 BuildSpec 생성기입니다.
 사용자의 자연어 요청을 BuildSpec YAML로 변환하세요.
-${options.catalogContext ? `사용 가능한 provider/dataset:\n${options.catalogContext}\n` : ""}
+사용 가능한 provider/dataset:\n${catalogContext}\n
 목록 밖의 provider/dataset은 사용하지 마세요.
 YAML만 출력하세요. 설명은 출력하지 마세요.`;
 
@@ -67,43 +154,71 @@ YAML만 출력하세요. 설명은 출력하지 마세요.`;
       rawOutput += chunk;
     }
 
-    // ① zod 파싱은 Builder /validate에 위임 — 여기서는 YAML 추출만
-    const yamlMatch = rawOutput.match(/```yaml\n([\s\S]*?)\n```/) ?? rawOutput.match(/^([\s\S]*yaml)/m);
-    const spec = yamlMatch ? yamlMatch[1].trim() : rawOutput.trim();
+    // ① YAML parse + 최소 BuildSpec source 구조 검증
+    const spec = extractYaml(rawOutput);
 
     if (!spec) {
       lastProblems = ["빈 출력이 반환되었습니다."];
       continue;
     }
 
-    // ③ Builder 검증
-    if (options.validateFn) {
-      const result = await options.validateFn(spec);
-      if (result.valid) {
-        try {
-          return {
-            spec: exchange.restoreText(spec),
-            status: "ok",
-            attempts,
-            remaining_problems: [],
-          };
-        } catch (error) {
-          return {
-            spec: null,
-            status: "error",
-            attempts,
-            remaining_problems: [
-              error instanceof Error ? error.message : "시크릿 복원에 실패했습니다.",
-            ],
-          };
-        }
-      }
-      lastProblems = result.problems ?? ["검증 실패"];
+    const parsed = parseGeneratedSpec(spec);
+    if (!parsed.success) {
+      lastProblems = parsed.error.issues.map((issue) =>
+        `${issue.path.join(".") || "spec"}: ${issue.message}`
+      );
       continue;
     }
 
-    // validateFn 없으면 그대로 반환 (게이트 우회 — 테스트용)
-    return { spec, status: "ok", attempts, remaining_problems: [] };
+    // ② typed /catalog 대조
+    const groundingProblems = catalogProblems(parsed.data, options.catalog);
+    if (groundingProblems.length > 0) {
+      lastProblems = groundingProblems;
+      continue;
+    }
+
+    let restoredSpec: string;
+    try {
+      restoredSpec = exchange.restoreText(spec);
+    } catch (error) {
+      return {
+        spec: null,
+        status: "error",
+        attempts,
+        remaining_problems: [
+          error instanceof Error ? error.message : "시크릿 복원에 실패했습니다.",
+        ],
+      };
+    }
+
+    // ③ Builder 검증
+    let validation: ValidateResponse;
+    try {
+      validation = await options.validateFn(restoredSpec, options.signal);
+    } catch (error) {
+      if (options.signal?.aborted) throw error;
+      return {
+        spec: null,
+        status: "error",
+        attempts,
+        remaining_problems: [
+          error instanceof Error ? error.message : "Builder 검증 요청에 실패했습니다.",
+        ],
+      };
+    }
+    if (validation.status === "valid") {
+      return { spec: restoredSpec, status: "ok", attempts, remaining_problems: [] };
+    }
+    if (validation.status === "invalid") {
+      lastProblems = validation.problems.length > 0 ? validation.problems : ["검증 실패"];
+      continue;
+    }
+    return {
+      spec: null,
+      status: "error",
+      attempts,
+      remaining_problems: [validation.error],
+    };
   }
 
   return {

--- a/src/features/assistant/provider.test.ts
+++ b/src/features/assistant/provider.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createProvider } from "./provider";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("assistant safe egress (#273)", () => {
+  it("최종 HTTP body에서 text와 structured content의 시크릿을 제거한다", async () => {
+    const textSecret = "xJ7kL9mN2pQ4rT6vW8yB3cD5eF7gH9j";
+    const structuredSecret = "low-entropy-key";
+    let requestBody = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        requestBody = String(init?.body);
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n',
+          { status: 200 },
+        );
+      }),
+    );
+
+    const provider = createProvider({
+      apiKey: "byok-key",
+      model: "test-model",
+      baseUrl: "https://llm.example.com/v1",
+    });
+    const chunks: string[] = [];
+    for await (const chunk of provider.stream([
+      { role: "user", content: `분석 ${textSecret}` },
+      {
+        role: "system",
+        content: "현재 스펙",
+        structuredContent: { sources: [{ params: { serviceKey: structuredSecret } }] },
+      },
+    ])) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.join("")).toBe("ok");
+    expect(requestBody).not.toContain(textSecret);
+    expect(requestBody).not.toContain(structuredSecret);
+    expect(requestBody).toContain("__SCRUBBED_");
+  });
+
+  it("일반 chat 응답에는 시크릿이나 플레이스홀더를 노출하지 않는다", async () => {
+    const secret = "low-entropy-key";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          'data: {"choices":[{"delta":{"content":"__SCRUB"}}]}\n\n' +
+            'data: {"choices":[{"delta":{"content":"BED_fake_0__"}}]}\n\n',
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const provider = createProvider({
+      apiKey: "byok-key",
+      model: "test-model",
+      baseUrl: "https://llm.example.com/v1",
+    });
+    let output = "";
+    for await (const chunk of provider.stream([
+      { role: "user", content: "분석", structuredContent: { serviceKey: secret } },
+    ])) {
+      output += chunk;
+    }
+
+    expect(output).toBe("[REDACTED]");
+    expect(output).not.toContain(secret);
+  });
+});

--- a/src/features/assistant/provider.ts
+++ b/src/features/assistant/provider.ts
@@ -6,13 +6,26 @@
  *
  * **공용 키를 VITE_*로 주입하는 것은 절대 금지** — 번들에 평문으로 박힌다.
  */
+import { createSecretScrubber, type SecretScrubber } from "./scrub";
 
 export interface AssistMessage {
   role: "system" | "user" | "assistant";
   content: string;
+  structuredContent?: unknown;
 }
 
+export interface AssistExchange {
+  readonly output: AsyncIterable<string>;
+  readonly displayOutput: AsyncIterable<string>;
+  readonly hadSecrets: boolean;
+  restoreText(text: string): string;
+}
+
+const SAFE_PROVIDER: unique symbol = Symbol("safe-assist-provider");
+
 export interface AssistProvider {
+  readonly [SAFE_PROVIDER]: true;
+  exchange(messages: AssistMessage[], signal?: AbortSignal): AssistExchange;
   stream(messages: AssistMessage[], signal?: AbortSignal): AsyncIterable<string>;
   readonly isConfigured: boolean;
 }
@@ -26,7 +39,12 @@ export interface AssistConfig {
 const DEFAULT_MODEL = "gpt-4o-mini";
 const DEFAULT_BASE_URL = "https://api.openai.com/v1";
 
-export class ByokProvider implements AssistProvider {
+interface AssistTransport {
+  stream(messages: AssistMessage[], signal?: AbortSignal): AsyncIterable<string>;
+  readonly isConfigured: boolean;
+}
+
+class ByokTransport implements AssistTransport {
   constructor(private config: AssistConfig) {}
 
   get isConfigured(): boolean {
@@ -82,10 +100,82 @@ export class ByokProvider implements AssistProvider {
   }
 }
 
-export function createProvider(config: AssistConfig): AssistProvider {
-  return new ByokProvider({
-    ...config,
-    model: config.model || DEFAULT_MODEL,
-    baseUrl: config.baseUrl || DEFAULT_BASE_URL,
+function prepareMessages(messages: AssistMessage[], scrubber: SecretScrubber): AssistMessage[] {
+  return messages.map(({ role, content, structuredContent }) => {
+    const safeText = scrubber.scrubText(content);
+    if (structuredContent === undefined) return { role, content: safeText };
+    const safeStructured = scrubber.scrub(structuredContent);
+    return { role, content: `${safeText}\n${JSON.stringify(safeStructured, null, 2)}` };
   });
+}
+
+const PLACEHOLDER_PREFIX = "__SCRUBBED_";
+const COMPLETE_PLACEHOLDER = /^__SCRUBBED_[A-Za-z0-9-]+_\d+__/;
+
+async function* redactDisplayOutput(output: AsyncIterable<string>): AsyncIterable<string> {
+  let pending = "";
+  for await (const chunk of output) {
+    pending += chunk;
+    while (pending) {
+      const marker = pending.indexOf(PLACEHOLDER_PREFIX);
+      if (marker < 0) {
+        const safeLength = Math.max(0, pending.length - (PLACEHOLDER_PREFIX.length - 1));
+        if (safeLength > 0) {
+          yield pending.slice(0, safeLength);
+          pending = pending.slice(safeLength);
+        }
+        break;
+      }
+      if (marker > 0) {
+        yield pending.slice(0, marker);
+        pending = pending.slice(marker);
+      }
+      const placeholder = pending.match(COMPLETE_PLACEHOLDER)?.[0];
+      if (!placeholder) break;
+      yield "[REDACTED]";
+      pending = pending.slice(placeholder.length);
+    }
+  }
+
+  if (pending.startsWith(PLACEHOLDER_PREFIX)) {
+    yield pending.replace(/^__SCRUBBED_\S*/, "[REDACTED]");
+  } else if (pending) {
+    yield pending;
+  }
+}
+
+class SafeAssistProvider implements AssistProvider {
+  readonly [SAFE_PROVIDER] = true;
+
+  constructor(private transport: AssistTransport) {}
+
+  get isConfigured(): boolean {
+    return this.transport.isConfigured;
+  }
+
+  exchange(messages: AssistMessage[], signal?: AbortSignal): AssistExchange {
+    const scrubber = createSecretScrubber();
+    const safeMessages = prepareMessages(messages, scrubber);
+    const output = this.transport.stream(safeMessages, signal);
+    return {
+      output,
+      displayOutput: redactDisplayOutput(output),
+      hadSecrets: scrubber.placeholders.size > 0,
+      restoreText: (text) => scrubber.restoreText(text),
+    };
+  }
+
+  async *stream(messages: AssistMessage[], signal?: AbortSignal): AsyncIterable<string> {
+    yield* this.exchange(messages, signal).displayOutput;
+  }
+}
+
+export function createProvider(config: AssistConfig): AssistProvider {
+  return new SafeAssistProvider(
+    new ByokTransport({
+      ...config,
+      model: config.model || DEFAULT_MODEL,
+      baseUrl: config.baseUrl || DEFAULT_BASE_URL,
+    }),
+  );
 }

--- a/src/features/assistant/scrub.test.ts
+++ b/src/features/assistant/scrub.test.ts
@@ -8,7 +8,13 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { looksLikeSecret, restoreSecrets, scrubSecrets } from "./scrub";
+import {
+  createSecretScrubber,
+  hasSecretPlaceholder,
+  looksLikeSecret,
+  restoreSecrets,
+  scrubSecrets,
+} from "./scrub";
 
 const SAMPLE_SERVICE_KEY =
   "9dF8kQ2mZ7xV3nL1pR4wY6tB0hJ5sC8gU2iE7oA9bN3cM6dP4qK1rS8tU0vW3xY5z";
@@ -67,6 +73,31 @@ describe("restoreSecrets — 배열 왕복 회귀 (#226 결함 c)", () => {
     const { scrubbed, placeholders } = scrubSecrets(original);
     const restored = restoreSecrets(scrubbed, placeholders);
     expect(restored).toEqual(original);
+  });
+
+  it("다른 요청이 만든 플레이스홀더를 복원하지 않는다", () => {
+    const requestA = createSecretScrubber("request-a");
+    const requestB = createSecretScrubber("request-b");
+    const scrubbed = requestA.scrub({ serviceKey: "test-key" }) as {
+      serviceKey: string;
+    };
+
+    expect(() => requestB.restore(scrubbed)).toThrow("알 수 없는 시크릿");
+  });
+
+  it("문자열 응답의 알려진 플레이스홀더만 복원한다", () => {
+    const scrubber = createSecretScrubber("request-a");
+    const scrubbed = scrubber.scrub({ serviceKey: "test-key" }) as {
+      serviceKey: string;
+    };
+
+    expect(scrubber.restoreText(`serviceKey: ${scrubbed.serviceKey}`)).toBe(
+      "serviceKey: test-key",
+    );
+    expect(() => scrubber.restoreText("__SCRUBBED_request-b_0__")).toThrow(
+      "알 수 없는 시크릿",
+    );
+    expect(hasSecretPlaceholder(scrubbed)).toBe(true);
   });
 });
 

--- a/src/features/assistant/scrub.ts
+++ b/src/features/assistant/scrub.ts
@@ -48,21 +48,39 @@ export function looksLikeSecret(value: string): boolean {
 }
 
 const SCRUBBED_PREFIX = "__SCRUBBED_";
+const SCRUBBED_PATTERN = /__SCRUBBED_[A-Za-z0-9-]+_\d+__/g;
+const SCRUBBED_TEST_PATTERN = /__SCRUBBED_[A-Za-z0-9-]+_\d+__/;
 
 export interface ScrubResult {
   scrubbed: unknown;
   placeholders: Map<string, string>;
 }
 
-export function scrubSecrets(data: unknown): ScrubResult {
+export interface SecretScrubber {
+  scrub(data: unknown): unknown;
+  scrubText(text: string): string;
+  restore(data: unknown): unknown;
+  restoreText(text: string): string;
+  readonly placeholders: ReadonlyMap<string, string>;
+}
+
+function requestId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+}
+
+export function createSecretScrubber(id = requestId()): SecretScrubber {
   const placeholders = new Map<string, string>();
   let counter = 0;
 
+  function replace(value: string): string {
+    const placeholder = `${SCRUBBED_PREFIX}${id}_${counter++}__`;
+    placeholders.set(placeholder, value);
+    return placeholder;
+  }
+
   function scrubValue(key: string, value: unknown): unknown {
     if (typeof value === "string" && (isSecretKey(key) || looksLikeSecret(value))) {
-      const placeholder = `${SCRUBBED_PREFIX}${counter++}__`;
-      placeholders.set(placeholder, value);
-      return placeholder;
+      return replace(value);
     }
     // 배열도 순회한다 (#226 결함 a). BuildSpec.sources 가 배열이라
     // !Array.isArray(value) 분기가 재귀를 끊어 sources[].params.serviceKey 에
@@ -81,13 +99,56 @@ export function scrubSecrets(data: unknown): ScrubResult {
     return value;
   }
 
-  const scrubbed = scrubValue("root", data);
-  return { scrubbed, placeholders };
+  function scrubText(text: string): string {
+    const assignmentPattern = /\b([\w-]*(?:servicekey|api[_-]?key|token|secret))([ \t]*[:=][ \t]*)([^\s,}\]]+)/gi;
+    const assigned = text.replace(assignmentPattern, (_match, key: string, separator: string, value: string) => {
+      const quote = value.startsWith("\"") || value.startsWith("'") ? value[0] : "";
+      const raw = quote ? value.slice(1, value.endsWith(quote) ? -1 : undefined) : value;
+      return `${key}${separator}${quote}${replace(raw)}${quote}`;
+    });
+
+    return assigned.replace(/\S{24,}/g, (token) => {
+      if (token.startsWith(SCRUBBED_PREFIX) || !looksLikeSecret(token)) return token;
+      return replace(token);
+    });
+  }
+
+  function restore(data: unknown): unknown {
+    if (typeof data === "string" && data.startsWith(SCRUBBED_PREFIX)) {
+      const value = placeholders.get(data);
+      if (value === undefined) throw new Error("알 수 없는 시크릿 플레이스홀더가 포함되어 있습니다.");
+      return value;
+    }
+    if (Array.isArray(data)) return data.map(restore);
+    if (data && typeof data === "object") {
+      return Object.fromEntries(
+        Object.entries(data as Record<string, unknown>).map(([key, value]) => [key, restore(value)]),
+      );
+    }
+    return data;
+  }
+
+  function restoreText(text: string): string {
+    return text.replace(SCRUBBED_PATTERN, (placeholder) => {
+      const value = placeholders.get(placeholder);
+      if (value === undefined) throw new Error("알 수 없는 시크릿 플레이스홀더가 포함되어 있습니다.");
+      return value;
+    });
+  }
+
+  return { scrub: (data) => scrubValue("root", data), scrubText, restore, restoreText, placeholders };
+}
+
+export function scrubSecrets(data: unknown): ScrubResult {
+  const scrubber = createSecretScrubber();
+  return { scrubbed: scrubber.scrub(data), placeholders: new Map(scrubber.placeholders) };
 }
 
 export function restoreSecrets(data: unknown, placeholders: Map<string, string>): unknown {
   if (typeof data === "string" && data.startsWith(SCRUBBED_PREFIX)) {
-    return placeholders.get(data) ?? data;
+    const value = placeholders.get(data);
+    if (value === undefined) throw new Error("알 수 없는 시크릿 플레이스홀더가 포함되어 있습니다.");
+    return value;
   }
   // 배열 왕복 복원 (#226 결함 c). scrub 가 배열을 순회하므로 restore 도 같이.
   if (Array.isArray(data)) {
@@ -102,4 +163,13 @@ export function restoreSecrets(data: unknown, placeholders: Map<string, string>)
     return result;
   }
   return data;
+}
+
+export function hasSecretPlaceholder(data: unknown): boolean {
+  if (typeof data === "string") return SCRUBBED_TEST_PATTERN.test(data);
+  if (Array.isArray(data)) return data.some(hasSecretPlaceholder);
+  if (data && typeof data === "object") {
+    return Object.values(data as Record<string, unknown>).some(hasSecretPlaceholder);
+  }
+  return false;
 }


### PR DESCRIPTION
## 개요

Closes #275
Closes #276

자연어 BuildSpec 생성 경로의 선언뿐이던 4중 게이트 중 typed YAML parse, catalog 대조, 필수 Builder `/validate`를 실제 fail-closed 흐름으로 구현합니다.

## 주요 변경

- `CatalogResponse`와 validator를 `GenerationOptions` 필수 dependency로 승격
- `yaml` parser를 명시적 runtime dependency로 추가
- canonical Builder YAML의 필수 필드와 `sources[].provider/dataset`을 Zod parse
- typed catalog index로 unknown provider, unknown dataset, provider/dataset mismatch 차단
- 빈 catalog에서는 LLM을 호출하지 않고 즉시 error
- 복원된 실제 BuildSpec candidate를 Builder `/validate`에 전달
- `invalid`만 bounded repair 대상으로 사용
- Builder `error`, network/auth/server failure, validator 누락은 즉시 error
- validation 요청까지 AbortSignal 전달

## 검증

- `npm test`: 55 files, 360 tests 통과
- `npm run typecheck`: 통과
- `npm run lint`: 통과
- `npm run build`: 통과

## 병합 순서

Depends on #278. 현재 stacked PR이라 #278이 병합되기 전에는 base 대비 두 커밋이 표시됩니다. #278 병합 후 이 PR의 diff는 catalog/validate gate 4개 파일로 자동 축소됩니다.

#277은 두 보안 PR(#278 및 본 PR) 병합 후 rebase하여 공통 safe provider와 typed gate를 사용해야 합니다.