### PR TITLE
feat: Evidence 기반 Reports 구현 (#258)

### DIFF
--- a/__tests__/newIaPages.test.tsx
+++ b/__tests__/newIaPages.test.tsx
@@ -22,13 +22,19 @@ describe("새 IA placeholder 화면 (#247)", () => {
     [<DiscoverPage />, "데이터 탐색"],
     [<WorkspacePage />, "작업대"],
     [<AddDataPage />, "데이터 추가"],
-    [<ReportsPage />, "리포트"],
     [<ProviderPage />, "Provider"],
     [<MonitoringPage />, "모니터링"],
   ])("renders its title and a 준비 중 안내 without crashing", (element, title) => {
     renderPage(element);
     expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
     expect(screen.getByText("아직 준비 중인 화면입니다")).toBeInTheDocument();
+  });
+
+  it("Reports is replaced with the real Builder evidence-based Report screen (#258)", () => {
+    renderPage(<ReportsPage />);
+    expect(screen.getByRole("heading", { name: "리포트" })).toBeInTheDocument();
+    expect(screen.getByText("새 Report 만들기")).toBeInTheDocument();
+    expect(screen.queryByText("아직 준비 중인 화면입니다")).not.toBeInTheDocument();
   });
 
   it("Kubi is replaced with the real context-aware Kubi screen (#256)", () => {

--- a/__tests__/reportEditorPage.test.tsx
+++ b/__tests__/reportEditorPage.test.tsx
@@ -1,22 +1,30 @@
 /**
- * ReportEditorPage IA 개편 회귀 테스트 (#258).
+ * ReportEditorPage 회귀 테스트 (#258, #258 Kubi/legacy summary/sticky sidebar 수정).
  *
  * - Builder evidence 요약 문장이 실제 evidence 값과 일치하는지(0/PASS로 꾸미지 않는지)
+ * - summary가 없는 legacy Report도 재조회한 evidence로 요약 문장을 보강해서 보여주는지,
+ *   저장된 draft/baseRunId/user·Kubi 블록은 건드리지 않는지, evidence 재조회 실패 시
+ *   기존 표시를 그대로 유지하는지
  * - 상세 evidence 표가 여전히 존재하고 펼칠 수 있는지
  * - Kubi/Builder 블록이 시각적으로 구분되는지
- * - Report Context sidebar가 실제 값만 보여주는지
- * - STALE이어도 baseRunId가 자동으로 바뀌지 않는지, Kubi 진입 시에도 고정된 dataset/run만
- *   context로 넘어가는지(최신 run으로 자동 전환 금지)
+ * - Report Context sidebar가 실제 값만 보여주고, desktop에서 sticky로 고정되는지
+ * - STALE이어도 baseRunId가 자동으로 바뀌지 않는지
+ * - "7. Kubi 분석"이 Reports 전용 축소 UX(기본 CTA/quick action, BYOK/채팅은 펼쳐야만 노출,
+ *   global drawer 미사용, Report 고정 dataset/run, 승인 전 미저장)로 동작하는지
  * - 좁은 viewport에서 sidebar가 아래로 collapse하는 반응형 grid recipe가 그대로인지
  * - PDF/DOCX CTA가 없는지
  */
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAssistConfig } from "@/features/assistant/config";
+import { useKubiStore } from "@/features/kubi/useKubiSession";
 import { buildDeterministicSections } from "@/features/reports/deterministicSections";
+import * as reportEvidenceApi from "@/features/reports/evidence";
 import { buildEvidenceRefs, fetchReportEvidence } from "@/features/reports/evidence";
 import { createReport, getReport, saveReport } from "@/features/reports/repository";
-import type { KubiInterpretationBlock, ReportDraft } from "@/features/reports/types";
+import type { BuilderEvidenceBlock, KubiInterpretationBlock, ReportDraft } from "@/features/reports/types";
+import { listKubiReportNotes, queueKubiReportNote } from "@/features/kubi/reportInbox";
 import { ReportEditorPage } from "@/pages/ReportEditorPage";
 import { useUIStore } from "@/shared/hooks/useUIStore";
 
@@ -53,6 +61,14 @@ async function makeReport(datasetId: string, runId: string, titlePrefix = "테�
   return report;
 }
 
+/** 저장된 BUILDER_EVIDENCE 블록에서 `summary`를 지워 "summary 추가 전에 저장된 legacy draft"를 흉내낸다. */
+function stripSummary(block: ReportDraft["blocks"][number]): ReportDraft["blocks"][number] {
+  if (block.provenance !== "BUILDER_EVIDENCE") return block;
+  const clone: Partial<BuilderEvidenceBlock> = { ...block };
+  delete clone.summary;
+  return clone as BuilderEvidenceBlock;
+}
+
 function makeKubiBlock(overrides: Partial<KubiInterpretationBlock> = {}): KubiInterpretationBlock {
   const now = new Date().toISOString();
   return {
@@ -72,10 +88,13 @@ function makeKubiBlock(overrides: Partial<KubiInterpretationBlock> = {}): KubiIn
 beforeEach(() => {
   localStorage.clear();
   useUIStore.setState({ isKubiDrawerOpen: false });
+  useKubiStore.setState({ turns: [], onboarded: false, pendingSeed: null });
+  useAssistConfig.getState().clear();
 });
 
 afterEach(() => {
   localStorage.clear();
+  vi.restoreAllMocks();
 });
 
 describe("ReportEditorPage IA 개편 (#258)", () => {
@@ -147,22 +166,6 @@ describe("ReportEditorPage IA 개편 (#258)", () => {
     expect(getReport(report.id)?.baseRunId).toBe("air-2026-08-13");
   });
 
-  it("Kubi로 분석하기는 Report가 고정한 dataset/run만 context로 넘기고 최신 run으로 바꾸지 않는다", async () => {
-    const report = await makeReport("air-quality", "air-2026-08-13");
-    renderReport(report.id);
-
-    await screen.findByText(/STALE/); // 최신 run(air-2026-08-14)이 따로 있는 상태에서도
-
-    fireEvent.click(screen.getByRole("button", { name: "현재 문맥으로 Kubi 분석" }));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("location").textContent).toContain("dataset=air-quality");
-    });
-    expect(screen.getByTestId("location").textContent).toContain("run=air-2026-08-13");
-    expect(screen.getByTestId("location").textContent).not.toContain("air-2026-08-14");
-    expect(useUIStore.getState().isKubiDrawerOpen).toBe(true);
-  });
-
   it("좁은 viewport에서 sidebar가 아래로 collapse하는 반응형 grid를 그대로 유지한다", async () => {
     const report = await makeReport("air-quality", "air-2026-08-14");
     renderReport(report.id);
@@ -179,5 +182,197 @@ describe("ReportEditorPage IA 개편 (#258)", () => {
     await screen.findByText(/이 보고서는/);
     expect(screen.queryByText(/PDF/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/DOCX/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("ReportEditorPage — legacy summary 보강 (#258 legacy summary 수정)", () => {
+  it("summary 없는 legacy draft를 다시 열면 현재 evidence 기준 요약 문장이 화면에 보강되고, 저장된 draft/baseRunId/블록은 그대로 유지된다", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    const legacyBlocks = [...report.blocks.map(stripSummary), makeKubiBlock()];
+    saveReport({ ...report, blocks: legacyBlocks }, { force: true });
+
+    // 저장된 draft 자체에는 summary가 없다.
+    const overviewBefore = getReport(report.id)?.blocks.find(
+      (block): block is BuilderEvidenceBlock => block.provenance === "BUILDER_EVIDENCE" && block.section === "overview",
+    );
+    expect(overviewBefore?.summary).toBeUndefined();
+
+    renderReport(report.id);
+
+    // 화면에는 재조회한 evidence 기준 요약 문장이 보강되어 보인다.
+    await screen.findByText(/이 보고서는/);
+
+    // baseRunId는 그대로다.
+    expect(getReport(report.id)?.baseRunId).toBe("air-2026-08-14");
+    // 저장된 draft 자체는 임의로 migration하지 않는다(저장을 강제하지 않음).
+    const overviewAfter = getReport(report.id)?.blocks.find(
+      (block): block is BuilderEvidenceBlock => block.provenance === "BUILDER_EVIDENCE" && block.section === "overview",
+    );
+    expect(overviewAfter?.summary).toBeUndefined();
+    // 기존 Kubi 블록은 보존된다.
+    expect(screen.getByTestId("block-kubi")).toBeInTheDocument();
+  });
+
+  it("evidence 재조회에 실패하면 legacy draft를 그대로 유지한다(요약 문장을 지어내지 않음)", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    const legacyBlocks = report.blocks.map(stripSummary);
+    saveReport({ ...report, blocks: legacyBlocks }, { force: true });
+
+    vi.spyOn(reportEvidenceApi, "fetchReportEvidence").mockRejectedValueOnce(new Error("network down"));
+
+    renderReport(report.id);
+
+    // 상세 표(overview 블록)는 그대로 보인다.
+    await screen.findByTestId("block-overview");
+    // 요약 문장은 생성되지 않는다 — 실패했다고 0/PASS 등으로 지어내지 않는다.
+    expect(screen.queryByText(/이 보고서는/)).not.toBeInTheDocument();
+  });
+});
+
+describe("ReportEditorPage — Report Context sidebar sticky (#258 sticky sidebar 수정)", () => {
+  it("desktop(lg 이상)에서 sidebar wrapper가 sticky로 고정된다", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    const wrapper = await screen.findByTestId("report-context-sidebar-wrapper");
+    expect(wrapper.className).toContain("lg:sticky");
+    expect(wrapper.className).toMatch(/lg:top-/);
+    expect(wrapper.className).toContain("lg:self-start");
+  });
+
+  it("좁은 viewport 1단 grid 안에서도 같은 wrapper를 그대로 쓴다(sticky는 lg: prefix로만 걸려 좁은 화면에서는 해제된다)", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    const grid = await screen.findByTestId("report-layout-grid");
+    const wrapper = await screen.findByTestId("report-context-sidebar-wrapper");
+    expect(grid).toContainElement(wrapper);
+    // sticky/self-start 클래스가 lg: 없이 기본으로 걸려있지 않아야 한다(모바일에서는 해제).
+    expect(wrapper.className).not.toMatch(/(^|\s)sticky(\s|$)/);
+    expect(wrapper.className).not.toMatch(/(^|\s)self-start(\s|$)/);
+  });
+});
+
+describe("ReportEditorPage — 7. Kubi 분석 (#258 Kubi Report UX 수정)", () => {
+  it("기본 상태에서는 전체 BYOK/채팅 form을 바로 노출하지 않는다", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    await screen.findByTestId("kubi-report-panel");
+    expect(screen.queryByLabelText("API Key")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Kubi에게 질문하기")).not.toBeInTheDocument();
+    expect(screen.queryByText("데모 질문 보내보기")).not.toBeInTheDocument();
+  });
+
+  it("Primary CTA와 4개의 quick action이 존재한다(기본 mock 모드에서는 CTA가 데모 문구로 표시된다)", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    await screen.findByTestId("kubi-report-panel");
+    expect(screen.getByRole("button", { name: "데모 보고서 분석 생성" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "품질 문제 해석" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pipeline 실패 원인 분석" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "데이터 활용 아이디어" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "주의사항·한계 작성" })).toBeInTheDocument();
+  });
+
+  it("BYOK가 설정되면 Primary CTA 문구가 '보고서용 AI 분석 생성'으로 바뀐다", async () => {
+    useAssistConfig.getState().setConfig({ apiKey: "sk-test", model: "gpt-4o-mini", baseUrl: "" });
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    await screen.findByTestId("kubi-report-panel");
+    expect(screen.getByRole("button", { name: "보고서용 AI 분석 생성" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "데모 보고서 분석 생성" })).not.toBeInTheDocument();
+  });
+
+  it("mock 모드에서는 '실제 AI 분석이 아닌 mock 응답입니다.' 문구가 표시된다", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    await screen.findByTestId("kubi-report-panel");
+    expect(screen.getByText("실제 AI 분석이 아닌 mock 응답입니다.")).toBeInTheDocument();
+  });
+
+  it("AI 설정을 누르면 BYOK 설정 form이 펼쳐진다", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    await screen.findByTestId("kubi-report-panel");
+    expect(screen.queryByLabelText("API Key")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "AI 설정" }));
+    expect(screen.getByLabelText("API Key")).toBeInTheDocument();
+  });
+
+  it("직접 질문하기를 누르면 기존 KubiContent 채팅이 펼쳐지고, global Kubi drawer는 열리지 않는다", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    await screen.findByTestId("kubi-report-panel");
+    fireEvent.click(screen.getByRole("button", { name: "직접 질문하기" }));
+
+    const chat = await screen.findByTestId("kubi-report-chat");
+    expect(within(chat).getByLabelText("Kubi에게 질문하기")).toBeInTheDocument();
+    expect(useUIStore.getState().isKubiDrawerOpen).toBe(false);
+  });
+
+  it("Kubi 분석 패널은 Report가 고정한 dataset/baseRunId를 context로 유지한다(최신 run 자동 전환 금지)", async () => {
+    // air-2026-08-13은 최신이 아니다(최신은 air-2026-08-14) — STALE 상태에서도 이 값을 써야 한다.
+    const report = await makeReport("air-quality", "air-2026-08-13");
+    renderReport(report.id);
+
+    await screen.findByTestId("kubi-report-panel");
+    await waitFor(() => {
+      expect(screen.getByTestId("location").textContent).toContain("dataset=air-quality");
+    });
+    expect(screen.getByTestId("location").textContent).toContain("run=air-2026-08-13");
+    expect(screen.getByTestId("location").textContent).not.toContain("air-2026-08-14");
+  });
+
+  it("생성 → 미리보기까지는 Report에 아무것도 저장하지 않고, '보고서에 추가'를 눌러야 KUBI_INTERPRETATION 블록이 추가된다", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    await screen.findByTestId("kubi-report-panel");
+    // 질문을 보내기 전에 URL이 Report 기준 dataset/run으로 이미 고정되어 있는지 먼저 기다린다
+    // (그렇지 않으면 turn의 context가 비어 있는 채로 생성되어 미리보기가 이 Report와 매칭되지
+    // 않는다 — KubiReportPanel의 useEffect가 그 값을 채운다).
+    await waitFor(() => {
+      expect(screen.getByTestId("location").textContent).toContain("dataset=air-quality");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "데모 보고서 분석 생성" }));
+
+    const preview = await screen.findByTestId("kubi-report-preview");
+    // 승인 전에는 Report에 저장되지 않는다.
+    expect(screen.queryByTestId("block-kubi")).not.toBeInTheDocument();
+    expect(getReport(report.id)?.blocks.some((block) => block.provenance === "KUBI_INTERPRETATION")).toBe(false);
+
+    fireEvent.click(within(preview).getByRole("button", { name: "보고서에 추가" }));
+
+    const kubiBlock = await screen.findByTestId("block-kubi");
+    // note 본문(생성된 분석 답변) 자체가 그대로 반영됐는지 확인한다 — "판단 근거" 줄과는 다른 문구를 쓴다.
+    expect(within(kubiBlock).getByText(/mock 데이터 기반 예시 응답입니다/)).toBeInTheDocument();
+    expect(getReport(report.id)?.blocks.some((block) => block.provenance === "KUBI_INTERPRETATION")).toBe(true);
+  });
+
+  it("대기 중인 Kubi 노트를 승인하면 기존 동작대로 KUBI_INTERPRETATION 블록이 추가된다(ADD_REPORT_BLOCK 승인 흐름 유지)", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    queueKubiReportNote({
+      note: "가격 결측이 특정 지역에 집중됩니다.",
+      reason: "품질 이슈 참고용",
+      context: { datasetId: "air-quality", runId: "air-2026-08-14" },
+      savedAt: new Date().toISOString(),
+    });
+
+    renderReport(report.id);
+
+    const addButton = await screen.findByRole("button", { name: "이 Report에 추가" });
+    fireEvent.click(addButton);
+
+    const kubiBlock = await screen.findByTestId("block-kubi");
+    expect(within(kubiBlock).getByText(/가격 결측이 특정 지역에 집중됩니다\./)).toBeInTheDocument();
+    expect(listKubiReportNotes()).toHaveLength(0);
   });
 });

--- a/__tests__/reportEditorPage.test.tsx
+++ b/__tests__/reportEditorPage.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * ReportEditorPage IA 개편 회귀 테스트 (#258).
+ *
+ * - Builder evidence 요약 문장이 실제 evidence 값과 일치하는지(0/PASS로 꾸미지 않는지)
+ * - 상세 evidence 표가 여전히 존재하고 펼칠 수 있는지
+ * - Kubi/Builder 블록이 시각적으로 구분되는지
+ * - Report Context sidebar가 실제 값만 보여주는지
+ * - STALE이어도 baseRunId가 자동으로 바뀌지 않는지, Kubi 진입 시에도 고정된 dataset/run만
+ *   context로 넘어가는지(최신 run으로 자동 전환 금지)
+ * - 좁은 viewport에서 sidebar가 아래로 collapse하는 반응형 grid recipe가 그대로인지
+ * - PDF/DOCX CTA가 없는지
+ */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildDeterministicSections } from "@/features/reports/deterministicSections";
+import { buildEvidenceRefs, fetchReportEvidence } from "@/features/reports/evidence";
+import { createReport, getReport, saveReport } from "@/features/reports/repository";
+import type { KubiInterpretationBlock, ReportDraft } from "@/features/reports/types";
+import { ReportEditorPage } from "@/pages/ReportEditorPage";
+import { useUIStore } from "@/shared/hooks/useUIStore";
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname + location.search}</div>;
+}
+
+function renderReport(reportId: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/reports/${reportId}`]}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/reports/:reportId" element={<ReportEditorPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+async function makeReport(datasetId: string, runId: string, titlePrefix = "테스트"): Promise<ReportDraft> {
+  const evidence = await fetchReportEvidence(datasetId, runId);
+  const blocks = buildDeterministicSections(evidence);
+  const evidenceRefs = buildEvidenceRefs(evidence);
+  const { report, result } = createReport({
+    title: `${titlePrefix} · ${runId}`,
+    datasetId,
+    baseRunId: runId,
+    buildSpecDigest: evidence.run.ok ? evidence.run.value.spec_digest : null,
+    evidenceFetchedAt: evidence.fetchedAt,
+    blocks,
+    evidenceRefs,
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return report;
+}
+
+function makeKubiBlock(overrides: Partial<KubiInterpretationBlock> = {}): KubiInterpretationBlock {
+  const now = new Date().toISOString();
+  return {
+    id: "kubi-1",
+    provenance: "KUBI_INTERPRETATION",
+    note: "가격 결측이 특정 지역에 집중됩니다.",
+    reason: "품질 이슈 참고용",
+    sourceContext: { datasetId: "air-quality", runId: "air-2026-08-14" },
+    isSameContext: true,
+    generatedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useUIStore.setState({ isKubiDrawerOpen: false });
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("ReportEditorPage IA 개편 (#258)", () => {
+  it("Builder evidence 요약 문장이 실제 PASS/FAIL 수치와 동일하게 표시된다", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    await screen.findByText(/이 보고서는/);
+    expect(screen.getByText(/1건은 PASS/)).toBeInTheDocument();
+    expect(screen.getByText(/1건은 FAIL/)).toBeInTheDocument();
+    expect(screen.queryByText(/0건은 WARN/)).not.toBeInTheDocument();
+  });
+
+  it("unavailable evidence를 0/PASS로 문장화하지 않는다", async () => {
+    const report = await makeReport("population", "population-2026-08-13");
+    renderReport(report.id);
+
+    await screen.findByText(/PASS로 간주하지 않습니다/);
+    expect(screen.queryByText(/\d건은 PASS/)).not.toBeInTheDocument();
+  });
+
+  it("상세 evidence 표는 지워지지 않고 펼쳐서 볼 수 있다", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    const schemaBlock = await screen.findByTestId("block-schema");
+    // dtype(datetime)은 요약 문장이 아니라 상세 표에만 있다 — 펼치기 전에는 없어야 한다.
+    expect(within(schemaBlock).queryByText("datetime")).not.toBeInTheDocument();
+
+    fireEvent.click(within(schemaBlock).getByText("상세 근거 보기"));
+    expect(await within(schemaBlock).findByText("datetime")).toBeInTheDocument();
+  });
+
+  it("Kubi 블록과 Builder Evidence 블록이 provenance 배지로 시각적으로 구분된다", async () => {
+    let report = await makeReport("air-quality", "air-2026-08-14");
+    report = { ...report, blocks: [...report.blocks, makeKubiBlock()] };
+    saveReport(report, { force: true });
+
+    renderReport(report.id);
+
+    await screen.findByTestId("block-kubi");
+    expect(screen.getByText("Kubi 분석 · AI 작성")).toBeInTheDocument();
+    expect(screen.getAllByText("Builder Evidence").length).toBeGreaterThan(0);
+    expect(screen.getByText("AI 작성 · Kubi")).toBeInTheDocument();
+  });
+
+  it("Report Context sidebar가 실제 base dataset/run/evidence 상태를 보여준다", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    const contextHeading = await screen.findByText("Report Context");
+    const contextCard = contextHeading.parentElement as HTMLElement;
+    expect(within(contextCard).getByText("air-quality")).toBeInTheDocument();
+    expect(within(contextCard).getByText("air-2026-08-14")).toBeInTheDocument();
+    await screen.findByText(/CURRENT/);
+  });
+
+  it("STALE이어도 baseRunId를 자동으로 바꾸지 않는다(최신 run 자동 전환 금지)", async () => {
+    // air-2026-08-13은 최신이 아니다(최신은 air-2026-08-14) → STALE 판정이 나와야 한다.
+    const report = await makeReport("air-quality", "air-2026-08-13");
+    renderReport(report.id);
+
+    await screen.findByText(/STALE/);
+    expect(getReport(report.id)?.baseRunId).toBe("air-2026-08-13");
+
+    // "다시 확인"을 눌러도 마찬가지다.
+    fireEvent.click(screen.getByRole("button", { name: "다시 확인" }));
+    await waitFor(() => expect(screen.getByText(/STALE/)).toBeInTheDocument());
+    expect(getReport(report.id)?.baseRunId).toBe("air-2026-08-13");
+  });
+
+  it("Kubi로 분석하기는 Report가 고정한 dataset/run만 context로 넘기고 최신 run으로 바꾸지 않는다", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-13");
+    renderReport(report.id);
+
+    await screen.findByText(/STALE/); // 최신 run(air-2026-08-14)이 따로 있는 상태에서도
+
+    fireEvent.click(screen.getByRole("button", { name: "현재 문맥으로 Kubi 분석" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location").textContent).toContain("dataset=air-quality");
+    });
+    expect(screen.getByTestId("location").textContent).toContain("run=air-2026-08-13");
+    expect(screen.getByTestId("location").textContent).not.toContain("air-2026-08-14");
+    expect(useUIStore.getState().isKubiDrawerOpen).toBe(true);
+  });
+
+  it("좁은 viewport에서 sidebar가 아래로 collapse하는 반응형 grid를 그대로 유지한다", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    const grid = await screen.findByTestId("report-layout-grid");
+    expect(grid.className).toContain("grid-cols-1");
+    expect(grid.className).toMatch(/lg:grid-cols-\[/);
+  });
+
+  it("PDF/DOCX 다운로드 CTA를 제공하지 않는다", async () => {
+    const report = await makeReport("air-quality", "air-2026-08-14");
+    renderReport(report.id);
+
+    await screen.findByText(/이 보고서는/);
+    expect(screen.queryByText(/PDF/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/DOCX/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -24,6 +24,7 @@ import { NewBuildPage } from "@/pages/NewBuildPage";
 import { PreviewPage } from "@/pages/PreviewPage";
 import { ProviderPage } from "@/pages/ProviderPage";
 import { QualityPage } from "@/pages/QualityPage";
+import { ReportEditorPage } from "@/pages/ReportEditorPage";
 import { ReportsPage } from "@/pages/ReportsPage";
 import { SettingsPage } from "@/pages/SettingsPage";
 import { ValidatePage } from "@/pages/ValidatePage";
@@ -125,6 +126,10 @@ export const router = createBrowserRouter([
       {
         path: "reports",
         element: withFeatureBoundary("Reports", <ReportsPage />),
+      },
+      {
+        path: "reports/:reportId",
+        element: withFeatureBoundary("Report 편집", <ReportEditorPage />),
       },
       // 새 IA의 SYSTEM 그룹(#259/#264에서 실제 기능 구현).
       {

--- a/src/features/kubi/KubiContent.tsx
+++ b/src/features/kubi/KubiContent.tsx
@@ -56,7 +56,12 @@ function ContextBar({ context, pageLabel, qualityLabel }: { context: KubiContext
   );
 }
 
-function ApiKeySetup() {
+/**
+ * BYOK(API Key/Model/Base URL) 설정 폼. `KubiContent`(BYOK 미설정 시 기본 노출)와
+ * `KubiReportPanel`(#258 — "AI 설정"을 눌렀을 때만 노출)이 이 컴포넌트 하나를 공유한다.
+ * 새 BYOK storage/security semantics를 만들지 않는다 — `useAssistConfig`만 그대로 재사용한다.
+ */
+export function ApiKeySetup() {
   const { apiKey, model, baseUrl, isDefaultBaseUrl, baseUrlSafe, baseUrlError, persistToStorage, setConfig, enablePersistence, disablePersistence } =
     useAssistConfig();
   const [draftKey, setDraftKey] = useState(apiKey);

--- a/src/features/kubi/reportInbox.test.ts
+++ b/src/features/kubi/reportInbox.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { listKubiReportNotes, queueKubiReportNote, removeKubiReportNote, type KubiReportNote } from "./reportInbox";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+function makeNote(overrides: Partial<KubiReportNote> = {}): KubiReportNote {
+  return {
+    note: "note",
+    reason: "reason",
+    context: { datasetId: "air-quality", runId: "air-2026-08-14" },
+    savedAt: "2026-08-14T09:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("removeKubiReportNote (#258)", () => {
+  it("큐에서 값이 일치하는 노트 하나만 제거한다", () => {
+    const a = makeNote({ note: "a", savedAt: "2026-08-14T09:00:00Z" });
+    const b = makeNote({ note: "b", savedAt: "2026-08-14T09:01:00Z" });
+    queueKubiReportNote(a);
+    queueKubiReportNote(b);
+
+    removeKubiReportNote(a);
+
+    const remaining = listKubiReportNotes();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].note).toBe("b");
+  });
+
+  it("이미 없는 노트를 제거하려 해도 조용히 무시한다", () => {
+    queueKubiReportNote(makeNote({ note: "only" }));
+    removeKubiReportNote(makeNote({ note: "not-in-queue", savedAt: "2026-08-14T10:00:00Z" }));
+    expect(listKubiReportNotes()).toHaveLength(1);
+  });
+});

--- a/src/features/kubi/reportInbox.ts
+++ b/src/features/kubi/reportInbox.ts
@@ -60,3 +60,24 @@ export function queueKubiReportNote(note: KubiReportNote): void {
 export function listKubiReportNotes(): KubiReportNote[] {
   return readEnvelope().notes;
 }
+
+/**
+ * 큐에서 노트 하나를 제거한다 (#258 — Reports 편집기가 노트를 Report에 KUBI_INTERPRETATION
+ * 블록으로 승인·반영한 뒤 호출한다). index가 아니라 값 자체로 찾는다 — 승인 사이에 다른 탭이
+ * 큐에 새 노트를 추가해 index가 밀렸을 가능성을 피하기 위함이다. 이미 없어졌으면(다른 탭이
+ * 먼저 소비) 조용히 무시한다.
+ */
+export function removeKubiReportNote(note: KubiReportNote): void {
+  try {
+    const envelope = readEnvelope();
+    const index = envelope.notes.findIndex(
+      (candidate) =>
+        candidate.savedAt === note.savedAt && candidate.note === note.note && candidate.reason === note.reason,
+    );
+    if (index === -1) return;
+    envelope.notes.splice(index, 1);
+    localStorage.setItem(INBOX_KEY, JSON.stringify(envelope));
+  } catch {
+    // localStorage 사용 불가 시 무시.
+  }
+}

--- a/src/features/reports/components/BlockView.tsx
+++ b/src/features/reports/components/BlockView.tsx
@@ -1,0 +1,176 @@
+/**
+ * 단일 Report 블록을 provenance에 맞게 읽기 전용으로 렌더링한다 (#258 §10, IA 개편).
+ *
+ * BUILDER_EVIDENCE 블록은 항상 read-only다(사용자가 실제 값을 몰래 바꿔치기할 수 없게 —
+ * #258 §3, §10). 수정하고 싶으면 evidence를 새로고침해 재생성하거나, 별도 USER_CONTENT
+ * 블록으로 자기 설명을 덧붙인다.
+ *
+ * IA 개편(표만 나열하는 조회 화면 금지): `summary`(deterministic 문장 요약)를 먼저 보여주고,
+ * 기존 `markdown`(표/상세 근거)는 `<details>`로 접어 필요할 때만 펼친다. 표 자체는 지우지
+ * 않는다 — 위치만 옮긴다.
+ */
+import { useState } from "react";
+import { Card } from "@/shared/ui";
+import { renderMarkdownToReact } from "../markdown";
+import type { BuilderEvidenceBlock, BuilderEvidenceSection, ReportBlock, ReportEvidenceRef } from "../types";
+import { ProvenanceBadge } from "./ProvenanceBadge";
+
+const EVIDENCE_STATUS_LABEL: Record<string, string> = {
+  ok: "",
+  partial: "일부만 확인됨",
+  unavailable: "확인할 수 없음",
+};
+
+const SECTION_LABEL: Record<BuilderEvidenceSection, string> = {
+  overview: "1. 데이터 개요",
+  pipeline: "2. 처리 흐름",
+  quality: "3. 품질 진단",
+  schema: "4. 데이터 구조",
+  data_summary: "5. 데이터 규모",
+  output: "6. Output",
+};
+
+/**
+ * NewBuildPage(#97)의 `<details className="group">` disclosure 패턴을 재사용하되, 열림 상태를
+ * React state로 직접 제어한다 — 브라우저 기본 toggle 동작에만 기대면 테스트 환경/스크린리더
+ * 조합에 따라 동작이 갈릴 수 있어, `summary` 클릭에서 기본 동작을 막고 state로만 연다/닫는다.
+ */
+function BuilderEvidenceBlockCard({ block }: { block: BuilderEvidenceBlock }) {
+  const [detailOpen, setDetailOpen] = useState(false);
+
+  // Output이 확인 불가할 때는 summary가 이미 사유를 전부 담고 있어, 표를 펼쳐도 같은 문장을
+  // 반복할 뿐이다 — 이때만 상세 근거 disclosure를 만들지 않는다(#258 IA 개편 §4).
+  const hasDetail = !(block.section === "output" && block.evidenceStatus === "unavailable");
+  // summary가 이미 evidenceStatus 사유를 문장으로 담고 있는 섹션이 많아, output에서는 배지성
+  // 경고 문구를 중복 표시하지 않는다.
+  const showStatusBanner = block.evidenceStatus !== "ok" && block.section !== "output";
+
+  return (
+    <Card className="space-y-3" data-testid={`block-${block.section}`}>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold">{SECTION_LABEL[block.section]}</h3>
+        <ProvenanceBadge provenance="BUILDER_EVIDENCE" />
+      </div>
+      {showStatusBanner ? (
+        <p className="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-950/30 dark:text-amber-300">
+          {EVIDENCE_STATUS_LABEL[block.evidenceStatus]}
+          {block.unavailableReason ? `: ${block.unavailableReason}` : ""}
+        </p>
+      ) : null}
+      <div className="space-y-2 text-sm leading-relaxed text-foreground">
+        {block.summary ? renderMarkdownToReact(block.summary) : renderMarkdownToReact(block.markdown)}
+      </div>
+      {block.summary && hasDetail ? (
+        <details className="group border-t border-border pt-2" open={detailOpen}>
+          <summary
+            className="flex cursor-pointer list-none items-center gap-1 text-xs font-semibold text-muted-foreground hover:text-foreground"
+            onClick={(event) => {
+              event.preventDefault();
+              setDetailOpen((prev) => !prev);
+            }}
+          >
+            상세 근거 보기
+            <span className="text-sm transition group-open:rotate-180" aria-hidden="true">
+              ⌄
+            </span>
+          </summary>
+          {detailOpen ? (
+            <div className="mt-3 space-y-2 text-sm text-foreground">{renderMarkdownToReact(block.markdown)}</div>
+          ) : null}
+        </details>
+      ) : null}
+    </Card>
+  );
+}
+
+export function BlockView({
+  block,
+  reportEvidenceRefs,
+  onEditUserContent,
+  onDeleteUserContent,
+  onRemoveKubiBlock,
+}: {
+  block: ReportBlock;
+  /** KUBI_INTERPRETATION 블록이 현재 Report와 같은 dataset/run 기준일 때만 넘긴다(#258 §7). */
+  reportEvidenceRefs?: ReportEvidenceRef[];
+  onEditUserContent?: (id: string) => void;
+  onDeleteUserContent?: (id: string) => void;
+  onRemoveKubiBlock?: (id: string) => void;
+}) {
+  if (block.provenance === "BUILDER_EVIDENCE") {
+    return <BuilderEvidenceBlockCard block={block} />;
+  }
+
+  if (block.provenance === "KUBI_INTERPRETATION") {
+    return (
+      <Card className="space-y-2 border-indigo-200 dark:border-indigo-900/60" data-testid="block-kubi">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="text-sm font-semibold">Kubi 분석 · AI 작성</h3>
+          <div className="flex items-center gap-2">
+            <ProvenanceBadge provenance="KUBI_INTERPRETATION" />
+            {onRemoveKubiBlock ? (
+              <button
+                type="button"
+                onClick={() => onRemoveKubiBlock(block.id)}
+                className="text-xs text-muted-foreground underline hover:text-foreground"
+              >
+                제거
+              </button>
+            ) : null}
+          </div>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          기준 Dataset: {block.sourceContext.datasetId ?? "N/A"} · 기준 Run: {block.sourceContext.runId ?? "N/A"}
+          {block.sourceContext.stage ? ` · Stage: ${block.sourceContext.stage}` : ""}
+        </p>
+        {!block.isSameContext ? (
+          <p className="rounded-lg bg-indigo-50 px-3 py-2 text-xs text-indigo-800 dark:bg-indigo-950/30 dark:text-indigo-300">
+            참고 분석 · 현재 Report의 기준 dataset/run과 다릅니다(자동으로 합치지 않음).
+          </p>
+        ) : null}
+        <p className="text-xs text-muted-foreground">
+          생성 시각 {new Date(block.generatedAt).toLocaleString("ko-KR")}
+          {block.provider ? ` · provider ${block.provider}` : ""}
+          {block.model ? ` · model ${block.model}` : ""}
+        </p>
+        <div className="space-y-2 text-sm text-foreground">{renderMarkdownToReact(block.note)}</div>
+        <p className="text-xs italic text-muted-foreground">판단 근거: {block.reason}</p>
+        {block.isSameContext && reportEvidenceRefs && reportEvidenceRefs.length > 0 ? (
+          <p className="text-xs text-muted-foreground">
+            연결된 Evidence: {reportEvidenceRefs.map((ref) => ref.label).join(", ")}
+          </p>
+        ) : null}
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="space-y-2 border-amber-200 dark:border-amber-900/60" data-testid="block-user">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold">{block.heading}</h3>
+        <div className="flex items-center gap-2">
+          <ProvenanceBadge provenance="USER_CONTENT" />
+          {onEditUserContent ? (
+            <button
+              type="button"
+              onClick={() => onEditUserContent(block.id)}
+              className="text-xs text-muted-foreground underline hover:text-foreground"
+            >
+              편집
+            </button>
+          ) : null}
+          {onDeleteUserContent ? (
+            <button
+              type="button"
+              onClick={() => onDeleteUserContent(block.id)}
+              className="text-xs text-muted-foreground underline hover:text-foreground"
+            >
+              삭제
+            </button>
+          ) : null}
+        </div>
+      </div>
+      <div className="space-y-2 text-sm text-foreground">{renderMarkdownToReact(block.markdown)}</div>
+    </Card>
+  );
+}

--- a/src/features/reports/components/EvidenceStatusBanner.tsx
+++ b/src/features/reports/components/EvidenceStatusBanner.tsx
@@ -1,0 +1,70 @@
+/**
+ * 저장된 Report의 기준 evidence 상태(CURRENT/STALE/ORPHAN/UNAVAILABLE)를 알린다 (#258 §8).
+ *
+ * 어떤 상태여도 저장된 Report 내용을 지우거나 자동으로 최신 run으로 바꾸지 않는다 —
+ * 이 배너는 상태를 알리고, STALE일 때만 "새 Report 만들기" 진입점을 보여준다.
+ */
+import { Card } from "@/shared/ui";
+import type { EvidenceStalenessResult } from "../staleness";
+
+const COPY: Record<EvidenceStalenessResult["status"], { title: string; tone: "default" | "warn" | "error" }> = {
+  current: { title: "CURRENT — 기준 run이 최신 상태입니다.", tone: "default" },
+  stale: { title: "STALE — 기준 run은 유효하지만 더 새로운 Run이 있습니다.", tone: "warn" },
+  orphan: { title: "ORPHAN — 기준 run을 더 이상 찾을 수 없습니다(삭제되었거나 접근 불가).", tone: "error" },
+  unavailable: { title: "UNAVAILABLE — evidence를 다시 확인하지 못했습니다.", tone: "warn" },
+};
+
+const TONE_CLASS: Record<"default" | "warn" | "error", string> = {
+  default: "border-border bg-card",
+  warn: "border-amber-300 bg-amber-50 dark:border-amber-900/60 dark:bg-amber-950/30",
+  error: "border-red-300 bg-red-50 dark:border-red-900/60 dark:bg-red-950/30",
+};
+
+export function EvidenceStatusBanner({
+  result,
+  loading,
+  onRecheck,
+  onCreateFromLatest,
+}: {
+  result: EvidenceStalenessResult | null;
+  loading: boolean;
+  onRecheck: () => void;
+  onCreateFromLatest?: () => void;
+}) {
+  if (loading) {
+    return (
+      <Card className="flex items-center justify-between gap-3 py-3 text-sm text-muted-foreground">
+        <span>기준 evidence를 다시 확인하는 중…</span>
+      </Card>
+    );
+  }
+  if (!result) return null;
+
+  const copy = COPY[result.status];
+  return (
+    <Card className={`flex flex-wrap items-center justify-between gap-3 border py-3 text-sm ${TONE_CLASS[copy.tone]}`}>
+      <div>
+        <p className="font-medium">{copy.title}</p>
+        {result.reason ? <p className="mt-0.5 text-xs text-muted-foreground">{result.reason}</p> : null}
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onRecheck}
+          className="rounded-lg border border-border px-3 py-1.5 text-xs font-medium hover:bg-muted"
+        >
+          다시 확인
+        </button>
+        {result.status === "stale" && onCreateFromLatest ? (
+          <button
+            type="button"
+            onClick={onCreateFromLatest}
+            className="rounded-lg border border-border px-3 py-1.5 text-xs font-medium hover:bg-muted"
+          >
+            최신 Run으로 새 Report 만들기
+          </button>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/src/features/reports/components/KubiInboxPanel.tsx
+++ b/src/features/reports/components/KubiInboxPanel.tsx
@@ -1,0 +1,94 @@
+/**
+ * Kubi 참고 노트 큐 → Report 반영 승인 패널 (#258 §7).
+ *
+ * `features/kubi/reportInbox.ts`(#256)에 쌓인, 사용자가 Kubi 채팅에서 이미 한 번
+ * 승인한 노트를 보여준다. 여기서 다시 한번: note 원문 → 연결 evidence(문맥) →
+ * 현재 Report의 기준 dataset/run과 같은지 → 사용자 승인 순서를 거친 뒤에만 Report에
+ * KUBI_INTERPRETATION 블록으로 추가한다. 자동으로 추가되지 않는다.
+ */
+import { useEffect, useState } from "react";
+import { listKubiReportNotes, removeKubiReportNote, type KubiReportNote } from "@/features/kubi/reportInbox";
+import { Card, EmptyState } from "@/shared/ui";
+import { noteMatchesReportContext, reportNoteToBlock } from "../kubiBlocks";
+import type { KubiInterpretationBlock, ReportDraft } from "../types";
+
+export function KubiInboxPanel({
+  report,
+  onApprove,
+  onNotesChanged,
+}: {
+  report: Pick<ReportDraft, "datasetId" | "baseRunId">;
+  onApprove: (block: KubiInterpretationBlock) => void;
+  /** 승인/무시로 큐가 바뀔 때마다 호출된다(Report Context sidebar의 대기 노트 수 갱신용). */
+  onNotesChanged?: () => void;
+}) {
+  const [notes, setNotes] = useState<KubiReportNote[]>([]);
+
+  useEffect(() => {
+    setNotes(listKubiReportNotes());
+  }, []);
+
+  function approve(note: KubiReportNote) {
+    onApprove(reportNoteToBlock(note, report));
+    removeKubiReportNote(note);
+    setNotes(listKubiReportNotes());
+    onNotesChanged?.();
+  }
+
+  function discard(note: KubiReportNote) {
+    removeKubiReportNote(note);
+    setNotes(listKubiReportNotes());
+    onNotesChanged?.();
+  }
+
+  return (
+    <Card>
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">대기 중인 Kubi 노트</p>
+      {notes.length === 0 ? (
+        <EmptyState
+          className="py-6"
+          title="대기 중인 Kubi 노트가 없습니다"
+          description="Kubi 대화에서 '보고서에 추가' action을 승인하면 여기에 쌓입니다."
+        />
+      ) : (
+        <ul className="mt-3 flex flex-col gap-3">
+          {notes.map((note, index) => {
+            const sameContext = noteMatchesReportContext(note, report);
+            return (
+              <li key={`${note.savedAt}-${index}`} className="rounded-lg border border-border p-3 text-sm">
+                <p className="text-foreground">{note.note}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {[note.context.datasetId, note.context.runId, note.context.stage].filter(Boolean).join(" · ") ||
+                    "문맥 없음"}
+                  {" · "}
+                  {new Date(note.savedAt).toLocaleString("ko-KR")}
+                </p>
+                <p
+                  className={`mt-1 text-xs font-medium ${sameContext ? "text-emerald-700 dark:text-emerald-400" : "text-amber-700 dark:text-amber-400"}`}
+                >
+                  {sameContext ? "현재 Report와 같은 dataset/run 기준" : "현재 Report와 다른 dataset/run 기준 · 참고 분석으로 추가됨"}
+                </p>
+                <div className="mt-2 flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => approve(note)}
+                    className="rounded-lg border border-border px-3 py-1.5 text-xs font-medium hover:bg-muted"
+                  >
+                    이 Report에 추가
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => discard(note)}
+                    className="rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted"
+                  >
+                    무시
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Card>
+  );
+}

--- a/src/features/reports/components/KubiReportPanel.tsx
+++ b/src/features/reports/components/KubiReportPanel.tsx
@@ -1,0 +1,269 @@
+/**
+ * "7. Kubi 분석" 섹션 전용 패널 (#258 Kubi Report UX 수정).
+ *
+ * 지금까지는 `KubiContent compact` 전체 — API Key/Model/Base URL 설정, 데모 질문, 자유
+ * 채팅까지 — 를 한 번에 펼쳐서 보여줬다. 이건 Reports 안에 Kubi 앱 전체를 그대로 삽입한
+ * 모습이라 목적이 불분명하다. 이 패널은 그 대신 "현재 Report용 AI 해석 생성"만 기본으로
+ * 보여주고, BYOK 설정/자유 채팅은 각각 [AI 설정]/[직접 질문하기]를 눌렀을 때만 펼친다.
+ *
+ * 새 provider/LLM/evidence pipeline이나 새 action contract를 만들지 않는다 — `useKubiSession`
+ * (#256)을 그대로 재사용하고, preset은 그 위에 얹는 단순 질문 template일 뿐이다. 생성된
+ * 답변을 Report에 반영하는 것도 기존 `KubiInterpretationBlock` 모양 그대로다(`kubiBlocks.ts`의
+ * `reportNoteToBlock`과 같은 필드 구성) — 다만 이 패널은 이미 Report 편집 화면 안에 있으므로
+ * reportInbox 큐를 거치지 않고 생성 → 미리보기 → 승인을 한 화면에서 끝낸다. 승인 전에는
+ * Report에 아무것도 저장하지 않는다(`onApprove`를 호출하기 전까지는 로컬 미리보기일 뿐).
+ *
+ * context(datasetId/baseRunId)는 Report가 고정한 값이다. `useKubiSession`은 URL의
+ * pathname+search에서 context를 읽으므로(`features/kubi/context.ts`), 이 패널이 mount되어
+ * 있는 동안 URL이 항상 Report 기준 `?dataset=&run=`을 가리키도록 보정한다 — 최신 run으로
+ * 자동 전환하지 않는다(#258 §8/§6과 동일 불변식).
+ */
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAssistConfig } from "@/features/assistant/config";
+import { ApiKeySetup, KubiContent } from "@/features/kubi/KubiContent";
+import { useKubiSession } from "@/features/kubi/useKubiSession";
+import type { KubiTurn } from "@/features/kubi/types";
+import { Button, Card } from "@/shared/ui";
+import { renderMarkdownToReact } from "../markdown";
+import type { KubiInterpretationBlock, ReportDraft } from "../types";
+
+interface Preset {
+  id: string;
+  label: string;
+  question: string;
+}
+
+/** 종합 분석은 Primary CTA, 나머지 넷은 quick action이다(#258 §2-1). 새 action contract가
+ * 아니라 `useKubiSession.ask/askDemo`에 그대로 넘길 질문 template일 뿐이다. */
+const COMPREHENSIVE_PRESET: Preset = {
+  id: "comprehensive",
+  label: "보고서용 AI 분석 생성",
+  question: "이 Report가 기준으로 하는 Dataset/Run을 종합적으로 분석해줘.",
+};
+
+const QUICK_PRESETS: Preset[] = [
+  { id: "quality", label: "품질 문제 해석", question: "현재 확인된 Quality 이슈를 해석해줘." },
+  { id: "pipeline", label: "Pipeline 실패 원인 분석", question: "이 Build의 Pipeline이 실패했다면 원인을 분석해줘." },
+  { id: "ideas", label: "데이터 활용 아이디어", question: "이 데이터를 어떻게 활용할 수 있을지 아이디어를 제안해줘." },
+  { id: "caveats", label: "주의사항·한계 작성", question: "이 데이터를 사용할 때 주의사항과 한계를 정리해줘." },
+];
+
+const MOCK_DISCLAIMER = "실제 AI 분석이 아닌 mock 응답입니다.";
+
+function newBlockId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return `kubi-${crypto.randomUUID()}`;
+  return `kubi-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/** turn.context가 이 Report의 기준 dataset/run과 같은지(참고 분석과 정본 분석을 구분). */
+function turnMatchesReport(turn: KubiTurn, report: Pick<ReportDraft, "datasetId" | "baseRunId">): boolean {
+  return turn.context.datasetId === report.datasetId && turn.context.runId === report.baseRunId;
+}
+
+export function KubiReportPanel({
+  report,
+  onApprove,
+}: {
+  report: Pick<ReportDraft, "id" | "datasetId" | "baseRunId">;
+  onApprove: (block: KubiInterpretationBlock) => void;
+}) {
+  const navigate = useNavigate();
+  const session = useKubiSession();
+  const { isConfigured } = useAssistConfig();
+
+  const [showByok, setShowByok] = useState(false);
+  const [showChat, setShowChat] = useState(false);
+  const [activeQuestion, setActiveQuestion] = useState<string | null>(null);
+
+  // Report가 고정한 dataset/run을 URL에 계속 반영한다 — 최신 run으로 자동 전환하지 않는다
+  // (#258 §8 불변식). 이미 일치하면 아무것도 하지 않는다(불필요한 history 갱신 방지).
+  useEffect(() => {
+    if (session.liveContext.datasetId === report.datasetId && session.liveContext.runId === report.baseRunId) {
+      return;
+    }
+    const params = new URLSearchParams({ dataset: report.datasetId, run: report.baseRunId });
+    navigate(`/reports/${encodeURIComponent(report.id)}?${params.toString()}`, { replace: true });
+  }, [report.id, report.datasetId, report.baseRunId, session.liveContext.datasetId, session.liveContext.runId, navigate]);
+
+  const isDemoMode = !isConfigured && session.isDemoAvailable;
+  const canGenerate = isConfigured || session.isDemoAvailable;
+
+  function generate(question: string) {
+    setActiveQuestion(question);
+    if (!isConfigured && session.isDemoAvailable) {
+      void session.askDemo(question);
+      return;
+    }
+    void session.ask(question);
+  }
+
+  // 이 Report 기준(context)으로 마지막에 생성을 요청한 turn만 미리보기로 보여준다. 다른
+  // 화면/context에서 만든 turn과 섞지 않는다.
+  const activeTurn = activeQuestion
+    ? [...session.turns]
+        .reverse()
+        .find((turn) => turn.question === activeQuestion && turnMatchesReport(turn, report))
+    : undefined;
+
+  function approve() {
+    if (!activeTurn?.response) return;
+    const now = new Date().toISOString();
+    const block: KubiInterpretationBlock = {
+      id: newBlockId(),
+      provenance: "KUBI_INTERPRETATION",
+      note: activeTurn.response.answer,
+      reason: activeTurn.isDemo ? "[DEMO] 보고서용 분석(mock 응답)" : "보고서용 AI 분석",
+      sourceContext: {
+        datasetId: activeTurn.context.datasetId,
+        runId: activeTurn.context.runId,
+        stage: activeTurn.context.stage,
+      },
+      isSameContext: turnMatchesReport(activeTurn, report),
+      generatedAt: activeTurn.createdAt,
+      createdAt: now,
+      updatedAt: now,
+    };
+    onApprove(block);
+    setActiveQuestion(null);
+  }
+
+  if (showChat) {
+    return (
+      <Card className="space-y-3" data-testid="kubi-report-chat">
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            직접 질문하기 · 현재 Report 기준({report.datasetId} · {report.baseRunId})
+          </p>
+          <Button size="sm" variant="ghost" onClick={() => setShowChat(false)}>
+            닫기
+          </Button>
+        </div>
+        <KubiContent compact />
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="kubi-report-panel">
+      <p className="text-xs text-muted-foreground">
+        현재 Report의 Dataset/Run과 Builder Evidence를 기준으로 보고서에 추가할 AI 해석을 생성할 수 있습니다.
+      </p>
+
+      {!isConfigured ? (
+        <Card variant="dashed" className="flex flex-wrap items-center justify-between gap-2 p-3 text-xs">
+          <span className="text-foreground">Kubi 분석에는 개인 LLM API Key가 필요합니다.</span>
+          <Button size="sm" variant="ghost" onClick={() => setShowByok((prev) => !prev)}>
+            AI 설정 열기
+          </Button>
+        </Card>
+      ) : null}
+
+      {showByok ? <ApiKeySetup /> : null}
+
+      {isDemoMode ? (
+        <p className="rounded-lg bg-violet-50 px-3 py-2 text-xs text-violet-800 dark:bg-violet-950/30 dark:text-violet-300">
+          {MOCK_DISCLAIMER}
+        </p>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          variant="secondary"
+          disabled={!canGenerate}
+          loading={activeTurn?.question === COMPREHENSIVE_PRESET.question && activeTurn.status === "loading"}
+          onClick={() => generate(COMPREHENSIVE_PRESET.question)}
+        >
+          {isDemoMode ? "데모 보고서 분석 생성" : COMPREHENSIVE_PRESET.label}
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        {QUICK_PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            disabled={!canGenerate}
+            onClick={() => generate(preset.question)}
+            className="rounded-full border border-border px-2.5 py-1 text-xs text-muted-foreground hover:border-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-xs">
+        <Button size="sm" variant="ghost" onClick={() => setShowChat(true)}>
+          직접 질문하기
+        </Button>
+        <Button size="sm" variant="ghost" onClick={() => setShowByok((prev) => !prev)}>
+          AI 설정
+        </Button>
+      </div>
+
+      {activeTurn ? (
+        <Card className="space-y-2 border-indigo-200 dark:border-indigo-900/60" data-testid="kubi-report-preview">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h3 className="text-sm font-semibold">Kubi 분석 · AI 작성</h3>
+            {activeTurn.isDemo ? (
+              <span className="rounded-full bg-violet-100 px-2 py-0.5 text-[10px] font-semibold text-violet-800 dark:bg-violet-950/50 dark:text-violet-300">
+                DEMO
+              </span>
+            ) : null}
+          </div>
+
+          {activeTurn.isDemo ? (
+            <p className="text-xs font-medium text-violet-800 dark:text-violet-300">{MOCK_DISCLAIMER}</p>
+          ) : null}
+
+          {activeTurn.status === "loading" ? (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+              생성 중…
+              <Button size="sm" variant="ghost" onClick={() => session.cancel(activeTurn.id)}>
+                취소
+              </Button>
+            </div>
+          ) : null}
+
+          {activeTurn.status === "error" ? (
+            <p role="alert" className="text-xs text-red-700 dark:text-red-300">
+              분석을 생성하지 못했습니다.
+            </p>
+          ) : null}
+
+          {activeTurn.response ? (
+            <>
+              <div className="space-y-2 text-sm text-foreground">
+                {renderMarkdownToReact(activeTurn.response.answer)}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                <p className="font-semibold uppercase tracking-wider">근거</p>
+                <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                  <li>Dataset: {report.datasetId}</li>
+                  <li>Run: {report.baseRunId}</li>
+                  {activeTurn.response.evidenceRefs.map((ref) => (
+                    <li key={`${ref.kind}:${ref.id}`}>{ref.label}</li>
+                  ))}
+                </ul>
+              </div>
+            </>
+          ) : null}
+
+          {activeTurn.status !== "loading" ? (
+            <div className="flex flex-wrap gap-2">
+              {activeTurn.response ? (
+                <Button size="sm" onClick={approve}>
+                  보고서에 추가
+                </Button>
+              ) : null}
+              <Button size="sm" variant="secondary" onClick={() => generate(activeTurn.question)}>
+                다시 생성
+              </Button>
+            </div>
+          ) : null}
+        </Card>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/reports/components/ProvenanceBadge.tsx
+++ b/src/features/reports/components/ProvenanceBadge.tsx
@@ -1,0 +1,33 @@
+/**
+ * Report 블록의 출처(provenance)를 항상 눈에 보이게 표시하는 배지 (#258 §2, §10).
+ *
+ * Builder evidence/AI 해석/사용자 작성 내용을 시각적으로 구분해, 어떤 값이 정본이고
+ * 어떤 값이 사람 또는 AI가 쓴 설명인지 색으로만이 아니라 텍스트로도 드러낸다.
+ */
+import type { BlockProvenance } from "../types";
+
+const META: Record<BlockProvenance, { label: string; className: string }> = {
+  BUILDER_EVIDENCE: {
+    label: "Builder Evidence",
+    className: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300",
+  },
+  KUBI_INTERPRETATION: {
+    label: "AI 작성 · Kubi",
+    className: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950/50 dark:text-indigo-300",
+  },
+  USER_CONTENT: {
+    label: "사용자 작성",
+    className: "bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300",
+  },
+};
+
+export function ProvenanceBadge({ provenance, className }: { provenance: BlockProvenance; className?: string }) {
+  const meta = META[provenance];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${meta.className} ${className ?? ""}`}
+    >
+      {meta.label}
+    </span>
+  );
+}

--- a/src/features/reports/components/ReportContextSidebar.tsx
+++ b/src/features/reports/components/ReportContextSidebar.tsx
@@ -1,0 +1,92 @@
+/**
+ * Report Context sidebar (`/reports/:reportId`, #258 IA 개편).
+ *
+ * 실제로 이 Report에 존재하는 값만 보여준다 — Prototype SSOT의 "Quality summary ON / Schema
+ * drift ON / Lineage ON / Analysis ideas ON" 같은 데모용 토글은 대응하는 기능이 없으므로
+ * 옮기지 않는다. Evidence 상태 판정/재확인 로직은 기존 `EvidenceStatusBanner`를 그대로
+ * 재사용한다(새로 만들지 않음).
+ */
+import { formatDateTime } from "@/features/datasets/model";
+import { Card } from "@/shared/ui";
+import type { EvidenceStalenessResult } from "../staleness";
+import type { BuilderEvidenceBlock, ReportDraft } from "../types";
+import { EvidenceStatusBanner } from "./EvidenceStatusBanner";
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start justify-between gap-3 py-1.5 text-xs">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-right font-medium text-foreground">{value}</span>
+    </div>
+  );
+}
+
+export function ReportContextSidebar({
+  report,
+  staleness,
+  stalenessLoading,
+  onRecheck,
+  onCreateFromLatest,
+  kubiBlockCount,
+  pendingKubiNoteCount,
+}: {
+  report: ReportDraft;
+  staleness: EvidenceStalenessResult | null;
+  stalenessLoading: boolean;
+  onRecheck: () => void;
+  onCreateFromLatest?: () => void;
+  kubiBlockCount: number;
+  pendingKubiNoteCount: number;
+}) {
+  const qualityBlock = report.blocks.find(
+    (block): block is BuilderEvidenceBlock => block.provenance === "BUILDER_EVIDENCE" && block.section === "quality",
+  );
+  const qualityCounts = qualityBlock?.qualityCounts;
+
+  const sourceKeys = [...new Set(report.evidenceRefs.filter((ref) => ref.kind === "stage").map((ref) => ref.id))];
+
+  return (
+    <aside className="flex flex-col gap-4">
+      <Card>
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Report Context</p>
+        <div className="mt-2 divide-y divide-border">
+          <Row label="Dataset" value={report.datasetId} />
+          <Row label="Base Run" value={report.baseRunId} />
+          {sourceKeys.length > 0 ? <Row label="Source" value={sourceKeys.join(", ")} /> : null}
+          <Row label="BuildSpec digest" value={report.buildSpecDigest ?? "N/A"} />
+          <Row label="Evidence 조회 시각" value={formatDateTime(report.evidenceFetchedAt)} />
+        </div>
+      </Card>
+
+      <div>
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Evidence Status</p>
+        <EvidenceStatusBanner
+          result={staleness}
+          loading={stalenessLoading}
+          onRecheck={onRecheck}
+          onCreateFromLatest={onCreateFromLatest}
+        />
+      </div>
+
+      {qualityCounts ? (
+        <Card>
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Quality</p>
+          <div className="mt-2 divide-y divide-border">
+            <Row label="PASS" value={String(qualityCounts.pass)} />
+            <Row label="WARN" value={String(qualityCounts.warn)} />
+            <Row label="FAIL" value={String(qualityCounts.fail)} />
+            <Row label="평가된 규칙 수" value={String(qualityCounts.evaluated)} />
+          </div>
+        </Card>
+      ) : null}
+
+      <Card>
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Kubi</p>
+        <div className="mt-2 divide-y divide-border">
+          <Row label="Kubi 분석 블록" value={`${kubiBlockCount}개`} />
+          <Row label="대기 중인 Kubi 노트" value={pendingKubiNoteCount > 0 ? `${pendingKubiNoteCount}건` : "없음"} />
+        </div>
+      </Card>
+    </aside>
+  );
+}

--- a/src/features/reports/components/UserContentEditor.tsx
+++ b/src/features/reports/components/UserContentEditor.tsx
@@ -1,0 +1,66 @@
+/**
+ * USER_CONTENT 블록 추가/편집 폼 (#258 §10).
+ *
+ * Builder evidence 블록과 섞이지 않도록 항상 별도 블록으로만 저장한다. 여기서 입력한
+ * 원문은 저장 시 그대로 markdown으로 보관되고, 렌더링은 항상 `markdown.ts`의 안전
+ * 렌더러를 거친다(에디터 자체는 plain textarea이므로 입력 단계에서 스크립트가 실행될
+ * 여지가 없다).
+ */
+import { useState } from "react";
+import { Button, Textarea, TextInput } from "@/shared/ui";
+
+export function UserContentEditor({
+  initialHeading = "",
+  initialMarkdown = "",
+  onSave,
+  onCancel,
+}: {
+  initialHeading?: string;
+  initialMarkdown?: string;
+  onSave: (heading: string, markdown: string) => void;
+  onCancel: () => void;
+}) {
+  const [heading, setHeading] = useState(initialHeading);
+  const [markdown, setMarkdown] = useState(initialMarkdown);
+
+  return (
+    <div className="space-y-3 rounded-xl border border-dashed border-border p-4">
+      <div>
+        <label className="text-xs font-medium text-muted-foreground" htmlFor="user-block-heading">
+          제목
+        </label>
+        <TextInput
+          id="user-block-heading"
+          value={heading}
+          onChange={(e) => setHeading(e.target.value)}
+          placeholder="예: 활용 아이디어"
+          className="mt-1"
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium text-muted-foreground" htmlFor="user-block-markdown">
+          내용(Markdown)
+        </label>
+        <Textarea
+          id="user-block-markdown"
+          value={markdown}
+          onChange={(e) => setMarkdown(e.target.value)}
+          rows={6}
+          placeholder="자유롭게 서술하세요. **굵게**, - 목록, [링크](https://...) 를 지원합니다."
+          className="mt-1"
+        />
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button variant="secondary" onClick={onCancel}>
+          취소
+        </Button>
+        <Button
+          onClick={() => onSave(heading.trim() || "제목 없음", markdown)}
+          disabled={markdown.trim().length === 0}
+        >
+          저장
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/reports/deterministicSections.test.ts
+++ b/src/features/reports/deterministicSections.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildDeterministicSections } from "./deterministicSections";
+import { fetchReportEvidence } from "./evidence";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("buildDeterministicSections (#258 §4, §5)", () => {
+  it("Overview/Pipeline/Quality/Schema/Data Summary/Output 6개 섹션을 만든다", async () => {
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+    const blocks = buildDeterministicSections(evidence);
+
+    expect(blocks.map((b) => b.section)).toEqual(["overview", "pipeline", "quality", "schema", "data_summary", "output"]);
+    expect(blocks.every((b) => b.provenance === "BUILDER_EVIDENCE")).toBe(true);
+  });
+
+  it("Overview에 BuildSpec digest와 run 시각을 포함한다", async () => {
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+    const [overview] = buildDeterministicSections(evidence);
+
+    expect(overview.markdown).toContain("sha256:air14");
+    expect(overview.markdown).toContain("air-2026-08-14");
+  });
+
+  it("Pipeline 섹션은 source별 bronze/silver/gold 상태를 그대로 표시한다(실패도 감춤 없이)", async () => {
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+    const [, pipeline] = buildDeterministicSections(evidence);
+
+    expect(pipeline.markdown).toContain("datago__air");
+    expect(pipeline.markdown).toContain("kma__weather");
+    expect(pipeline.markdown).toContain("failed");
+    expect(pipeline.evidenceStatus).toBe("ok");
+  });
+
+  it("quality availability=unavailable인 run은 PASS/0으로 꾸미지 않고 그대로 확인 불가로 남긴다", async () => {
+    const evidence = await fetchReportEvidence("population", "population-2026-08-13");
+    const quality = buildDeterministicSections(evidence).find((b) => b.section === "quality")!;
+
+    // "PASS로 간주하지 않습니다"라는 명시적 부정 문구는 있어도 되지만, PASS를 대표 상태처럼
+    // 단독으로 내세우지는 않는다.
+    expect(quality.markdown).not.toMatch(/summary.*PASS \d/i);
+    expect(quality.markdown).toContain("PASS로 간주하지 않습니다");
+    expect(quality.markdown).toContain("unavailable");
+  });
+
+  it("Quality 섹션은 실제 PASS/WARN/FAIL 결과와 schema drift를 표시한다", async () => {
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+    const quality = buildDeterministicSections(evidence).find((b) => b.section === "quality")!;
+
+    expect(quality.markdown).toContain("FAIL");
+    expect(quality.markdown).toContain("column_removed");
+  });
+
+  it("Schema 섹션은 silver schema가 없는 source를 확인할 수 없음으로 구분한다(부분 실패)", async () => {
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+    const schema = buildDeterministicSections(evidence).find((b) => b.section === "schema")!;
+
+    expect(schema.markdown).toContain("observed_at");
+    expect(schema.markdown).toContain("확인할 수 없음");
+    expect(schema.evidenceStatus).toBe("partial");
+  });
+
+  it("Data Summary는 실제 row_counts/total_row_count를 그대로 사용한다(임의 0 대체 없음)", async () => {
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+    const dataSummary = buildDeterministicSections(evidence).find((b) => b.section === "data_summary")!;
+
+    expect(dataSummary.markdown).toContain("1,200");
+    expect(dataSummary.markdown).toContain("1,000");
+  });
+
+  it("Output evidence를 확인할 수 없으면 N/A가 아니라 사유를 포함해 unavailable로 표시한다", async () => {
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+    const output = buildDeterministicSections(evidence).find((b) => b.section === "output")!;
+
+    expect(output.evidenceStatus).toBe("unavailable");
+    expect(output.unavailableReason).toBeTruthy();
+  });
+
+  it("dataset 조회 자체가 실패해도 예외를 던지지 않고 unavailable 섹션들을 만든다", async () => {
+    const evidence = await fetchReportEvidence("does-not-exist", "does-not-exist-run");
+    const blocks = buildDeterministicSections(evidence);
+
+    expect(blocks).toHaveLength(6);
+    expect(blocks.find((b) => b.section === "overview")?.evidenceStatus).toBe("unavailable");
+  });
+});

--- a/src/features/reports/deterministicSections.ts
+++ b/src/features/reports/deterministicSections.ts
@@ -1,0 +1,313 @@
+/**
+ * Deterministic Report section 생성 (#258 §4, §5).
+ *
+ * `ReportEvidenceBundle`(Builder에서 그대로 가져온 값)만 입력으로 받아 코드가 그대로
+ * BUILDER_EVIDENCE 블록을 구성한다 — LLM은 이 단계에 전혀 관여하지 않는다. 값이 없거나
+ * 조회에 실패한 항목은 "N/A"/"확인할 수 없음"으로 표시하며 0/PASS/정상으로 바꾸지 않는다.
+ */
+import { formatDateTime, sourceLabel } from "@/features/datasets/model";
+import {
+  flattenQualityResults,
+  flattenSchemaDrift,
+  formatQualityValue,
+} from "@/features/quality/model";
+import type { ReportEvidenceBundle } from "./evidence";
+import { buildSectionSummaries, computeQualityCounts } from "./narrativeSummary";
+import type { BuilderEvidenceBlock, BuilderEvidenceSection } from "./types";
+
+const NA = "N/A";
+const UNAVAILABLE = "확인할 수 없음";
+
+function newBlockId(section: BuilderEvidenceSection): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return `evidence-${section}-${crypto.randomUUID()}`;
+  return `evidence-${section}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function makeBlock(
+  section: BuilderEvidenceSection,
+  title: string,
+  markdown: string,
+  evidenceStatus: BuilderEvidenceBlock["evidenceStatus"],
+  unavailableReason: string | undefined,
+  now: string,
+  summary: string,
+): BuilderEvidenceBlock {
+  return {
+    id: newBlockId(section),
+    provenance: "BUILDER_EVIDENCE",
+    section,
+    title,
+    markdown,
+    evidenceStatus,
+    unavailableReason,
+    summary,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function mdTable(header: string[], rows: string[][]): string {
+  const sep = header.map(() => "---");
+  return [`| ${header.join(" | ")} |`, `| ${sep.join(" | ")} |`, ...rows.map((row) => `| ${row.join(" | ")} |`)].join(
+    "\n",
+  );
+}
+
+function buildOverview(evidence: ReportEvidenceBundle, now: string, summary: string): BuilderEvidenceBlock {
+  if (!evidence.dataset.ok) {
+    return makeBlock(
+      "overview",
+      "1. Overview",
+      `Dataset 정보를 불러오지 못했습니다: ${evidence.dataset.reason}`,
+      "unavailable",
+      evidence.dataset.reason,
+      now,
+      summary,
+    );
+  }
+  const dataset = evidence.dataset.value;
+  const rows: string[][] = [
+    ["Dataset", `${dataset.title} (\`${dataset.dataset_id}\`)`],
+    ["Provider(s)", [...new Set(dataset.sources.map((s) => s.provider))].join(", ") || NA],
+    ["Sources", dataset.sources.map((s) => sourceLabel(s)).join(", ") || NA],
+    ["기준 Run", `\`${evidence.runId}\``],
+    ["Run 상태", evidence.run.ok ? evidence.run.value.status : UNAVAILABLE],
+    [
+      "Run 시작 / 종료",
+      evidence.run.ok
+        ? `${formatDateTime(evidence.run.value.started_at)} → ${formatDateTime(evidence.run.value.finished_at)}`
+        : UNAVAILABLE,
+    ],
+    ["BuildSpec digest", evidence.run.ok ? (evidence.run.value.spec_digest ?? NA) : UNAVAILABLE],
+    ["Dataset 최종 갱신", formatDateTime(dataset.updated_at)],
+  ];
+  const status = evidence.run.ok ? "ok" : "partial";
+  return makeBlock(
+    "overview",
+    "1. Overview",
+    mdTable(["항목", "값"], rows),
+    status,
+    evidence.run.ok ? undefined : evidence.run.reason,
+    now,
+    summary,
+  );
+}
+
+function buildPipeline(evidence: ReportEvidenceBundle, now: string, summary: string): BuilderEvidenceBlock {
+  if (evidence.stages.ok) {
+    const rows = evidence.stages.value.sources.map((source) => [
+      `\`${source.source_key}\``,
+      source.bronze.status,
+      source.silver.status,
+      source.gold.status,
+    ]);
+    if (rows.length === 0) {
+      return makeBlock("pipeline", "2. Pipeline", `이 run에 대한 source가 없습니다.`, "ok", undefined, now, summary);
+    }
+    return makeBlock(
+      "pipeline",
+      "2. Pipeline",
+      mdTable(["Source", "Bronze", "Silver", "Gold"], rows),
+      "ok",
+      undefined,
+      now,
+      summary,
+    );
+  }
+
+  // stage 상세 조회는 실패했지만 dataset 요약에 stage map이 남아있으면 그걸로 대체한다(부분 실패 허용).
+  if (evidence.dataset.ok) {
+    const rows = Object.entries(evidence.dataset.value.stages).map(([sourceKey, stage]) => [
+      `\`${sourceKey}\``,
+      stage.bronze,
+      stage.silver,
+      stage.gold,
+    ]);
+    return makeBlock(
+      "pipeline",
+      "2. Pipeline",
+      `run 단위 stage 상세 조회에 실패해 dataset 요약 기준으로 표시합니다(${evidence.stages.reason}).\n\n${mdTable(["Source", "Bronze", "Silver", "Gold"], rows)}`,
+      "partial",
+      evidence.stages.reason,
+      now,
+      summary,
+    );
+  }
+
+  return makeBlock(
+    "pipeline",
+    "2. Pipeline",
+    `Pipeline 상태를 불러오지 못했습니다: ${evidence.stages.reason}`,
+    "unavailable",
+    evidence.stages.reason,
+    now,
+    summary,
+  );
+}
+
+function buildQuality(evidence: ReportEvidenceBundle, now: string, summary: string): BuilderEvidenceBlock {
+  const qualityCounts = computeQualityCounts(evidence) ?? undefined;
+  if (!evidence.quality.ok) {
+    return {
+      ...makeBlock(
+        "quality",
+        "3. Quality",
+        `Quality 결과를 불러오지 못했습니다: ${evidence.quality.reason}`,
+        "unavailable",
+        evidence.quality.reason,
+        now,
+        summary,
+      ),
+      qualityCounts,
+    };
+  }
+  const quality = evidence.quality.value;
+  if (quality.availability === "unavailable") {
+    return {
+      ...makeBlock(
+        "quality",
+        "3. Quality",
+        `이 run은 Quality 평가가 제공되지 않습니다(availability=unavailable). PASS로 간주하지 않습니다.`,
+        "ok",
+        undefined,
+        now,
+        summary,
+      ),
+      qualityCounts,
+    };
+  }
+
+  const results = flattenQualityResults(quality);
+  const drift = flattenSchemaDrift(quality);
+  const pass = results.filter((r) => r.status === "pass").length;
+  const warn = results.filter((r) => r.status === "warn").length;
+  const fail = results.filter((r) => r.status === "fail").length;
+
+  const summaryLine = `availability: \`${quality.availability}\` · evaluated_checks: **${quality.evaluated_checks}** · PASS ${pass} / WARN ${warn} / FAIL ${fail}`;
+
+  const resultRows =
+    results.length === 0
+      ? []
+      : results.map((r) => [
+          `\`${r.source_key}\``,
+          r.category,
+          r.rule,
+          r.column ?? NA,
+          r.status.toUpperCase(),
+          formatQualityValue(r.rule, r.actual),
+          formatQualityValue(r.rule, r.threshold),
+        ]);
+
+  const driftLines =
+    drift.length === 0
+      ? "schema drift가 관찰되지 않았습니다."
+      : drift.map((d) => `- \`${d.column ?? NA}\`: ${d.kind} — ${d.detail}`).join("\n");
+
+  const parts = [summaryLine];
+  if (resultRows.length > 0) {
+    parts.push(mdTable(["Source", "Category", "Rule", "Column", "결과", "실제값", "기준값"], resultRows));
+  } else {
+    parts.push("평가된 규칙이 없습니다(evaluated_checks=0).");
+  }
+  parts.push(`**Schema drift**\n\n${driftLines}`);
+
+  return {
+    ...makeBlock("quality", "3. Quality", parts.join("\n\n"), "ok", undefined, now, summary),
+    qualityCounts,
+  };
+}
+
+function buildSchema(evidence: ReportEvidenceBundle, now: string, summary: string): BuilderEvidenceBlock {
+  const entries = Object.entries(evidence.schemas);
+  if (entries.length === 0) {
+    return makeBlock(
+      "schema",
+      "4. Schema",
+      `Schema 정보를 불러올 source가 없습니다.`,
+      "unavailable",
+      undefined,
+      now,
+      summary,
+    );
+  }
+
+  const unavailableCount = entries.filter(([, schema]) => schema.origin === "unavailable").length;
+  const parts = entries.map(([sourceKey, schema]) => {
+    if (schema.origin === "silver") {
+      const rows = schema.columns.map((col) => [col.name, col.dtype, col.nullable ? "Y" : "N", String(col.unique_count)]);
+      return `**\`${sourceKey}\`** (silver)\n\n${mdTable(["Column", "Type", "Nullable", "Unique"], rows)}`;
+    }
+    if (schema.origin === "gold_names_only") {
+      const rows = (schema.columnNamesOnly ?? []).map((name) => [name, NA, NA]);
+      return `**\`${sourceKey}\`** (gold — column 이름만 제공, dtype 없음)\n\n${mdTable(["Column", "Type", "Nullable"], rows)}`;
+    }
+    return `**\`${sourceKey}\`**: ${UNAVAILABLE}${schema.reason ? ` (${schema.reason})` : ""}`;
+  });
+
+  const status: BuilderEvidenceBlock["evidenceStatus"] =
+    unavailableCount === 0 ? "ok" : unavailableCount === entries.length ? "unavailable" : "partial";
+
+  return makeBlock("schema", "4. Schema", parts.join("\n\n"), status, undefined, now, summary);
+}
+
+function buildDataSummary(evidence: ReportEvidenceBundle, now: string, summary: string): BuilderEvidenceBlock {
+  if (!evidence.dataset.ok) {
+    return makeBlock(
+      "data_summary",
+      "5. Data Summary",
+      `Row count 정보를 불러오지 못했습니다: ${evidence.dataset.reason}`,
+      "unavailable",
+      evidence.dataset.reason,
+      now,
+      summary,
+    );
+  }
+  const dataset = evidence.dataset.value;
+  const rows = Object.entries(dataset.row_counts).map(([sourceKey, count]) => [`\`${sourceKey}\``, count.toLocaleString("ko-KR")]);
+  const body = [
+    `**Total row count**: ${dataset.total_row_count.toLocaleString("ko-KR")}`,
+    rows.length > 0 ? mdTable(["Source", "Row count"], rows) : "source별 row count 정보가 없습니다.",
+  ].join("\n\n");
+  return makeBlock("data_summary", "5. Data Summary", body, "ok", undefined, now, summary);
+}
+
+function buildOutput(evidence: ReportEvidenceBundle, now: string, summary: string): BuilderEvidenceBlock {
+  if (!evidence.output.ok) {
+    return makeBlock(
+      "output",
+      "6. Output",
+      `Output/Artifact 정보를 확인할 수 없습니다: ${evidence.output.reason}`,
+      "unavailable",
+      evidence.output.reason,
+      now,
+      summary,
+    );
+  }
+  const files = evidence.output.value.files;
+  if (files.length === 0) {
+    return makeBlock("output", "6. Output", "이 run에 대해 보고된 output 파일이 없습니다.", "ok", undefined, now, summary);
+  }
+  return makeBlock(
+    "output",
+    "6. Output",
+    files.map((f) => `- \`${f}\``).join("\n"),
+    "ok",
+    undefined,
+    now,
+    summary,
+  );
+}
+
+/** evidence bundle로부터 6개 deterministic BUILDER_EVIDENCE 블록을 생성한다. */
+export function buildDeterministicSections(evidence: ReportEvidenceBundle): BuilderEvidenceBlock[] {
+  const now = new Date().toISOString();
+  const summaries = buildSectionSummaries(evidence);
+  return [
+    buildOverview(evidence, now, summaries.overview),
+    buildPipeline(evidence, now, summaries.pipeline),
+    buildQuality(evidence, now, summaries.quality),
+    buildSchema(evidence, now, summaries.schema),
+    buildDataSummary(evidence, now, summaries.data_summary),
+    buildOutput(evidence, now, summaries.output),
+  ];
+}

--- a/src/features/reports/evidence.test.ts
+++ b/src/features/reports/evidence.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildEvidenceRefs, fetchReportEvidence } from "./evidence";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("fetchReportEvidence (#258)", () => {
+  it("모든 evidence를 한 번에 모은다(정상 dataset/run)", async () => {
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+
+    expect(evidence.dataset.ok).toBe(true);
+    expect(evidence.run.ok).toBe(true);
+    if (evidence.run.ok) expect(evidence.run.value.spec_digest).toBe("sha256:air14");
+    expect(evidence.stages.ok).toBe(true);
+    expect(evidence.quality.ok).toBe(true);
+    if (evidence.quality.ok) expect(evidence.quality.value.availability).toBe("partial");
+  });
+
+  it("silver schema를 온전히 가진 source는 origin=silver, 실패한 source는 origin=unavailable로 구분한다", async () => {
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+
+    expect(evidence.schemas["datago__air"]?.origin).toBe("silver");
+    expect(evidence.schemas["datago__air"]?.columns.length).toBeGreaterThan(0);
+    // kma__weather는 mock에서 silver failed, gold not_run이라 schema를 얻을 수 없다.
+    expect(evidence.schemas["kma__weather"]?.origin).toBe("unavailable");
+    expect(evidence.schemas["kma__weather"]?.reason).toBeTruthy();
+  });
+
+  it("run이 dataset의 run 목록에 없으면 run을 실패로 표시하되 dataset/stages/quality는 그대로 시도한다(부분 실패 허용)", async () => {
+    const evidence = await fetchReportEvidence("air-quality", "does-not-exist-run");
+
+    expect(evidence.dataset.ok).toBe(true);
+    expect(evidence.run.ok).toBe(false);
+    if (!evidence.run.ok) expect(evidence.run.reason).toContain("run 목록");
+  });
+
+  it("존재하지 않는 dataset이면 dataset을 실패로 표시하지만 전체를 던지지 않는다", async () => {
+    const evidence = await fetchReportEvidence("does-not-exist", "does-not-exist-run");
+
+    expect(evidence.dataset.ok).toBe(false);
+    expect(evidence.run.ok).toBe(false);
+    expect(evidence.quality.ok).toBe(false);
+  });
+
+  it("mock/demo 모드에서는 output evidence를 신뢰할 수 있는 형태로 제공하지 않는다(임의 데이터를 만들지 않음)", async () => {
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+    expect(evidence.output.ok).toBe(false);
+  });
+
+  it("evidenceRefs는 실제로 확인된 조각만 포함한다", async () => {
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+    const refs = buildEvidenceRefs(evidence);
+
+    expect(refs.some((r) => r.kind === "dataset" && r.id === "air-quality")).toBe(true);
+    expect(refs.some((r) => r.kind === "run" && r.id === "air-2026-08-14")).toBe(true);
+    expect(refs.some((r) => r.kind === "output")).toBe(false);
+  });
+});

--- a/src/features/reports/evidence.ts
+++ b/src/features/reports/evidence.ts
@@ -1,0 +1,167 @@
+/**
+ * Report 기준 Builder evidence 조회 (#258).
+ *
+ * `features/kubi/evidence.ts`(#256)와 같은 패턴을 따른다 — 여러 Builder 엔드포인트를
+ * 병렬/순차로 호출하되, 하나가 실패해도 나머지는 그대로 쓴다("부분 실패 허용", #258 §5).
+ * 새 Builder 엔드포인트를 만들지 않고 `features/datasets/api`(#256/#253/#254가 이미
+ * 검증한 client)만 재사용한다.
+ *
+ * Output(산출물) evidence는 실연동 모드에서만 조회한다 — mock 모드의 `getBuildManifest`는
+ * run_id와 무관한 별도 데모 카탈로그(`shared/lib/demoDatasets.ts`)로 폴백하기 때문에,
+ * 그대로 쓰면 이 dataset/run과 상관없는 파일 목록을 evidence처럼 보여주게 된다(#258 §4 —
+ * 없는 정보를 추측해서 만들지 않는다).
+ */
+import {
+  getBuildQuality,
+  getBuildStageDetail,
+  getDataset,
+  listBuildStages,
+  listDatasetRuns,
+} from "@/features/datasets/api";
+import { getBuildManifest } from "@/features/artifacts/api";
+import { isRealBuilderEnabled } from "@/shared/lib/builderApi";
+import type {
+  BuildQualityResponse,
+  DatasetDetailResponse,
+  DatasetRunSummary,
+  RunStagesResponse,
+  StageDetailResponse,
+} from "@/shared/lib/builderApi";
+import type { ReportEvidenceRef } from "./types";
+
+/** silver StageDetailResponse의 schema 배열 원소 타입(별도 export 타입이 없어 판별 유니온에서 추출). */
+type SilverColumnInfo = Extract<StageDetailResponse, { stage: "silver" }>["schema"][number];
+
+type Settled<T> = { ok: true; value: T } | { ok: false; reason: string };
+
+async function settle<T>(promise: Promise<T>): Promise<Settled<T>> {
+  try {
+    return { ok: true, value: await promise };
+  } catch (cause) {
+    return { ok: false, reason: cause instanceof Error ? cause.message : "조회에 실패했습니다." };
+  }
+}
+
+export interface ReportSourceSchema {
+  sourceKey: string;
+  /** silver schema를 온전히 얻었으면 "silver", gold column 이름만 얻었으면 "gold_names_only" */
+  origin: "silver" | "gold_names_only" | "unavailable";
+  columns: SilverColumnInfo[];
+  /** gold_names_only일 때만 채워지는, dtype 정보가 없는 컬럼 이름 목록 */
+  columnNamesOnly?: string[];
+  reason?: string;
+}
+
+export interface ReportOutputEvidence {
+  files: string[];
+}
+
+export interface ReportEvidenceBundle {
+  fetchedAt: string;
+  datasetId: string;
+  runId: string;
+  dataset: Settled<DatasetDetailResponse>;
+  /** listDatasetRuns 응답에서 runId와 일치하는 항목(spec_digest/시각 등). run 자체가 삭제/접근불가면 실패로 표시. */
+  run: Settled<DatasetRunSummary>;
+  stages: Settled<RunStagesResponse>;
+  quality: Settled<BuildQualityResponse>;
+  schemas: Record<string, ReportSourceSchema>;
+  output: Settled<ReportOutputEvidence>;
+}
+
+async function fetchSourceSchema(runId: string, sourceKey: string, signal?: AbortSignal): Promise<ReportSourceSchema> {
+  const silver = await settle(getBuildStageDetail(runId, "silver", sourceKey, 0, signal));
+  if (silver.ok && silver.value.stage === "silver" && silver.value.available && silver.value.schema.length > 0) {
+    return { sourceKey, origin: "silver", columns: silver.value.schema };
+  }
+
+  const gold = await settle(getBuildStageDetail(runId, "gold", sourceKey, 0, signal));
+  if (gold.ok && gold.value.stage === "gold" && gold.value.available && gold.value.columns.length > 0) {
+    return { sourceKey, origin: "gold_names_only", columns: [], columnNamesOnly: gold.value.columns };
+  }
+
+  const reason = !silver.ok && !gold.ok
+    ? "silver/gold schema 조회에 모두 실패했습니다."
+    : "이 source는 아직 schema를 만들 수 있는 stage까지 진행되지 않았습니다.";
+  return { sourceKey, origin: "unavailable", columns: [], reason };
+}
+
+/**
+ * 기준 dataset/run에 대한 evidence를 한 번에 모은다.
+ *
+ * @param datasetId - Report의 기준 dataset.
+ * @param runId - Report가 고정한 기준 run(baseRunId). 최신 run으로 자동 대체하지 않는다.
+ * @param signal - 취소 signal.
+ */
+export async function fetchReportEvidence(
+  datasetId: string,
+  runId: string,
+  signal?: AbortSignal,
+): Promise<ReportEvidenceBundle> {
+  const [datasetResult, runsResult, stagesResult, qualityResult] = await Promise.all([
+    settle(getDataset(datasetId, signal)),
+    settle(listDatasetRuns(datasetId, 50, signal)),
+    settle(listBuildStages(runId, signal)),
+    settle(getBuildQuality(runId, signal)),
+  ]);
+
+  const runResult: Settled<DatasetRunSummary> = runsResult.ok
+    ? (() => {
+        const match = runsResult.value.runs.find((run) => run.run_id === runId);
+        return match ? { ok: true, value: match } : { ok: false, reason: "이 dataset의 run 목록에서 기준 run을 찾을 수 없습니다(삭제되었거나 접근할 수 없음)." };
+      })()
+    : { ok: false, reason: runsResult.reason };
+
+  const sourceKeys = stagesResult.ok
+    ? stagesResult.value.sources.map((s) => s.source_key)
+    : datasetResult.ok
+      ? Object.keys(datasetResult.value.stages)
+      : [];
+
+  const schemaEntries = await Promise.all(
+    sourceKeys.map(async (sourceKey) => [sourceKey, await fetchSourceSchema(runId, sourceKey, signal)] as const),
+  );
+  const schemas: Record<string, ReportSourceSchema> = Object.fromEntries(schemaEntries);
+
+  const output: Settled<ReportOutputEvidence> = isRealBuilderEnabled()
+    ? await settle(getBuildManifest(runId, signal).then((manifest) => ({ files: manifest.outputs ?? [] })))
+    : { ok: false, reason: "mock/demo 모드에서는 이 run에 실제로 대응하는 output evidence를 제공하지 않습니다." };
+
+  return {
+    fetchedAt: new Date().toISOString(),
+    datasetId,
+    runId,
+    dataset: datasetResult,
+    run: runResult,
+    stages: stagesResult,
+    quality: qualityResult,
+    schemas,
+    output,
+  };
+}
+
+/** evidence bundle에서 실제로 확인된 조각만 안정적 참조 목록으로 만든다(확인 못한 항목은 포함하지 않음). */
+export function buildEvidenceRefs(evidence: ReportEvidenceBundle): ReportEvidenceRef[] {
+  const refs: ReportEvidenceRef[] = [];
+  if (evidence.dataset.ok) {
+    refs.push({ kind: "dataset", id: evidence.datasetId, label: evidence.dataset.value.title });
+  }
+  if (evidence.run.ok) {
+    refs.push({ kind: "run", id: evidence.runId, label: `Run ${evidence.runId}` });
+  }
+  if (evidence.quality.ok) {
+    refs.push({ kind: "quality", id: evidence.runId, label: "Quality" });
+  }
+  for (const [sourceKey, schema] of Object.entries(evidence.schemas)) {
+    if (schema.origin !== "unavailable") refs.push({ kind: "schema", id: sourceKey, label: `Schema · ${sourceKey}` });
+  }
+  if (evidence.stages.ok) {
+    for (const source of evidence.stages.value.sources) {
+      refs.push({ kind: "stage", id: source.source_key, label: `Stage · ${source.source_key}` });
+    }
+  }
+  if (evidence.output.ok) {
+    refs.push({ kind: "output", id: evidence.runId, label: "Output" });
+  }
+  return refs;
+}

--- a/src/features/reports/export.test.ts
+++ b/src/features/reports/export.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import { generateHtmlExport, generateMarkdownExport, sanitizeFilename } from "./export";
+import type { ReportDraft } from "./types";
+
+function makeReport(overrides: Partial<ReportDraft> = {}): ReportDraft {
+  return {
+    id: "r1",
+    title: "테스트 Report",
+    datasetId: "air-quality",
+    baseRunId: "air-2026-08-14",
+    buildSpecDigest: "sha256:air14",
+    createdAt: "2026-08-14T08:00:00Z",
+    updatedAt: "2026-08-14T08:00:00Z",
+    evidenceFetchedAt: "2026-08-14T08:00:00Z",
+    version: 1,
+    revision: 1,
+    evidenceRefs: [],
+    blocks: [
+      {
+        id: "e1",
+        provenance: "BUILDER_EVIDENCE",
+        section: "quality",
+        title: "3. Quality",
+        markdown: "availability: `partial` · evaluated_checks: **2**",
+        evidenceStatus: "ok",
+        createdAt: "x",
+        updatedAt: "x",
+      },
+      {
+        id: "k1",
+        provenance: "KUBI_INTERPRETATION",
+        note: '<script>alert(1)</script> price 결측이 특정 지역에 집중되어 있습니다.',
+        reason: "Gold column profile",
+        sourceContext: { datasetId: "air-quality", runId: "air-2026-08-14" },
+        isSameContext: true,
+        generatedAt: "2026-08-14T09:00:00Z",
+        provider: "byok",
+        createdAt: "x",
+        updatedAt: "x",
+      },
+      { id: "u1", provenance: "USER_CONTENT", heading: "활용 아이디어", markdown: "지역별 분석이 필요합니다.", createdAt: "x", updatedAt: "x" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("sanitizeFilename (#258 §12)", () => {
+  it("경로/예약 문자를 제거한다", () => {
+    expect(sanitizeFilename('a/b\\c:d*e?f"g<h>i|j')).toBe("abcdefghij");
+  });
+
+  it("공백은 밑줄로 바꾼다", () => {
+    expect(sanitizeFilename("대기질 통합 데이터 report")).toBe("대기질_통합_데이터_report");
+  });
+
+  it("빈 제목이면 report로 대체한다", () => {
+    expect(sanitizeFilename("///")).toBe("report");
+    expect(sanitizeFilename("   ")).toBe("report");
+  });
+});
+
+describe("generateMarkdownExport / generateHtmlExport (#258 §12, §13)", () => {
+  it("Markdown 내보내기에 title/dataset/base run/생성시각/evidence 조회시각을 포함한다", () => {
+    const md = generateMarkdownExport(makeReport(), "current");
+    expect(md).toContain("테스트 Report");
+    expect(md).toContain("Dataset: air-quality");
+    expect(md).toContain("Base Run: air-2026-08-14");
+    expect(md).toContain("생성 시각");
+    expect(md).toContain("Evidence 조회 시각");
+  });
+
+  it("Builder Evidence/AI/사용자 블록을 provenance 태그로 구분한다", () => {
+    const md = generateMarkdownExport(makeReport(), "current");
+    expect(md).toContain("[Builder Evidence]");
+    expect(md).toContain("[AI 작성");
+    expect(md).toContain("[사용자 작성]");
+  });
+
+  it("stale/orphan 경고를 포함한다", () => {
+    const md = generateMarkdownExport(makeReport(), "stale");
+    expect(md).toContain("STALE");
+  });
+
+  it("HTML 내보내기는 <script> 태그를 절대 포함하지 않는다(Kubi note에 악성 문자열이 있어도)", () => {
+    const html = generateHtmlExport(makeReport(), "current");
+    expect(html).not.toContain("<script>");
+    expect(html.toLowerCase()).not.toContain("<script");
+  });
+
+  it("HTML 내보내기는 self-contained 문서이며 provenance 태그를 포함한다", () => {
+    const html = generateHtmlExport(makeReport(), "current");
+    expect(html).toContain("<!doctype html>");
+    expect(html).toContain("Builder Evidence");
+    expect(html).toContain("AI 작성");
+    expect(html).toContain("사용자 작성");
+  });
+
+  it("다른 Run 기준 Kubi 블록은 참고 분석으로 구분해서 내보낸다", () => {
+    const report = makeReport({
+      blocks: [
+        {
+          id: "k2",
+          provenance: "KUBI_INTERPRETATION",
+          note: "다른 run 분석",
+          reason: "x",
+          sourceContext: { datasetId: "air-quality", runId: "air-2026-08-13" },
+          isSameContext: false,
+          generatedAt: "2026-08-13T09:00:00Z",
+          createdAt: "x",
+          updatedAt: "x",
+        },
+      ],
+    });
+    const md = generateMarkdownExport(report, "current");
+    expect(md).toContain("다른 Run 기준");
+    const html = generateHtmlExport(report, "current");
+    expect(html).toContain("다른 Run 기준");
+  });
+
+  it("BUILDER_EVIDENCE 블록에 summary가 있으면 Markdown export가 summary와 상세 표를 모두 포함한다", () => {
+    const report = makeReport({
+      blocks: [
+        {
+          id: "e1",
+          provenance: "BUILDER_EVIDENCE",
+          section: "quality",
+          title: "3. 품질 진단",
+          markdown: "| check | result |\n| --- | --- |\n| null_rate | PASS |",
+          evidenceStatus: "ok",
+          summary: "품질 검사 2건 중 2건 통과했습니다.",
+          createdAt: "x",
+          updatedAt: "x",
+        },
+      ],
+    });
+    const md = generateMarkdownExport(report, "current");
+    const summaryIndex = md.indexOf("품질 검사 2건 중 2건 통과했습니다.");
+    const detailHeadingIndex = md.indexOf("### 상세 근거");
+    const tableIndex = md.indexOf("| check | result |");
+    expect(summaryIndex).toBeGreaterThan(-1);
+    expect(detailHeadingIndex).toBeGreaterThan(summaryIndex);
+    expect(tableIndex).toBeGreaterThan(detailHeadingIndex);
+  });
+
+  it("BUILDER_EVIDENCE 블록에 summary가 있으면 HTML export가 escaped summary와 기존 evidence를 모두 포함한다", () => {
+    const report = makeReport({
+      blocks: [
+        {
+          id: "e1",
+          provenance: "BUILDER_EVIDENCE",
+          section: "quality",
+          title: "3. 품질 진단",
+          markdown: "| check | result |\n| --- | --- |\n| null_rate | PASS |",
+          evidenceStatus: "ok",
+          summary: "<script>alert(1)</script> 품질 검사 요약",
+          createdAt: "x",
+          updatedAt: "x",
+        },
+      ],
+    });
+    const html = generateHtmlExport(report, "current");
+    expect(html).not.toContain("<script>");
+    expect(html.toLowerCase()).not.toContain("<script");
+    expect(html).toContain("품질 검사 요약");
+    const summaryIndex = html.indexOf("품질 검사 요약");
+    const detailHeadingIndex = html.indexOf("상세 근거");
+    const tableIndex = html.indexOf("null_rate");
+    expect(detailHeadingIndex).toBeGreaterThan(summaryIndex);
+    expect(tableIndex).toBeGreaterThan(detailHeadingIndex);
+  });
+
+  it("summary가 없는 legacy draft(BUILDER_EVIDENCE)는 기존처럼 상세 표만 출력한다", () => {
+    const report = makeReport();
+    const md = generateMarkdownExport(report, "current");
+    expect(md).not.toContain("### 상세 근거");
+    expect(md).toContain("availability: `partial` · evaluated_checks: **2**");
+
+    const html = generateHtmlExport(report, "current");
+    expect(html).not.toContain("상세 근거");
+  });
+});

--- a/src/features/reports/export.ts
+++ b/src/features/reports/export.ts
@@ -1,0 +1,163 @@
+/**
+ * Report 내보내기 (#258 §12, §13).
+ *
+ * 실제로 구현하는 형식만 제공한다: Markdown 다운로드, 안전한 HTML 다운로드, Browser Print.
+ * PDF/DOCX는 만들지 않으며 그렇게 보이게 표시하지 않는다 — Browser Print는 "PDF 생성"이
+ * 아니라 브라우저 인쇄 대화상자를 여는 것뿐이다.
+ *
+ * 내보내는 파일에는 항상 title/dataset/base run/createdAt/evidenceFetchedAt/provenance
+ * 구분/stale-orphan 경고를 포함한다. Kubi/사용자 콘텐츠는 `markdown.ts`의 안전 렌더러만
+ * 거쳐 HTML로 들어간다 — 원문을 그대로 삽입하지 않는다.
+ */
+import { escapeHtml, renderMarkdownToHtml } from "./markdown";
+import type { EvidenceRunStatus } from "./types";
+import type { ReportDraft } from "./types";
+
+const STATUS_LABEL: Record<EvidenceRunStatus, string> = {
+  current: "CURRENT: 기준 run 확인됨, 최신",
+  stale: "STALE: 기준 run은 유효하지만 더 새 run이 있습니다",
+  orphan: "ORPHAN: 기준 run을 더 이상 찾을 수 없습니다",
+  unavailable: "UNAVAILABLE: evidence를 다시 확인하지 못했습니다",
+};
+
+const FILENAME_INVALID_CHARS = /["*/:<>?\\|]/g;
+
+/** 경로 구분자 등 파일명에 쓸 수 없는 문자를 제거하고 길이를 제한한다. */
+export function sanitizeFilename(title: string): string {
+  const cleaned = title
+    .replace(FILENAME_INVALID_CHARS, "")
+    .trim()
+    .replace(/\s+/g, "_")
+    .replace(/^\.+/, "")
+    .slice(0, 80);
+  return cleaned.length > 0 ? cleaned : "report";
+}
+
+function metadataLines(report: ReportDraft, staleness: EvidenceRunStatus | null): string[] {
+  const lines = [
+    `Report: ${report.title}`,
+    `Dataset: ${report.datasetId}`,
+    `Base Run: ${report.baseRunId}`,
+    `BuildSpec digest: ${report.buildSpecDigest ?? "N/A"}`,
+    `생성 시각: ${report.createdAt}`,
+    `Evidence 조회 시각: ${report.evidenceFetchedAt}`,
+    `내보내기 시각: ${new Date().toISOString()}`,
+  ];
+  if (staleness) lines.push(`Evidence 상태: ${STATUS_LABEL[staleness]}`);
+  return lines;
+}
+
+const PROVENANCE_LABEL = {
+  BUILDER_EVIDENCE: "[Builder Evidence]",
+  KUBI_INTERPRETATION: "[AI 작성 - Kubi]",
+  USER_CONTENT: "[사용자 작성]",
+} as const;
+
+/** Markdown 파일 내용을 만든다. */
+export function generateMarkdownExport(report: ReportDraft, staleness: EvidenceRunStatus | null): string {
+  const parts = [`# ${report.title}`, "", metadataLines(report, staleness).map((line) => `- ${line}`).join("\n"), ""];
+
+  for (const block of report.blocks) {
+    if (block.provenance === "BUILDER_EVIDENCE") {
+      parts.push(`## ${block.title} ${PROVENANCE_LABEL.BUILDER_EVIDENCE}`);
+      if (block.evidenceStatus !== "ok") {
+        parts.push(`> evidence 상태: ${block.evidenceStatus}${block.unavailableReason ? ` (${block.unavailableReason})` : ""}`);
+      }
+      if (block.summary) {
+        parts.push(block.summary);
+        parts.push("### 상세 근거");
+      }
+      parts.push(block.markdown);
+    } else if (block.provenance === "KUBI_INTERPRETATION") {
+      parts.push(`## Kubi 참고 분석 ${PROVENANCE_LABEL.KUBI_INTERPRETATION}`);
+      if (!block.isSameContext) {
+        parts.push(`> 참고 분석 - 현재 Report와 다른 Run 기준 (dataset: ${block.sourceContext.datasetId ?? "N/A"}, run: ${block.sourceContext.runId ?? "N/A"})`);
+      }
+      parts.push(`생성 시각: ${block.generatedAt}${block.provider ? ` / provider: ${block.provider}` : ""}${block.model ? ` / model: ${block.model}` : ""}`);
+      parts.push(block.note);
+      parts.push(`_판단 근거: ${block.reason}_`);
+    } else {
+      parts.push(`## ${block.heading} ${PROVENANCE_LABEL.USER_CONTENT}`);
+      parts.push(block.markdown);
+    }
+    parts.push("");
+  }
+
+  return parts.join("\n");
+}
+
+const HTML_DOC_STYLE = `
+  body { font-family: -apple-system, "Segoe UI", sans-serif; color: #1a1a1a; max-width: 860px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.65; }
+  h1 { font-size: 1.6rem; } h2 { font-size: 1.2rem; margin-top: 2rem; border-bottom: 1px solid #ddd; padding-bottom: .3rem; }
+  table { border-collapse: collapse; width: 100%; margin: .75rem 0; font-size: .9rem; }
+  th, td { border: 1px solid #ddd; padding: .4rem .6rem; text-align: left; }
+  .meta { background: #f6f7f9; border: 1px solid #e2e4e8; border-radius: 8px; padding: 1rem; font-size: .85rem; }
+  .tag { display: inline-block; font-size: .7rem; font-weight: 600; padding: .1rem .5rem; border-radius: 999px; margin-left: .4rem; }
+  .tag-evidence { background: #e6f4ea; color: #1e6b3b; }
+  .tag-kubi { background: #eef0ff; color: #3730a3; }
+  .tag-user { background: #fff4e5; color: #92400e; }
+  .warn { color: #92400e; background: #fff4e5; border: 1px solid #f3d9a8; border-radius: 6px; padding: .5rem .75rem; font-size: .85rem; }
+`;
+
+/** 안전한 self-contained HTML 문서를 만든다. `<script>`는 절대 포함하지 않는다. */
+export function generateHtmlExport(report: ReportDraft, staleness: EvidenceRunStatus | null): string {
+  const meta = metadataLines(report, staleness).map((line) => `<li>${escapeHtml(line)}</li>`).join("");
+  const staleWarning =
+    staleness && staleness !== "current" ? `<p class="warn">${escapeHtml(STATUS_LABEL[staleness])}</p>` : "";
+
+  const blocksHtml = report.blocks
+    .map((block) => {
+      if (block.provenance === "BUILDER_EVIDENCE") {
+        const statusNote =
+          block.evidenceStatus !== "ok"
+            ? `<p class="warn">evidence 상태: ${escapeHtml(block.evidenceStatus)}${block.unavailableReason ? ` (${escapeHtml(block.unavailableReason)})` : ""}</p>`
+            : "";
+        const summaryHtml = block.summary
+          ? `${renderMarkdownToHtml(block.summary)}<h3>상세 근거</h3>`
+          : "";
+        return `<h2>${escapeHtml(block.title)}<span class="tag tag-evidence">Builder Evidence</span></h2>${statusNote}${summaryHtml}${renderMarkdownToHtml(block.markdown)}`;
+      }
+      if (block.provenance === "KUBI_INTERPRETATION") {
+        const contextNote = !block.isSameContext
+          ? `<p class="warn">참고 분석 - 다른 Run 기준 (dataset: ${escapeHtml(block.sourceContext.datasetId ?? "N/A")}, run: ${escapeHtml(block.sourceContext.runId ?? "N/A")})</p>`
+          : "";
+        return `<h2>Kubi 참고 분석<span class="tag tag-kubi">AI 작성</span></h2>${contextNote}<p><small>생성 시각: ${escapeHtml(block.generatedAt)}${block.provider ? ` / provider: ${escapeHtml(block.provider)}` : ""}${block.model ? ` / model: ${escapeHtml(block.model)}` : ""}</small></p>${renderMarkdownToHtml(block.note)}<p><em>판단 근거: ${escapeHtml(block.reason)}</em></p>`;
+      }
+      return `<h2>${escapeHtml(block.heading)}<span class="tag tag-user">사용자 작성</span></h2>${renderMarkdownToHtml(block.markdown)}`;
+    })
+    .join("\n");
+
+  return [
+    "<!doctype html>",
+    '<html lang="ko"><head><meta charset="utf-8" />',
+    `<title>${escapeHtml(report.title)}</title>`,
+    `<style>${HTML_DOC_STYLE}</style>`,
+    "</head><body>",
+    `<h1>${escapeHtml(report.title)}</h1>`,
+    `<ul class="meta">${meta}</ul>`,
+    staleWarning,
+    blocksHtml,
+    "</body></html>",
+  ].join("\n");
+}
+
+/** Blob을 만들어 브라우저 다운로드를 시작한다(실제 배포 웹앱 - Claude Artifact 샌드박스와 무관). */
+export function triggerDownload(filename: string, content: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+export function downloadMarkdown(report: ReportDraft, staleness: EvidenceRunStatus | null): void {
+  triggerDownload(`${sanitizeFilename(report.title)}.md`, generateMarkdownExport(report, staleness), "text/markdown;charset=utf-8");
+}
+
+export function downloadHtml(report: ReportDraft, staleness: EvidenceRunStatus | null): void {
+  triggerDownload(`${sanitizeFilename(report.title)}.html`, generateHtmlExport(report, staleness), "text/html;charset=utf-8");
+}

--- a/src/features/reports/kubiBlocks.test.ts
+++ b/src/features/reports/kubiBlocks.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { KubiReportNote } from "@/features/kubi/reportInbox";
+import { noteMatchesReportContext, reportNoteToBlock } from "./kubiBlocks";
+
+function makeNote(overrides: Partial<KubiReportNote> = {}): KubiReportNote {
+  return {
+    note: "price 결측 1.8%가 특정 지역에 집중되어 있습니다.",
+    reason: "Gold column profile 기준",
+    context: { datasetId: "air-quality", runId: "air-2026-08-14", stage: "gold" },
+    savedAt: "2026-08-14T09:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("reportNoteToBlock / noteMatchesReportContext (#258 §6, §7)", () => {
+  it("같은 dataset/run 문맥이면 isSameContext=true로 정본 문맥임을 표시한다", () => {
+    const note = makeNote();
+    const block = reportNoteToBlock(note, { datasetId: "air-quality", baseRunId: "air-2026-08-14" });
+
+    expect(block.provenance).toBe("KUBI_INTERPRETATION");
+    expect(block.isSameContext).toBe(true);
+    expect(noteMatchesReportContext(note, { datasetId: "air-quality", baseRunId: "air-2026-08-14" })).toBe(true);
+  });
+
+  it("다른 run에서 만든 note는 isSameContext=false로 남겨 참고 분석임을 구분한다(정본처럼 합치지 않음)", () => {
+    const note = makeNote({ context: { datasetId: "air-quality", runId: "air-2026-08-13" } });
+    const block = reportNoteToBlock(note, { datasetId: "air-quality", baseRunId: "air-2026-08-14" });
+
+    expect(block.isSameContext).toBe(false);
+    expect(block.sourceContext.runId).toBe("air-2026-08-13");
+  });
+
+  it("note/reason/생성시각을 그대로 보존한다(LLM 원문을 임의로 바꾸지 않음)", () => {
+    const note = makeNote();
+    const block = reportNoteToBlock(note, { datasetId: "air-quality", baseRunId: "air-2026-08-14" });
+
+    expect(block.note).toBe(note.note);
+    expect(block.reason).toBe(note.reason);
+    expect(block.generatedAt).toBe(note.savedAt);
+  });
+});

--- a/src/features/reports/kubiBlocks.ts
+++ b/src/features/reports/kubiBlocks.ts
@@ -1,0 +1,43 @@
+/**
+ * Kubi 참고 노트 → Report KUBI_INTERPRETATION 블록 변환 (#258 §6, §7).
+ *
+ * `ADD_REPORT_BLOCK`은 이미 #256에서 구현·승인되어 `features/kubi/reportInbox.ts` 큐에
+ * 쌓인다. 새 action contract를 만들지 않고 그 큐를 그대로 소비한다. 여기서 다시 한번
+ * 사용자 승인을 요구한다(#258 §7의 5단계: note 표시 → evidence 표시 → context 비교 →
+ * 사용자 승인 → 블록 추가) — Kubi 채팅에서의 승인은 "참고 노트 큐에 넣는 것"까지고, 이
+ * Report에 실제로 반영할지는 별도 승인 단계다.
+ */
+import type { KubiReportNote } from "@/features/kubi/reportInbox";
+import type { KubiInterpretationBlock, ReportDraft } from "./types";
+
+/** 큐의 note context가 이 Report의 기준 dataset/run과 같은 문맥인지 비교한다. */
+export function noteMatchesReportContext(note: KubiReportNote, report: Pick<ReportDraft, "datasetId" | "baseRunId">): boolean {
+  return note.context.datasetId === report.datasetId && note.context.runId === report.baseRunId;
+}
+
+function newBlockId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return `kubi-${crypto.randomUUID()}`;
+  return `kubi-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * 승인된 Kubi 참고 노트를 KUBI_INTERPRETATION 블록으로 변환한다.
+ *
+ * 다른 dataset/run에서 만든 note라도 그대로 추가할 수 있게 하되(#258 §7 — 완전히 막지는
+ * 않음), `isSameContext=false`로 남겨 UI가 "참고 분석 · 다른 Run 기준"으로 명확히
+ * 구분해서 보여줄 수 있게 한다. 정본 분석처럼 합치지 않는다.
+ */
+export function reportNoteToBlock(note: KubiReportNote, report: Pick<ReportDraft, "datasetId" | "baseRunId">): KubiInterpretationBlock {
+  const now = new Date().toISOString();
+  return {
+    id: newBlockId(),
+    provenance: "KUBI_INTERPRETATION",
+    note: note.note,
+    reason: note.reason,
+    sourceContext: note.context,
+    isSameContext: noteMatchesReportContext(note, report),
+    generatedAt: note.savedAt,
+    createdAt: now,
+    updatedAt: now,
+  };
+}

--- a/src/features/reports/markdown.test.ts
+++ b/src/features/reports/markdown.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { escapeHtml, isSafeHref, renderMarkdownToHtml, renderMarkdownToReact } from "./markdown";
+
+describe("markdown safety (#258 §13) — untrusted Kubi/사용자 입력을 다룬다", () => {
+  it("<script> 태그는 실행 가능한 형태로 만들지 않고 escape된 텍스트로 남는다", () => {
+    const html = renderMarkdownToHtml('<script>alert("xss")</script>');
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("javascript: 링크는 <a href>로 만들지 않는다(원문은 클릭 불가능한 escape된 텍스트로만 남는다)", () => {
+    expect(isSafeHref("javascript:alert(1)")).toBe(false);
+    const html = renderMarkdownToHtml("[클릭](javascript:alert(1))");
+    expect(html).not.toContain("<a ");
+    expect(html).not.toContain('href="javascript:');
+  });
+
+  it("http(s) 링크만 <a>로 만들고 새 창 안전 속성을 붙인다", () => {
+    expect(isSafeHref("https://example.com")).toBe(true);
+    const html = renderMarkdownToHtml("[문서](https://example.com/doc)");
+    expect(html).toContain('href="https://example.com/doc"');
+    expect(html).toContain('rel="noopener noreferrer"');
+    expect(html).toContain('target="_blank"');
+  });
+
+  it("onerror 등 이벤트 핸들러처럼 보이는 텍스트도 실행 가능한 태그로 만들지 않고 escape된 텍스트로만 남는다", () => {
+    const html = renderMarkdownToHtml('<img src=x onerror="alert(1)">');
+    expect(html).not.toContain("<img ");
+    expect(html).not.toMatch(/<img\s|<img>/);
+    expect(html).toContain("&lt;img");
+    expect(html).toContain("&quot;alert(1)&quot;");
+  });
+
+  it("React 렌더러는 dangerouslySetInnerHTML 없이도 굵게/링크/목록을 표현한다", () => {
+    const node = renderMarkdownToReact("**중요** 내용입니다.\n\n- 항목1\n- 항목2\n\n[링크](https://example.com)");
+    const markup = renderToStaticMarkup(node as never);
+    expect(markup).toContain("<strong>중요</strong>");
+    expect(markup).toContain("<li>항목1</li>");
+    expect(markup).toContain('href="https://example.com"');
+  });
+
+  it("React 렌더러도 javascript: 링크는 <a>로 만들지 않는다", () => {
+    const node = renderMarkdownToReact("[클릭](javascript:alert(1))");
+    const markup = renderToStaticMarkup(node as never);
+    expect(markup).not.toContain("<a ");
+    expect(markup).not.toContain('href="javascript:');
+  });
+
+  it("테이블을 파이프 문법으로 렌더링한다", () => {
+    const html = renderMarkdownToHtml("| a | b |\n| --- | --- |\n| 1 | 2 |");
+    expect(html).toContain("<table>");
+    expect(html).toContain("<th>a</th>");
+    expect(html).toContain("<td>1</td>");
+  });
+
+  it("escapeHtml은 5대 특수문자를 모두 이스케이프한다", () => {
+    expect(escapeHtml(`<>&"'`)).toBe("&lt;&gt;&amp;&quot;&#39;");
+  });
+});

--- a/src/features/reports/markdown.ts
+++ b/src/features/reports/markdown.ts
@@ -1,0 +1,292 @@
+/**
+ * 최소 안전 Markdown 파서/렌더러 (#258).
+ *
+ * Kubi 응답과 사용자 입력은 untrusted input으로 취급한다(#258 §13). 이 저장소에는 markdown
+ * 렌더링/HTML sanitize 라이브러리가 없고(package.json 확인 완료), 이슈 지침상 새 대형
+ * dependency를 들이기 전에 기존 코드를 재사용해야 하므로, 대신 아주 작은 subset(GFM의 일부)만
+ * 지원하는 파서를 직접 둔다 — 지원하지 않는 문법은 그냥 이스케이프된 텍스트로 남는다.
+ *
+ * 안전성의 핵심 불변식: `<script>`/`javascript:`/on* 이벤트 속성 등 임의 HTML을 절대
+ * 생성하지 않는다.
+ * - React 렌더러(`renderMarkdownToReact`)는 `dangerouslySetInnerHTML`을 전혀 쓰지 않고
+ *   React 엘리먼트만 만든다(React가 텍스트 노드를 자동 이스케이프).
+ * - HTML 문자열 렌더러(`renderMarkdownToHtml`, 내보내기용)는 원문을 절대 그대로 넣지 않고
+ *   `escapeHtml`을 통과한 텍스트만 우리가 만든 태그 사이에 넣는다.
+ * - 링크는 `http(s)://`로 시작하는 href만 허용하고, 새 창으로 열 때 `rel="noopener
+ *   noreferrer"`를 강제한다(#258 §13).
+ */
+import { Fragment, createElement, type ReactNode } from "react";
+
+// ---------------------------------------------------------------------------
+// 블록 파싱
+// ---------------------------------------------------------------------------
+
+type Block =
+  | { type: "heading"; level: 1 | 2 | 3; text: string }
+  | { type: "paragraph"; text: string }
+  | { type: "list"; ordered: boolean; items: string[] }
+  | { type: "blockquote"; text: string }
+  | { type: "table"; header: string[]; rows: string[][] }
+  | { type: "hr" };
+
+function splitTableRow(line: string): string[] {
+  const trimmed = line.trim().replace(/^\|/, "").replace(/\|$/, "");
+  return trimmed.split("|").map((cell) => cell.trim());
+}
+
+function isTableSeparatorRow(line: string): boolean {
+  const cells = splitTableRow(line);
+  return cells.length > 0 && cells.every((cell) => /^:?-{2,}:?$/.test(cell));
+}
+
+/** 텍스트를 blank-line 단위 블록으로 나눈 뒤 각 블록을 분류한다. 알 수 없는 형태는 문단으로 취급한다. */
+function parseBlocks(markdown: string): Block[] {
+  const normalized = markdown.replace(/\r\n/g, "\n");
+  const chunks = normalized.split(/\n{2,}/).map((chunk) => chunk.trim()).filter(Boolean);
+  const blocks: Block[] = [];
+
+  for (const chunk of chunks) {
+    const lines = chunk.split("\n");
+
+    if (/^-{3,}$/.test(chunk.trim())) {
+      blocks.push({ type: "hr" });
+      continue;
+    }
+
+    const headingMatch = /^(#{1,3})\s+(.*)$/.exec(lines[0]);
+    if (headingMatch && lines.length === 1) {
+      blocks.push({ type: "heading", level: headingMatch[1].length as 1 | 2 | 3, text: headingMatch[2].trim() });
+      continue;
+    }
+
+    if (lines.length >= 2 && lines[0].includes("|") && isTableSeparatorRow(lines[1])) {
+      const header = splitTableRow(lines[0]);
+      const rows = lines.slice(2).filter((line) => line.includes("|")).map(splitTableRow);
+      blocks.push({ type: "table", header, rows });
+      continue;
+    }
+
+    if (lines.every((line) => /^\s*([-*])\s+/.test(line))) {
+      blocks.push({ type: "list", ordered: false, items: lines.map((line) => line.replace(/^\s*[-*]\s+/, "")) });
+      continue;
+    }
+
+    if (lines.every((line) => /^\s*\d+\.\s+/.test(line))) {
+      blocks.push({ type: "list", ordered: true, items: lines.map((line) => line.replace(/^\s*\d+\.\s+/, "")) });
+      continue;
+    }
+
+    if (lines.every((line) => /^>\s?/.test(line))) {
+      blocks.push({ type: "blockquote", text: lines.map((line) => line.replace(/^>\s?/, "")).join(" ") });
+      continue;
+    }
+
+    blocks.push({ type: "paragraph", text: lines.join(" ") });
+  }
+
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// 인라인 토큰(굵게/기울임/코드/링크)
+// ---------------------------------------------------------------------------
+
+type InlineToken =
+  | { type: "text"; text: string }
+  | { type: "bold"; text: string }
+  | { type: "italic"; text: string }
+  | { type: "code"; text: string }
+  | { type: "link"; text: string; href: string };
+
+/** `http://`/`https://`로 시작하는 href만 안전하다고 판단한다. `javascript:` 등은 전부 거부. */
+export function isSafeHref(href: string): boolean {
+  return /^https?:\/\//i.test(href.trim());
+}
+
+const INLINE_PATTERN = /\*\*(.+?)\*\*|`(.+?)`|\*(.+?)\*|_(.+?)_|\[([^\]]+)\]\((\S+?)\)/g;
+
+function tokenizeInline(text: string): InlineToken[] {
+  const tokens: InlineToken[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  INLINE_PATTERN.lastIndex = 0;
+
+  while ((match = INLINE_PATTERN.exec(text))) {
+    if (match.index > lastIndex) tokens.push({ type: "text", text: text.slice(lastIndex, match.index) });
+
+    if (match[1] !== undefined) tokens.push({ type: "bold", text: match[1] });
+    else if (match[2] !== undefined) tokens.push({ type: "code", text: match[2] });
+    else if (match[3] !== undefined) tokens.push({ type: "italic", text: match[3] });
+    else if (match[4] !== undefined) tokens.push({ type: "italic", text: match[4] });
+    else if (match[5] !== undefined && match[6] !== undefined) {
+      const href = match[6];
+      if (isSafeHref(href)) tokens.push({ type: "link", text: match[5], href });
+      else tokens.push({ type: "text", text: `${match[5]} (${href})` });
+    }
+
+    lastIndex = INLINE_PATTERN.lastIndex;
+  }
+  if (lastIndex < text.length) tokens.push({ type: "text", text: text.slice(lastIndex) });
+  return tokens;
+}
+
+// ---------------------------------------------------------------------------
+// React 렌더러 — dangerouslySetInnerHTML을 쓰지 않는다.
+// ---------------------------------------------------------------------------
+
+function renderInlineToReact(text: string, keyPrefix: string): ReactNode[] {
+  return tokenizeInline(text).map((token, index) => {
+    const key = `${keyPrefix}-${index}`;
+    switch (token.type) {
+      case "text":
+        return token.text;
+      case "bold":
+        return createElement("strong", { key }, token.text);
+      case "italic":
+        return createElement("em", { key }, token.text);
+      case "code":
+        return createElement("code", { key, className: "rounded bg-muted px-1 py-0.5 text-xs" }, token.text);
+      case "link":
+        return createElement(
+          "a",
+          { key, href: token.href, target: "_blank", rel: "noopener noreferrer", className: "underline" },
+          token.text,
+        );
+    }
+  });
+}
+
+/** Markdown 원문을 안전한 React 엘리먼트 트리로 렌더링한다(미리보기/편집기 표시용). */
+export function renderMarkdownToReact(markdown: string): ReactNode {
+  const blocks = parseBlocks(markdown);
+  if (blocks.length === 0) return null;
+
+  return createElement(
+    Fragment,
+    null,
+    blocks.map((block, index) => {
+      const key = `block-${index}`;
+      switch (block.type) {
+        case "heading": {
+          const tag = `h${block.level + 2}`; // 문서 내 상대 크기 — h1은 Report 제목이 쓴다.
+          return createElement(tag, { key, className: "font-semibold" }, renderInlineToReact(block.text, key));
+        }
+        case "paragraph":
+          return createElement("p", { key, className: "leading-relaxed" }, renderInlineToReact(block.text, key));
+        case "list":
+          return createElement(
+            block.ordered ? "ol" : "ul",
+            { key, className: block.ordered ? "list-decimal pl-5" : "list-disc pl-5" },
+            block.items.map((item, itemIndex) =>
+              createElement("li", { key: `${key}-${itemIndex}` }, renderInlineToReact(item, `${key}-${itemIndex}`)),
+            ),
+          );
+        case "blockquote":
+          return createElement(
+            "blockquote",
+            { key, className: "border-l-2 border-border pl-3 italic text-muted-foreground" },
+            renderInlineToReact(block.text, key),
+          );
+        case "table":
+          return createElement(
+            "div",
+            { key, className: "overflow-x-auto" },
+            createElement(
+              "table",
+              { className: "w-full text-left text-sm" },
+              createElement(
+                "thead",
+                null,
+                createElement(
+                  "tr",
+                  null,
+                  block.header.map((cell, cellIndex) =>
+                    createElement("th", { key: cellIndex, className: "border-b border-border px-2 py-1 font-semibold" }, cell),
+                  ),
+                ),
+              ),
+              createElement(
+                "tbody",
+                null,
+                block.rows.map((row, rowIndex) =>
+                  createElement(
+                    "tr",
+                    { key: rowIndex },
+                    row.map((cell, cellIndex) =>
+                      createElement("td", { key: cellIndex, className: "border-b border-border px-2 py-1" }, cell),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+        case "hr":
+          return createElement("hr", { key, className: "border-border" });
+      }
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// HTML 문자열 렌더러 — export/print용. 원문은 escapeHtml을 거친 뒤에만 태그 안에 들어간다.
+// ---------------------------------------------------------------------------
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderInlineToHtml(text: string): string {
+  return tokenizeInline(text)
+    .map((token) => {
+      switch (token.type) {
+        case "text":
+          return escapeHtml(token.text);
+        case "bold":
+          return `<strong>${escapeHtml(token.text)}</strong>`;
+        case "italic":
+          return `<em>${escapeHtml(token.text)}</em>`;
+        case "code":
+          return `<code>${escapeHtml(token.text)}</code>`;
+        case "link":
+          // href는 isSafeHref로 이미 http(s)만 허용됨. 속성 값 자체도 이스케이프한다.
+          return `<a href="${escapeHtml(token.href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(token.text)}</a>`;
+      }
+    })
+    .join("");
+}
+
+/** Markdown 원문을 안전한 HTML 문자열로 렌더링한다(내보내기/인쇄용). */
+export function renderMarkdownToHtml(markdown: string): string {
+  const blocks = parseBlocks(markdown);
+  return blocks
+    .map((block) => {
+      switch (block.type) {
+        case "heading":
+          return `<h${block.level + 2}>${renderInlineToHtml(block.text)}</h${block.level + 2}>`;
+        case "paragraph":
+          return `<p>${renderInlineToHtml(block.text)}</p>`;
+        case "list": {
+          const tag = block.ordered ? "ol" : "ul";
+          const items = block.items.map((item) => `<li>${renderInlineToHtml(item)}</li>`).join("");
+          return `<${tag}>${items}</${tag}>`;
+        }
+        case "blockquote":
+          return `<blockquote>${renderInlineToHtml(block.text)}</blockquote>`;
+        case "table": {
+          const header = block.header.map((cell) => `<th>${renderInlineToHtml(cell)}</th>`).join("");
+          const rows = block.rows
+            .map((row) => `<tr>${row.map((cell) => `<td>${renderInlineToHtml(cell)}</td>`).join("")}</tr>`)
+            .join("");
+          return `<table><thead><tr>${header}</tr></thead><tbody>${rows}</tbody></table>`;
+        }
+        case "hr":
+          return "<hr />";
+      }
+    })
+    .join("\n");
+}

--- a/src/features/reports/narrativeSummary.test.ts
+++ b/src/features/reports/narrativeSummary.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { fetchReportEvidence } from "./evidence";
+import {
+  buildDataSummarySummary,
+  buildOutputSummary,
+  buildOverviewSummary,
+  buildPipelineSummary,
+  buildQualitySummary,
+  buildSchemaSummary,
+  computeQualityCounts,
+} from "./narrativeSummary";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("narrativeSummary (#258 IA 개편)", () => {
+  describe("buildOverviewSummary", () => {
+    it("실제 evidence 값(제목/run id/provider/run 상태)만으로 문장을 만든다", async () => {
+      const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+      const summary = buildOverviewSummary(evidence);
+
+      expect(summary).toContain("대기질 통합 데이터");
+      expect(summary).toContain("air-2026-08-14");
+      expect(summary).toContain("data.go.kr");
+      expect(summary).toContain("kma");
+      expect(summary).toContain("failed");
+    });
+
+    it("dataset 조회가 실패하면 개요를 요약할 수 없다고 말하고 값을 지어내지 않는다", async () => {
+      const evidence = await fetchReportEvidence("does-not-exist", "does-not-exist-run");
+      const summary = buildOverviewSummary(evidence);
+      expect(summary).toContain("요약할 수 없습니다");
+      expect(summary).not.toMatch(/Provider의 Source로 구성되어 있습니다\.\s*$/);
+    });
+  });
+
+  describe("buildPipelineSummary", () => {
+    it("실패한 source는 실패 사실과 다음 단계 미실행을 그대로 문장화한다", async () => {
+      const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+      const summary = buildPipelineSummary(evidence);
+
+      expect(summary).toContain("datago__air");
+      expect(summary).toContain("kma__weather");
+      expect(summary).toContain("Silver 단계에서 실패하여 Gold 단계가 실행되지 않았습니다");
+      expect(summary).toContain("Bronze → Silver → Gold까지 모두 정상 처리되었습니다");
+    });
+  });
+
+  describe("buildQualitySummary / computeQualityCounts", () => {
+    it("실제 PASS/FAIL 건수와 개별 결과를 문장으로 만든다(WARN 0건은 생략)", async () => {
+      const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+      const summary = buildQualitySummary(evidence);
+      const counts = computeQualityCounts(evidence);
+
+      expect(counts).toEqual({ pass: 1, warn: 0, fail: 1, evaluated: 2 });
+      expect(summary).toContain("총 2건의 품질 검사가 평가되었습니다");
+      expect(summary).toContain("1건은 PASS");
+      expect(summary).toContain("1건은 FAIL");
+      expect(summary).not.toContain("0건은 WARN");
+      // 실제 규칙별 서술: pm10 결측률 PASS, temperature 필수 컬럼 FAIL
+      expect(summary).toContain("pm10");
+      expect(summary).toContain("1.0%");
+      expect(summary).toContain("temperature");
+      expect(summary).toContain("확인되지 않아 FAIL했습니다");
+    });
+
+    it("quality availability=unavailable이면 PASS/0으로 꾸미지 않고 counts도 채우지 않는다", async () => {
+      const evidence = await fetchReportEvidence("population", "population-2026-08-13");
+      const summary = buildQualitySummary(evidence);
+      const counts = computeQualityCounts(evidence);
+
+      expect(summary).toContain("PASS로 간주하지 않습니다");
+      expect(summary).not.toMatch(/\d건은 PASS/);
+      expect(counts).toBeNull();
+    });
+
+    it("quality 조회 자체가 실패하면 counts를 채우지 않는다", async () => {
+      const evidence = await fetchReportEvidence("does-not-exist", "does-not-exist-run");
+      expect(computeQualityCounts(evidence)).toBeNull();
+      expect(buildQualitySummary(evidence)).toContain("불러오지 못해");
+    });
+  });
+
+  describe("buildSchemaSummary", () => {
+    it("silver schema가 있는 source는 컬럼명을 나열하고, 없는 source는 확인 불가로 구분한다", async () => {
+      const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+      const summary = buildSchemaSummary(evidence);
+
+      expect(summary).toContain("observed_at");
+      expect(summary).toContain("value");
+      expect(summary).toContain("kma__weather");
+      expect(summary).toContain("해당 단계의 Schema를 확인할 수 없습니다");
+    });
+  });
+
+  describe("buildDataSummarySummary", () => {
+    it("실제 total_row_count/row_counts만 사용하고 0으로 대체하지 않는다", async () => {
+      const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+      const summary = buildDataSummarySummary(evidence);
+
+      expect(summary).toContain("1,200건");
+      expect(summary).toContain("1,000건");
+      expect(summary).toContain("200건");
+    });
+
+    it("dataset 조회가 실패하면 0건이 아니라 확인할 수 없다고 말한다", async () => {
+      const evidence = await fetchReportEvidence("does-not-exist", "does-not-exist-run");
+      const summary = buildDataSummarySummary(evidence);
+      expect(summary).not.toContain("0건");
+      expect(summary).toContain("확인할 수 없");
+    });
+  });
+
+  describe("buildOutputSummary", () => {
+    it("mock/demo 모드에서는 output을 확인할 수 없다고 말하고 같은 경고를 두 번 반복하지 않는다", async () => {
+      const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+      const summary = buildOutputSummary(evidence);
+
+      expect(summary).toContain("Output 확인 불가");
+      // "확인할 수 없" 표현이 한 번만 등장한다(중복 경고 금지, #258 IA 개편 §4).
+      const occurrences = summary.split("확인").length - 1;
+      expect(occurrences).toBeLessThanOrEqual(2);
+    });
+  });
+});

--- a/src/features/reports/narrativeSummary.ts
+++ b/src/features/reports/narrativeSummary.ts
@@ -1,0 +1,272 @@
+/**
+ * Report 본문 요약 문장 생성 (#258 IA 개편 — 표만 나열하는 조회 화면이 아니라 "읽을 수 있는
+ * 보고서 본문"이 먼저 보이게 한다).
+ *
+ * `deterministicSections.ts`가 만드는 상세 표(BuilderEvidenceBlock.markdown)는 그대로 두고,
+ * 그 앞에 놓일 문장 요약만 이 파일에서 만든다. 값은 전부 `ReportEvidenceBundle`(Builder에서
+ * 그대로 가져온 값)에서만 가져오며 LLM은 관여하지 않는다 — row count/PASS·WARN·FAIL/schema/
+ * pipeline status/실제값·기준값 중 어떤 것도 새로 만들지 않는다(#258 §4와 동일 불변식).
+ * 확인하지 못한 값은 "확인할 수 없습니다"라고 쓰지 0/PASS로 꾸미지 않는다.
+ */
+import {
+  flattenQualityResults,
+  flattenSchemaDrift,
+  formatQualityValue,
+  isDuplicateCategory,
+  isMissingCategory,
+  isSchemaCategory,
+} from "@/features/quality/model";
+import type { QualityCheckResult, SchemaDriftFinding, StageStatus } from "@/shared/lib/builderApi";
+import type { ReportEvidenceBundle, ReportSourceSchema } from "./evidence";
+import type { BuilderEvidenceSection } from "./types";
+
+const UNAVAILABLE = "확인할 수 없습니다.";
+
+type StageTriple = { bronze: StageStatus; silver: StageStatus; gold: StageStatus };
+
+const STAGE_LABEL: Record<keyof StageTriple, string> = {
+  bronze: "Bronze",
+  silver: "Silver",
+  gold: "Gold",
+};
+
+const STAGE_ICON: Record<StageStatus, string> = {
+  completed: "✓",
+  failed: "✕",
+  not_run: "미실행",
+  unavailable: "확인 불가",
+};
+
+export interface QualityCounts {
+  pass: number;
+  warn: number;
+  fail: number;
+  evaluated: number;
+}
+
+// ---------------------------------------------------------------------------
+// 1. 데이터 개요
+// ---------------------------------------------------------------------------
+
+export function buildOverviewSummary(evidence: ReportEvidenceBundle): string {
+  if (!evidence.dataset.ok) {
+    return `\`${evidence.datasetId}\` 정보를 불러오지 못해 개요를 요약할 수 없습니다(${evidence.dataset.reason}).`;
+  }
+  const dataset = evidence.dataset.value;
+  const providers = [...new Set(dataset.sources.map((s) => s.provider))].join(", ") || UNAVAILABLE;
+  const runStatus = evidence.run.ok ? evidence.run.value.status : null;
+
+  return [
+    `이 보고서는 \`${dataset.title}\`의 Build \`${evidence.runId}\`를 기준으로 작성되었습니다.`,
+    `데이터는 ${providers} Provider의 Source로 구성되어 있습니다.`,
+    runStatus ? `해당 Run은 ${runStatus} 상태로 종료되었습니다.` : `해당 Run의 종료 상태는 ${UNAVAILABLE}`,
+  ].join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// 2. 처리 흐름
+// ---------------------------------------------------------------------------
+
+function pipelineFlowLine(sourceKey: string, stage: StageTriple): string {
+  // 마크다운 렌더러는 한 줄바꿈을 별도 줄로 만들지 않으므로(GFM hard-break 미지원), 소스명과
+  // 흐름을 각자 문단으로 나눠 굵은 글씨 줄이 실제로 별도 줄에 보이게 한다.
+  return `**${sourceKey}**\n\nSource → Bronze ${STAGE_ICON[stage.bronze]} → Silver ${STAGE_ICON[stage.silver]} → Gold ${STAGE_ICON[stage.gold]}`;
+}
+
+function pipelineSourceSentence(sourceKey: string, stage: StageTriple): string {
+  if (stage.gold === "completed") {
+    return `\`${sourceKey}\`는 Bronze → Silver → Gold까지 모두 정상 처리되었습니다.`;
+  }
+
+  const order: Array<[keyof StageTriple, StageStatus]> = [
+    ["bronze", stage.bronze],
+    ["silver", stage.silver],
+    ["gold", stage.gold],
+  ];
+
+  const failedIndex = order.findIndex(([, status]) => status === "failed");
+  if (failedIndex !== -1) {
+    const [failedStage] = order[failedIndex];
+    const next = order[failedIndex + 1];
+    if (next && next[1] === "not_run") {
+      return `\`${sourceKey}\`는 ${STAGE_LABEL[failedStage]} 단계에서 실패하여 ${STAGE_LABEL[next[0]]} 단계가 실행되지 않았습니다.`;
+    }
+    return `\`${sourceKey}\`는 ${STAGE_LABEL[failedStage]} 단계에서 실패했습니다.`;
+  }
+
+  const stalled = order.find(([, status]) => status !== "completed");
+  if (stalled) {
+    const [name, status] = stalled;
+    return status === "not_run"
+      ? `\`${sourceKey}\`는 ${STAGE_LABEL[name]} 단계가 아직 실행되지 않았습니다.`
+      : `\`${sourceKey}\`는 ${STAGE_LABEL[name]} 단계 상태를 확인할 수 없습니다.`;
+  }
+
+  return `\`${sourceKey}\`의 처리 상태를 확인할 수 없습니다.`;
+}
+
+export function buildPipelineSummary(evidence: ReportEvidenceBundle): string {
+  const sources: Array<[string, StageTriple]> = evidence.stages.ok
+    ? evidence.stages.value.sources.map((s) => [
+        s.source_key,
+        { bronze: s.bronze.status, silver: s.silver.status, gold: s.gold.status },
+      ])
+    : evidence.dataset.ok
+      ? Object.entries(evidence.dataset.value.stages)
+      : [];
+
+  if (sources.length === 0) {
+    return `처리 흐름 정보를 ${UNAVAILABLE}`;
+  }
+
+  const flows = sources.map(([key, stage]) => pipelineFlowLine(key, stage)).join("\n\n");
+  const sentences = sources.map(([key, stage]) => pipelineSourceSentence(key, stage)).join(" ");
+  return `${flows}\n\n${sentences}`;
+}
+
+// ---------------------------------------------------------------------------
+// 3. 품질 진단
+// ---------------------------------------------------------------------------
+
+/** 실제 evidence가 있을 때만 값을 채운다(quality 응답 자체가 없거나 availability=unavailable이면 null). */
+export function computeQualityCounts(evidence: ReportEvidenceBundle): QualityCounts | null {
+  if (!evidence.quality.ok || evidence.quality.value.availability === "unavailable") return null;
+  const results = flattenQualityResults(evidence.quality.value);
+  return {
+    pass: results.filter((r) => r.status === "pass").length,
+    warn: results.filter((r) => r.status === "warn").length,
+    fail: results.filter((r) => r.status === "fail").length,
+    evaluated: results.length,
+  };
+}
+
+function qualityResultSentence(result: QualityCheckResult): string {
+  const source = `\`${result.source_key}\``;
+  const column = result.column ? `\`${result.column}\`` : null;
+  const verb = result.status === "pass" ? "PASS" : result.status === "warn" ? "WARN" : "FAIL";
+
+  if (isMissingCategory(result.category) && result.rule === "max_null_ratio") {
+    const actual = formatQualityValue(result.rule, result.actual);
+    const threshold = formatQualityValue(result.rule, result.threshold);
+    const compare = result.status === "pass" ? "이내여서" : "초과해";
+    return `${source}의 ${column ?? "대상 컬럼"} 결측률은 ${actual}로 기준값 ${threshold} ${compare} ${verb}했습니다.`;
+  }
+  if (isSchemaCategory(result.category) && result.rule === "required_column") {
+    if (result.status === "pass") return `${source}에서 필수 컬럼 ${column ?? ""}이 확인되어 ${verb}했습니다.`;
+    return `${source}에서는 필수 컬럼 ${column ?? ""}이 확인되지 않아 ${verb}했습니다.${result.detail ? ` (${result.detail})` : ""}`;
+  }
+  if (result.rule === "min_rows") {
+    const actual = formatQualityValue(result.rule, result.actual);
+    const threshold = formatQualityValue(result.rule, result.threshold);
+    return `${source}의 행 수는 ${actual}로 기준값 ${threshold} ${result.status === "pass" ? "이상이어서" : "미달해"} ${verb}했습니다.`;
+  }
+  if (isDuplicateCategory(result.category)) {
+    const actual = formatQualityValue(result.rule, result.actual);
+    const threshold = formatQualityValue(result.rule, result.threshold);
+    return `${source}의 중복률은 ${actual}로 기준값 ${threshold} ${result.status === "pass" ? "이내여서" : "초과해"} ${verb}했습니다.`;
+  }
+
+  // 알 수 없는 rule은 의미를 추측하지 않고 실제값/기준값을 그대로 서술한다.
+  const actual = formatQualityValue(result.rule, result.actual);
+  const threshold = formatQualityValue(result.rule, result.threshold);
+  return `${source}의 \`${result.rule}\`${column ? ` (${column})` : ""} 결과는 ${verb}입니다(실제값 ${actual}, 기준값 ${threshold}).${result.detail ? ` ${result.detail}` : ""}`;
+}
+
+function schemaDriftSentence(drift: SchemaDriftFinding[]): string {
+  if (drift.length === 0) return "";
+  return `Schema drift: ${drift.map((d) => `\`${d.column ?? "N/A"}\` ${d.kind}(${d.detail})`).join(", ")}`;
+}
+
+export function buildQualitySummary(evidence: ReportEvidenceBundle): string {
+  if (!evidence.quality.ok) {
+    return `Quality 결과를 불러오지 못해 요약할 수 없습니다(${evidence.quality.reason}).`;
+  }
+  const quality = evidence.quality.value;
+  if (quality.availability === "unavailable") {
+    return `이 run은 Quality 평가가 제공되지 않습니다(availability=unavailable). PASS로 간주하지 않습니다.`;
+  }
+
+  const results = flattenQualityResults(quality);
+  if (results.length === 0) {
+    return `기준 Run에서는 평가된 품질 규칙이 없습니다(evaluated_checks=0).`;
+  }
+
+  const pass = results.filter((r) => r.status === "pass").length;
+  const warn = results.filter((r) => r.status === "warn").length;
+  const fail = results.filter((r) => r.status === "fail").length;
+  // WARN이 0건이면 문장에서 생략한다(예시처럼 PASS/FAIL만 자연스럽게 언급) — 그래도 evaluated_checks
+  // 분모는 항상 실제 건수를 그대로 쓴다.
+  const parts = [`${pass}건은 PASS`, warn > 0 ? `${warn}건은 WARN` : null, `${fail}건은 FAIL`].filter(
+    (part): part is string => part !== null,
+  );
+  const header = `기준 Run에서는 총 ${results.length}건의 품질 검사가 평가되었습니다. 이 중 ${parts.join(", ")}입니다.`;
+  const detail = results.map(qualityResultSentence).join(" ");
+  const drift = schemaDriftSentence(flattenSchemaDrift(quality));
+
+  return [header, detail, drift].filter(Boolean).join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// 4. 데이터 구조
+// ---------------------------------------------------------------------------
+
+function schemaSourceSentence(sourceKey: string, schema: ReportSourceSchema): string {
+  const source = `\`${sourceKey}\``;
+  if (schema.origin === "silver") {
+    const columns = schema.columns.map((c) => `\`${c.name}\``).join(", ");
+    return `${source} Silver 결과에서는 ${columns} 컬럼이 확인되었습니다.`;
+  }
+  if (schema.origin === "gold_names_only") {
+    const columns = (schema.columnNamesOnly ?? []).map((name) => `\`${name}\``).join(", ") || UNAVAILABLE;
+    return `${source}는 Silver schema를 확인할 수 없어 Gold 결과의 컬럼 이름만 확인됩니다: ${columns}.`;
+  }
+  return `${source}는 해당 단계의 Schema를 확인할 수 없습니다.${schema.reason ? ` (${schema.reason})` : ""}`;
+}
+
+export function buildSchemaSummary(evidence: ReportEvidenceBundle): string {
+  const entries = Object.entries(evidence.schemas);
+  if (entries.length === 0) return `Schema 정보를 불러올 source가 없어 ${UNAVAILABLE}`;
+  return entries.map(([sourceKey, schema]) => schemaSourceSentence(sourceKey, schema)).join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// 5. 데이터 규모
+// ---------------------------------------------------------------------------
+
+export function buildDataSummarySummary(evidence: ReportEvidenceBundle): string {
+  if (!evidence.dataset.ok) {
+    return `Row count 정보를 ${UNAVAILABLE}(${evidence.dataset.reason})`;
+  }
+  const dataset = evidence.dataset.value;
+  const rows = Object.entries(dataset.row_counts);
+  const totalLine = `확인 가능한 Source의 총 행 수는 ${dataset.total_row_count.toLocaleString("ko-KR")}건입니다.`;
+  if (rows.length === 0) return `${totalLine} source별 세부 정보는 ${UNAVAILABLE}`;
+  const bySource = rows.map(([key, count]) => `\`${key}\` ${count.toLocaleString("ko-KR")}건`).join(", ");
+  return `${totalLine} ${bySource}으로 구성됩니다.`;
+}
+
+// ---------------------------------------------------------------------------
+// 6. Output
+// ---------------------------------------------------------------------------
+
+export function buildOutputSummary(evidence: ReportEvidenceBundle): string {
+  if (!evidence.output.ok) {
+    return `**Output 확인 불가**\n\n${evidence.output.reason}`;
+  }
+  const files = evidence.output.value.files;
+  if (files.length === 0) return `이 run에 대해 보고된 output 파일이 없습니다.`;
+  return `이 run에는 총 ${files.length}개의 output 파일이 있습니다: ${files.map((f) => `\`${f}\``).join(", ")}.`;
+}
+
+// ---------------------------------------------------------------------------
+
+export function buildSectionSummaries(evidence: ReportEvidenceBundle): Record<BuilderEvidenceSection, string> {
+  return {
+    overview: buildOverviewSummary(evidence),
+    pipeline: buildPipelineSummary(evidence),
+    quality: buildQualitySummary(evidence),
+    schema: buildSchemaSummary(evidence),
+    data_summary: buildDataSummarySummary(evidence),
+    output: buildOutputSummary(evidence),
+  };
+}

--- a/src/features/reports/repository.test.ts
+++ b/src/features/reports/repository.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  REPORT_STORE_LIMIT,
+  createReport,
+  deleteReport,
+  duplicateReport,
+  getReport,
+  hasAnyReport,
+  listReportSummaries,
+  renameReport,
+  saveReport,
+} from "./repository";
+import type { ReportDraft } from "./types";
+
+function makeInput(overrides: Partial<Parameters<typeof createReport>[0]> = {}) {
+  return {
+    title: "테스트 Report",
+    datasetId: "air-quality",
+    baseRunId: "air-2026-08-14",
+    buildSpecDigest: "sha256:air14",
+    evidenceFetchedAt: "2026-08-14T08:00:00Z",
+    blocks: [],
+    evidenceRefs: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("reports repository (#258 §11)", () => {
+  it("여러 Report를 각자의 id로 저장하고 목록으로 나열한다", () => {
+    const a = createReport(makeInput({ title: "A" }));
+    const b = createReport(makeInput({ title: "B" }));
+    expect(a.result.ok).toBe(true);
+    expect(b.result.ok).toBe(true);
+    expect(a.report.id).not.toBe(b.report.id);
+
+    const summaries = listReportSummaries();
+    expect(summaries.map((s) => s.title).sort()).toEqual(["A", "B"]);
+    expect(hasAnyReport()).toBe(true);
+  });
+
+  it("생성 시점의 datasetId/baseRunId를 저장한 뒤 다시 읽어도 그대로 유지한다(run pin)", () => {
+    const { report } = createReport(makeInput({ datasetId: "air-quality", baseRunId: "air-2026-08-13" }));
+    const reloaded = getReport(report.id);
+    expect(reloaded?.datasetId).toBe("air-quality");
+    expect(reloaded?.baseRunId).toBe("air-2026-08-13");
+
+    // evidence를 다시 채워 저장해도(예: refresh) baseRunId 자체는 호출부가 바꾸지 않는 한 유지된다.
+    saveReport({ ...reloaded!, evidenceFetchedAt: "2026-08-15T00:00:00Z" });
+    expect(getReport(report.id)?.baseRunId).toBe("air-2026-08-13");
+  });
+
+  it("제목을 바꾼다(rename)", () => {
+    const { report } = createReport(makeInput({ title: "원래 제목" }));
+    const result = renameReport(report.id, "새 제목");
+    expect(result.ok).toBe(true);
+    expect(getReport(report.id)?.title).toBe("새 제목");
+  });
+
+  it("복제하면 새 id를 갖고 블록/참조는 독립적으로 복사된다(duplicate)", () => {
+    const { report } = createReport(
+      makeInput({ blocks: [{ id: "b1", provenance: "USER_CONTENT", heading: "h", markdown: "m", createdAt: "x", updatedAt: "x" }] }),
+    );
+    const outcome = duplicateReport(report.id);
+    expect(outcome?.result.ok).toBe(true);
+    expect(outcome?.report.id).not.toBe(report.id);
+    expect(outcome?.report.blocks).toHaveLength(1);
+
+    // 복제본을 수정해도 원본에는 영향이 없어야 한다(참조 공유 없음).
+    const clonedId = outcome!.report.id;
+    const cloned = getReport(clonedId)!;
+    saveReport({ ...cloned, blocks: [] });
+    expect(getReport(report.id)?.blocks).toHaveLength(1);
+  });
+
+  it("삭제하면 목록/조회에서 사라진다(delete)", () => {
+    const { report } = createReport(makeInput());
+    expect(deleteReport(report.id)).toBe(true);
+    expect(getReport(report.id)).toBeNull();
+    expect(listReportSummaries().find((s) => s.id === report.id)).toBeUndefined();
+  });
+
+  it("없는 id를 삭제/이름변경/복제하면 실패를 알린다", () => {
+    expect(deleteReport("no-such-id")).toBe(false);
+    expect(renameReport("no-such-id", "x").ok).toBe(false);
+    expect(duplicateReport("no-such-id")).toBeNull();
+  });
+
+  it("낮은 revision으로 저장을 시도하면(다른 탭이 먼저 저장) 거부하고 conflict를 알린다", () => {
+    const { report } = createReport(makeInput());
+    const reloaded1 = getReport(report.id)!;
+    const reloaded2 = getReport(report.id)!;
+
+    // 탭 1이 먼저 저장해 revision을 올린다.
+    const first = saveReport({ ...reloaded1, title: "탭1이 저장" });
+    expect(first.ok).toBe(true);
+
+    // 탭 2는 옛 revision을 들고 있다가 저장을 시도한다.
+    const second = saveReport({ ...reloaded2, title: "탭2가 저장" });
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.conflict).toBe(true);
+
+    // 탭 1의 내용이 보존되어 있어야 한다(덮어써지지 않음).
+    expect(getReport(report.id)?.title).toBe("탭1이 저장");
+  });
+
+  it("force:true면 conflict를 무시하고 덮어쓴다(사용자가 명시적으로 선택했을 때만)", () => {
+    const { report } = createReport(makeInput());
+    const stale = getReport(report.id)!;
+    saveReport({ ...stale, title: "먼저 저장" });
+
+    const forced = saveReport({ ...stale, title: "강제 덮어쓰기" }, { force: true });
+    expect(forced.ok).toBe(true);
+    expect(getReport(report.id)?.title).toBe("강제 덮어쓰기");
+  });
+
+  it("저장소 사용이 불가능하면(quota 초과) 저장된 것처럼 보이지 않고 명시적으로 실패를 알린다", () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota exceeded", "QuotaExceededError");
+    });
+
+    const { result } = createReport(makeInput());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toContain("저장 공간");
+
+    setItemSpy.mockRestore();
+  });
+
+  it("저장 가능한 최대 개수를 넘으면 새 Report 저장을 거부한다(자동 삭제하지 않음)", () => {
+    for (let i = 0; i < REPORT_STORE_LIMIT; i++) {
+      const { result } = createReport(makeInput({ title: `report-${i}` }));
+      expect(result.ok).toBe(true);
+    }
+    const { result: overflow } = createReport(makeInput({ title: "overflow" }));
+    expect(overflow.ok).toBe(false);
+    expect(listReportSummaries()).toHaveLength(REPORT_STORE_LIMIT);
+  });
+
+  it("evidenceRefs/blocks를 저장한 그대로 되돌려준다(provenance 보존)", () => {
+    const blocks: ReportDraft["blocks"] = [
+      { id: "e1", provenance: "BUILDER_EVIDENCE", section: "overview", title: "1. Overview", markdown: "x", evidenceStatus: "ok", createdAt: "x", updatedAt: "x" },
+      { id: "k1", provenance: "KUBI_INTERPRETATION", note: "note", reason: "reason", sourceContext: {}, isSameContext: true, generatedAt: "x", createdAt: "x", updatedAt: "x" },
+      { id: "u1", provenance: "USER_CONTENT", heading: "h", markdown: "m", createdAt: "x", updatedAt: "x" },
+    ];
+    const { report } = createReport(makeInput({ blocks }));
+    const reloaded = getReport(report.id)!;
+    expect(reloaded.blocks.map((b) => b.provenance)).toEqual(["BUILDER_EVIDENCE", "KUBI_INTERPRETATION", "USER_CONTENT"]);
+  });
+});

--- a/src/features/reports/repository.ts
+++ b/src/features/reports/repository.ts
@@ -1,0 +1,215 @@
+/**
+ * Report Draft 로컬 저장소 (#258).
+ *
+ * `draftStorage.ts`/`specStore.ts`와 같은 `{version, ...}` 봉투 규약을 따르되, 단일 키에
+ * 하나만 저장하던 그 모듈들과 달리 **여러 Report를 각자의 id로 저장**한다(#258 §11 —
+ * "단일 localStorage key 하나에 Report 하나만 저장하는 구조는 피한다"). `#260 Workspace`가
+ * 나중에 같은 저장 계층을 재사용할 수 있도록 이 파일의 함수 시그니처만 의존하게 하고,
+ * 내부 표현(localStorage 봉투)은 자유롭게 바꿀 수 있는 여지를 남긴다.
+ *
+ * 저장 실패(quota 초과/storage 사용 불가/직렬화 실패)를 조용히 삼키지 않는다 — 호출부가
+ * "저장됨"이라고 잘못 표시하지 않도록 항상 명시적 결과를 반환한다(#258 §11, §12).
+ */
+import { REPORT_VERSION, type ReportDraft, type ReportSummary } from "./types";
+
+const STORE_KEY = "kpubdata-studio:reports";
+export const STORE_VERSION = 1;
+
+/** 저장 가능한 최대 Report 수. 넘으면 가장 오래 수정되지 않은 것부터 저장을 거부한다(자동 삭제하지 않음). */
+export const REPORT_STORE_LIMIT = 30;
+
+interface StoreEnvelope {
+  version: number;
+  reports: Record<string, ReportDraft>;
+}
+
+export type SaveResult =
+  | { ok: true; revision: number }
+  | { ok: false; reason: string; conflict?: boolean };
+
+function emptyEnvelope(): StoreEnvelope {
+  return { version: STORE_VERSION, reports: {} };
+}
+
+function isStorageAvailable(): boolean {
+  try {
+    return typeof localStorage !== "undefined";
+  } catch {
+    return false;
+  }
+}
+
+/** 저장된 봉투를 읽는다. 없거나 버전이 다르거나 손상되면 빈 봉투를 반환한다(손상 값은 정리). */
+function readEnvelope(): StoreEnvelope {
+  if (!isStorageAvailable()) return emptyEnvelope();
+  try {
+    const raw = localStorage.getItem(STORE_KEY);
+    if (!raw) return emptyEnvelope();
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      (parsed as StoreEnvelope).version !== STORE_VERSION ||
+      typeof (parsed as StoreEnvelope).reports !== "object" ||
+      (parsed as StoreEnvelope).reports === null
+    ) {
+      localStorage.removeItem(STORE_KEY);
+      return emptyEnvelope();
+    }
+    return parsed as StoreEnvelope;
+  } catch {
+    return emptyEnvelope();
+  }
+}
+
+/**
+ * 봉투를 저장한다. 성공/실패를 그대로 알린다 — quota 초과·storage 미지원·직렬화 실패를
+ * 구분해 이유를 돌려주고, 실패했는데도 저장된 것처럼 보이게 하지 않는다.
+ */
+function writeEnvelope(envelope: StoreEnvelope): SaveResult {
+  if (!isStorageAvailable()) {
+    return { ok: false, reason: "이 브라우저에서 로컬 저장소를 사용할 수 없습니다(프라이빗 모드 등)." };
+  }
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(envelope);
+  } catch {
+    return { ok: false, reason: "Report 내용을 저장 형식으로 변환하지 못했습니다." };
+  }
+  try {
+    localStorage.setItem(STORE_KEY, serialized);
+    return { ok: true, revision: 0 };
+  } catch (cause) {
+    const isQuota =
+      cause instanceof DOMException &&
+      (cause.name === "QuotaExceededError" || cause.name === "NS_ERROR_DOM_QUOTA_REACHED" || cause.code === 22);
+    return {
+      ok: false,
+      reason: isQuota
+        ? "저장 공간이 부족합니다. 오래된 Report를 삭제한 뒤 다시 시도하세요."
+        : "Report를 저장하지 못했습니다.",
+    };
+  }
+}
+
+function newId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
+  return `report-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/** 저장된 Report 목록을 최근 수정 순으로 요약해 반환한다. */
+export function listReportSummaries(): ReportSummary[] {
+  const envelope = readEnvelope();
+  return Object.values(envelope.reports)
+    .map((report) => ({
+      id: report.id,
+      title: report.title,
+      datasetId: report.datasetId,
+      baseRunId: report.baseRunId,
+      createdAt: report.createdAt,
+      updatedAt: report.updatedAt,
+    }))
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+/** id로 Report 전체를 불러온다. 없으면 null. */
+export function getReport(id: string): ReportDraft | null {
+  if (!id) return null;
+  return readEnvelope().reports[id] ?? null;
+}
+
+/**
+ * Report를 저장한다(생성/수정 공용). 이미 저장된 revision보다 낮은 revision으로 저장을
+ * 시도하면(다른 탭에서 먼저 저장한 경우) 기본적으로 거부한다 — 복잡한 3-way merge 대신
+ * "먼저 저장한 내용을 보존하고 사용자에게 알린다"는 최소 안전 모델을 따른다(#258 §13).
+ * `force: true`를 넘기면 그래도 덮어쓴다(사용자가 명시적으로 선택했을 때만 호출부가 사용).
+ */
+export function saveReport(report: ReportDraft, options: { force?: boolean } = {}): SaveResult {
+  const envelope = readEnvelope();
+  const existing = envelope.reports[report.id];
+
+  if (existing && !options.force && existing.revision > report.revision) {
+    return {
+      ok: false,
+      conflict: true,
+      reason: "다른 탭 또는 창에서 이 Report를 먼저 저장했습니다. 최신 내용을 다시 불러온 뒤 저장하세요.",
+    };
+  }
+
+  const keys = Object.keys(envelope.reports);
+  if (!existing && keys.length >= REPORT_STORE_LIMIT) {
+    return {
+      ok: false,
+      reason: `저장 가능한 Report 수(${REPORT_STORE_LIMIT}개)를 초과했습니다. 사용하지 않는 Report를 먼저 삭제하세요.`,
+    };
+  }
+
+  const nextRevision = (existing?.revision ?? 0) + 1;
+  const toStore: ReportDraft = { ...report, revision: nextRevision, updatedAt: new Date().toISOString() };
+  envelope.reports[report.id] = toStore;
+
+  const result = writeEnvelope(envelope);
+  if (!result.ok) return result;
+  return { ok: true, revision: nextRevision };
+}
+
+/** 새 Report를 만들어 저장한다. 저장 실패 시 report는 반환하되 저장은 되지 않았음을 result로 알린다. */
+export function createReport(
+  input: Pick<ReportDraft, "title" | "datasetId" | "baseRunId" | "buildSpecDigest" | "evidenceFetchedAt" | "blocks" | "evidenceRefs">,
+): { report: ReportDraft; result: SaveResult } {
+  const now = new Date().toISOString();
+  const report: ReportDraft = {
+    id: newId(),
+    title: input.title,
+    datasetId: input.datasetId,
+    baseRunId: input.baseRunId,
+    buildSpecDigest: input.buildSpecDigest,
+    createdAt: now,
+    updatedAt: now,
+    evidenceFetchedAt: input.evidenceFetchedAt,
+    version: REPORT_VERSION,
+    revision: 0,
+    blocks: input.blocks,
+    evidenceRefs: input.evidenceRefs,
+  };
+  const result = saveReport(report, { force: true });
+  return { report: result.ok ? { ...report, revision: result.revision } : report, result };
+}
+
+/** 제목만 바꿔 저장한다. */
+export function renameReport(id: string, title: string): SaveResult {
+  const report = getReport(id);
+  if (!report) return { ok: false, reason: "Report를 찾을 수 없습니다." };
+  return saveReport({ ...report, title }, { force: true });
+}
+
+/** 기존 Report를 복제해 새 id로 저장한다(블록/evidence 전부 복사, 참조 공유 없음). */
+export function duplicateReport(id: string, titleOverride?: string): { report: ReportDraft; result: SaveResult } | null {
+  const source = getReport(id);
+  if (!source) return null;
+  const now = new Date().toISOString();
+  const cloned: ReportDraft = {
+    ...structuredClone(source),
+    id: newId(),
+    title: titleOverride ?? `${source.title} (복제본)`,
+    createdAt: now,
+    updatedAt: now,
+    revision: 0,
+  };
+  const result = saveReport(cloned, { force: true });
+  return { report: result.ok ? { ...cloned, revision: result.revision } : cloned, result };
+}
+
+/** id의 Report를 삭제한다. 존재하지 않았거나 저장소 사용 불가 시 false. */
+export function deleteReport(id: string): boolean {
+  if (!isStorageAvailable()) return false;
+  const envelope = readEnvelope();
+  if (!envelope.reports[id]) return false;
+  delete envelope.reports[id];
+  return writeEnvelope(envelope).ok;
+}
+
+/** 저장된 Report가 있는지 확인한다(빈 상태 안내용). */
+export function hasAnyReport(): boolean {
+  return Object.keys(readEnvelope().reports).length > 0;
+}

--- a/src/features/reports/staleness.test.ts
+++ b/src/features/reports/staleness.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { checkReportEvidenceStatus } from "./staleness";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("checkReportEvidenceStatus (#258 §8)", () => {
+  it("기준 run이 dataset의 최신 run이면 CURRENT", async () => {
+    const result = await checkReportEvidenceStatus("air-quality", "air-2026-08-14");
+    expect(result.status).toBe("current");
+  });
+
+  it("기준 run은 유효하지만 더 최신 run이 있으면 STALE(자동 교체하지 않고 알리기만)", async () => {
+    const result = await checkReportEvidenceStatus("air-quality", "air-2026-08-13");
+    expect(result.status).toBe("stale");
+    expect(result.latestRunId).toBe("air-2026-08-14");
+  });
+
+  it("기준 run이 run 목록에서 사라졌으면 ORPHAN", async () => {
+    const result = await checkReportEvidenceStatus("air-quality", "air-run-that-was-deleted");
+    expect(result.status).toBe("orphan");
+  });
+
+  it("run 목록 자체를 조회하지 못하면 UNAVAILABLE(CURRENT/STALE/ORPHAN 중 무엇인지 단정하지 않음)", async () => {
+    const result = await checkReportEvidenceStatus("does-not-exist-dataset", "some-run");
+    expect(result.status).toBe("unavailable");
+  });
+});

--- a/src/features/reports/staleness.ts
+++ b/src/features/reports/staleness.ts
@@ -1,0 +1,76 @@
+/**
+ * 저장된 Report의 기준 dataset/run이 여전히 유효한지 판정한다 (#258 §8).
+ *
+ * Report를 다시 열 때 기준 evidence를 "가능한 범위에서" 재확인하되, 결과가 무엇이든
+ * 저장된 Report 내용을 지우거나 최신 run으로 자동 교체하지 않는다 — 이 모듈은 상태
+ * 판정만 하고, 실제로 무엇을 보여줄지는 호출부(UI)가 결정한다.
+ *
+ * 네 가지 상태만 구분한다:
+ * - CURRENT: 기준 run이 이 dataset의 최신 run과 같다(재확인 가능, 최신).
+ * - STALE: 기준 run은 여전히 접근 가능하지만 더 최신 run이 생겼다.
+ * - ORPHAN: dataset의 run 목록 조회는 성공했지만 기준 run이 더 이상 그 목록에 없다
+ *   (삭제되었거나 접근 권한을 잃음).
+ * - UNAVAILABLE: run 목록 자체를 조회하지 못해 위 셋 중 무엇인지 판정할 수 없다.
+ */
+import { getDataset, listDatasetRuns } from "@/features/datasets/api";
+import type { EvidenceRunStatus } from "./types";
+
+export interface EvidenceStalenessResult {
+  status: EvidenceRunStatus;
+  /** 판정 시점 dataset의 최신 run(확인 가능했을 때만). */
+  latestRunId?: string;
+  /** STALE/ORPHAN/UNAVAILABLE일 때 사람이 읽는 사유. */
+  reason?: string;
+  checkedAt: string;
+}
+
+async function settle<T>(promise: Promise<T>): Promise<{ ok: true; value: T } | { ok: false; reason: string }> {
+  try {
+    return { ok: true, value: await promise };
+  } catch (cause) {
+    return { ok: false, reason: cause instanceof Error ? cause.message : "조회에 실패했습니다." };
+  }
+}
+
+/**
+ * @param datasetId - Report가 고정한 기준 dataset.
+ * @param baseRunId - Report가 고정한 기준 run(변경하지 않음).
+ * @param signal - 취소 signal.
+ */
+export async function checkReportEvidenceStatus(
+  datasetId: string,
+  baseRunId: string,
+  signal?: AbortSignal,
+): Promise<EvidenceStalenessResult> {
+  const checkedAt = new Date().toISOString();
+  const [datasetResult, runsResult] = await Promise.all([
+    settle(getDataset(datasetId, signal)),
+    settle(listDatasetRuns(datasetId, 50, signal)),
+  ]);
+
+  if (!runsResult.ok) {
+    return {
+      status: "unavailable",
+      reason: `run 목록을 다시 불러오지 못했습니다: ${runsResult.reason}`,
+      checkedAt,
+    };
+  }
+
+  const stillExists = runsResult.value.runs.some((run) => run.run_id === baseRunId);
+  if (!stillExists) {
+    return {
+      status: "orphan",
+      reason: "기준 run이 더 이상 이 dataset의 run 목록에 없습니다(삭제되었거나 접근할 수 없음).",
+      checkedAt,
+    };
+  }
+
+  // Builder 응답은 최신 run이 먼저 오는 순서를 유지한다(dataset.latest_run_id와 동일 기준).
+  const latestRunId = datasetResult.ok ? datasetResult.value.latest_run_id : runsResult.value.runs[0]?.run_id;
+
+  if (latestRunId && latestRunId !== baseRunId) {
+    return { status: "stale", latestRunId, reason: `새로운 Run(\`${latestRunId}\`)이 있습니다.`, checkedAt };
+  }
+
+  return { status: "current", latestRunId, checkedAt };
+}

--- a/src/features/reports/types.ts
+++ b/src/features/reports/types.ts
@@ -1,0 +1,139 @@
+/**
+ * Report 데이터 모델 (#258).
+ *
+ * Report 안의 모든 블록은 출처(provenance)가 셋 중 하나로 고정된다 — Builder에서 그대로
+ * 가져온 값(BUILDER_EVIDENCE), Kubi가 생성한 해석(KUBI_INTERPRETATION), 사용자가 직접 쓴
+ * 내용(USER_CONTENT). 세 종류를 같은 표현으로 섞어서 저장하지 않는다(#258 리뷰 §2) —
+ * BUILDER_EVIDENCE 블록은 deterministic 코드만 생성하고, 사용자는 별도 USER_CONTENT
+ * 블록으로만 자기 설명을 남긴다.
+ *
+ * Report는 생성 당시 선택한 dataset/run(`datasetId`/`baseRunId`)을 고정해서 저장한다.
+ * 새 Run이 생겨도 이 값을 자동으로 바꾸지 않는다(#258 리뷰 §1) — `staleness.ts`가 저장된
+ * 기준과 현재 Builder 상태를 비교해 CURRENT/STALE/ORPHAN/UNAVAILABLE만 판정한다.
+ */
+
+/** Report 블록의 출처. 세 종류를 같은 표현으로 섞지 않기 위한 판별 태그. */
+export type BlockProvenance = "BUILDER_EVIDENCE" | "KUBI_INTERPRETATION" | "USER_CONTENT";
+
+interface BaseBlock {
+  id: string;
+  provenance: BlockProvenance;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** deterministic section 종류. Builder evidence에서만 채워지며 LLM이 생성하지 않는다. */
+export type BuilderEvidenceSection =
+  | "overview"
+  | "pipeline"
+  | "quality"
+  | "schema"
+  | "data_summary"
+  | "output";
+
+/**
+ * Builder evidence로부터 코드가 그대로 구성한 블록. 값이 없거나 조회에 실패한 필드는
+ * "N/A"/"확인할 수 없음"으로 표시하며, 0/PASS/정상 등으로 임의 대체하지 않는다(#258 §4).
+ * 사용자가 직접 편집할 수 없다 — 실제 값과 사용자가 고친 값을 구분 없이 섞지 않기 위함이다
+ * (#258 §10). 다시 만들고 싶으면 evidence를 새로고침해 재생성한다.
+ */
+export interface BuilderEvidenceBlock extends BaseBlock {
+  provenance: "BUILDER_EVIDENCE";
+  section: BuilderEvidenceSection;
+  title: string;
+  /** 렌더링된 안전한 plain-text/markdown 본문(사용자가 입력한 원문이 아니라 코드가 생성) */
+  markdown: string;
+  /** 이 섹션이 의존한 evidence 조회가 전부 성공했는지, 일부만 실패했는지, 전부 실패했는지 */
+  evidenceStatus: "ok" | "partial" | "unavailable";
+  /** unavailable/partial일 때 사람이 읽을 수 있는 사유(재시도 유도용) */
+  unavailableReason?: string;
+  /**
+   * `markdown`(상세 근거 표)를 deterministic 문장으로 요약한 본문(#258 IA 개편).
+   * `narrativeSummary.ts`가 evidence에서 그대로 문장화하며, 값이 없으면 0/PASS로 꾸미지
+   * 않고 "확인할 수 없습니다"라고 쓴다. optional인 이유: 이 필드가 추가되기 전에 저장된
+   * Report에는 없을 수 있고, 그 경우 렌더러는 상세 표만 보여준다.
+   */
+  summary?: string;
+  /**
+   * section이 "quality"일 때만, 실제 Builder quality evidence가 있을 때만 채워지는 집계.
+   * availability=unavailable이거나 quality 조회 자체가 실패하면 채우지 않는다(가짜 0으로
+   * 대체하지 않음) — Report Context sidebar의 Quality summary 표시에 쓰인다.
+   */
+  qualityCounts?: { pass: number; warn: number; fail: number; evaluated: number };
+}
+
+/**
+ * Kubi가 제안(ADD_REPORT_BLOCK)했고 사용자가 승인한 해석 블록(#258 §6, §7).
+ *
+ * `sourceContext`는 이 note가 생성된 시점의 dataset/run/stage다 — Report의 base와 다를 수
+ * 있으며, 다르면 `isSameContext=false`로 남겨 "참고 분석"임을 구분한다(다른 Run의 분석을
+ * 현재 Report의 정본처럼 합치지 않는다).
+ */
+export interface KubiInterpretationBlock extends BaseBlock {
+  provenance: "KUBI_INTERPRETATION";
+  note: string;
+  reason: string;
+  sourceContext: { datasetId?: string; runId?: string; stage?: string };
+  /** sourceContext가 이 Report의 datasetId/baseRunId와 일치하는지 */
+  isSameContext: boolean;
+  /** ADD_REPORT_BLOCK이 큐에 쌓인 시각(Kubi가 답변을 생성한 시각과 동일하게 취급) */
+  generatedAt: string;
+  /** evidenceRefs 등 세부 근거는 reportInbox가 보관하지 않으므로 채울 수 있을 때만 채운다 */
+  provider?: string;
+  model?: string;
+}
+
+/** 사용자가 직접 쓰거나 수정한 자유 서술 블록. */
+export interface UserContentBlock extends BaseBlock {
+  provenance: "USER_CONTENT";
+  heading: string;
+  markdown: string;
+}
+
+export type ReportBlock = BuilderEvidenceBlock | KubiInterpretationBlock | UserContentBlock;
+
+/** 저장된 Report를 다시 열었을 때 기준 evidence가 여전히 유효한지에 대한 판정(#258 §8). */
+export type EvidenceRunStatus = "current" | "stale" | "orphan" | "unavailable";
+
+/** Report가 인용하는 evidence 조각에 대한 안정적 참조(내보내기/재확인에 사용). */
+export interface ReportEvidenceRef {
+  kind: "dataset" | "run" | "quality" | "schema" | "stage" | "output";
+  id: string;
+  label: string;
+}
+
+/**
+ * 저장되는 Report Draft. `id`는 저장소 내에서 유일하며, `datasetId`/`baseRunId`는
+ * 생성 시점에 고정되어 이후 편집으로도 바뀌지 않는다(별도 "새 Run 기준으로 만들기" 흐름만
+ * 새 Report를 만든다).
+ */
+export interface ReportDraft {
+  id: string;
+  title: string;
+  datasetId: string;
+  baseRunId: string;
+  /** run 조회 시 얻은 spec_digest(있으면). Builder가 spec을 영속화하지 않으므로 null일 수 있다. */
+  buildSpecDigest: string | null;
+  createdAt: string;
+  updatedAt: string;
+  /** 이 Report의 BUILDER_EVIDENCE 블록을 마지막으로 채운 evidence 조회 시각 */
+  evidenceFetchedAt: string;
+  /** Report 봉투 스키마 버전(개별 Report 단위, 저장소 봉투 버전과 별개) */
+  version: number;
+  /** 같은 브라우저의 다른 탭에서 저장했는지 감지하기 위한 낙관적 동시성 카운터(#258 §13 최소 안전판) */
+  revision: number;
+  blocks: ReportBlock[];
+  evidenceRefs: ReportEvidenceRef[];
+}
+
+/** Report 목록 화면에 필요한 최소 요약(전체 블록을 불러오지 않고 나열하기 위함). */
+export interface ReportSummary {
+  id: string;
+  title: string;
+  datasetId: string;
+  baseRunId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const REPORT_VERSION = 1;

--- a/src/pages/ReportEditorPage.tsx
+++ b/src/pages/ReportEditorPage.tsx
@@ -1,0 +1,410 @@
+/**
+ * Report 편집 화면 (`/reports/:reportId`, #258).
+ *
+ * 저장된 Report Draft 하나를 열어 문서(1~6 Builder evidence 요약, 7 Kubi 분석, 8 사용자 메모)를
+ * 읽고 편집하고, 기준 evidence를 새로고침하거나 Kubi 참고 노트를 승인해 반영하고,
+ * Markdown/HTML/Print로 내보낸다.
+ *
+ * IA(#258 IA 개편, Prototype SSOT `report-layout` 반영): desktop에서는 왼쪽에 실제 보고서
+ * 문서, 오른쪽에 이 Report에 실제로 존재하는 값만 보여주는 Report Context sidebar를 둔
+ * 2단 구조다. 좁은 viewport에서는 sidebar가 문서 아래로 collapse한다(`grid-cols-1` →
+ * `lg:grid-cols-[minmax(0,1fr)_320px]`).
+ *
+ * 모든 편집 동작은 즉시 저장한다(autosave) — 그래야 "Evidence 새로고침" 같은 동작이
+ * 저장되지 않은 사용자 편집을 잃어버릴 걱정 없이 deterministic 블록만 안전하게 교체할 수
+ * 있다(#258 §9의 최소 안전 모델).
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { buildDeterministicSections } from "@/features/reports/deterministicSections";
+import { buildEvidenceRefs, fetchReportEvidence } from "@/features/reports/evidence";
+import { downloadHtml, downloadMarkdown } from "@/features/reports/export";
+import { createReport, getReport, saveReport } from "@/features/reports/repository";
+import { checkReportEvidenceStatus, type EvidenceStalenessResult } from "@/features/reports/staleness";
+import type {
+  BuilderEvidenceBlock,
+  KubiInterpretationBlock,
+  ReportDraft,
+  UserContentBlock,
+} from "@/features/reports/types";
+import { BlockView } from "@/features/reports/components/BlockView";
+import { KubiInboxPanel } from "@/features/reports/components/KubiInboxPanel";
+import { ReportContextSidebar } from "@/features/reports/components/ReportContextSidebar";
+import { UserContentEditor } from "@/features/reports/components/UserContentEditor";
+import { listKubiReportNotes } from "@/features/kubi/reportInbox";
+import { useUIStore } from "@/shared/hooks/useUIStore";
+import { Button, Card, EmptyState, ErrorState, PageHeader, TextInput } from "@/shared/ui";
+
+function newBlockId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return `user-${crypto.randomUUID()}`;
+  return `user-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function ReportEditorPage() {
+  const { reportId } = useParams<{ reportId: string }>();
+  const navigate = useNavigate();
+  const openKubiDrawer = useUIStore((state) => state.openKubiDrawer);
+
+  const [report, setReport] = useState<ReportDraft | null | undefined>(undefined);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(null);
+
+  const [staleness, setStaleness] = useState<EvidenceStalenessResult | null>(null);
+  const [stalenessLoading, setStalenessLoading] = useState(false);
+
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+
+  const [addingUserBlock, setAddingUserBlock] = useState(false);
+  const [editingUserBlockId, setEditingUserBlockId] = useState<string | null>(null);
+
+  const [titleDraft, setTitleDraft] = useState("");
+  const [pendingKubiNoteCount, setPendingKubiNoteCount] = useState(0);
+
+  useEffect(() => {
+    if (!reportId) {
+      setReport(null);
+      return;
+    }
+    const loaded = getReport(reportId);
+    setReport(loaded);
+    setTitleDraft(loaded?.title ?? "");
+  }, [reportId]);
+
+  const refreshPendingKubiNoteCount = useCallback(() => {
+    setPendingKubiNoteCount(listKubiReportNotes().length);
+  }, []);
+
+  useEffect(() => {
+    refreshPendingKubiNoteCount();
+  }, [refreshPendingKubiNoteCount]);
+
+  const runStalenessCheck = useCallback((current: ReportDraft, signal?: AbortSignal) => {
+    setStalenessLoading(true);
+    checkReportEvidenceStatus(current.datasetId, current.baseRunId, signal)
+      .then((result) => {
+        if (signal?.aborted) return;
+        setStaleness(result);
+      })
+      .finally(() => {
+        if (!signal?.aborted) setStalenessLoading(false);
+      });
+  }, []);
+
+  const loadedReportId = report?.id;
+  useEffect(() => {
+    if (!report) return;
+    const controller = new AbortController();
+    runStalenessCheck(report, controller.signal);
+    return () => controller.abort();
+    // report.id가 바뀔 때만 재확인하면 충분하다(같은 report 객체 참조 변경마다 재확인할 필요는 없음).
+    // report/runStalenessCheck 자체는 매 렌더 새 참조가 될 수 있어 의도적으로 의존성에서 제외한다.
+    // 이 재확인은 판정만 할 뿐 baseRunId를 절대 바꾸지 않는다(#258 §8 불변식) — STALE이어도
+    // "최신 Run으로 새 Report 만들기"를 사용자가 명시적으로 눌러야만 별도 Report가 새로 생긴다.
+  }, [loadedReportId]);
+
+  function persist(next: ReportDraft) {
+    const result = saveReport(next);
+    if (!result.ok) {
+      setSaveError(result.reason);
+      return false;
+    }
+    const saved = { ...next, revision: result.revision };
+    setReport(saved);
+    setSaveError(null);
+    setLastSavedAt(new Date().toISOString());
+    return true;
+  }
+
+  function handleTitleBlur() {
+    if (!report) return;
+    const trimmed = titleDraft.trim() || "제목 없음";
+    if (trimmed === report.title) return;
+    persist({ ...report, title: trimmed });
+  }
+
+  function handleAddUserBlock(heading: string, markdown: string) {
+    if (!report) return;
+    const now = new Date().toISOString();
+    const block: UserContentBlock = {
+      id: newBlockId(),
+      provenance: "USER_CONTENT",
+      heading,
+      markdown,
+      createdAt: now,
+      updatedAt: now,
+    };
+    persist({ ...report, blocks: [...report.blocks, block] });
+    setAddingUserBlock(false);
+  }
+
+  function handleEditUserBlock(id: string, heading: string, markdown: string) {
+    if (!report) return;
+    const now = new Date().toISOString();
+    persist({
+      ...report,
+      blocks: report.blocks.map((block) =>
+        block.id === id && block.provenance === "USER_CONTENT" ? { ...block, heading, markdown, updatedAt: now } : block,
+      ),
+    });
+    setEditingUserBlockId(null);
+  }
+
+  function handleDeleteUserBlock(id: string) {
+    if (!report) return;
+    if (!window.confirm("이 블록을 삭제하시겠습니까?")) return;
+    persist({ ...report, blocks: report.blocks.filter((block) => block.id !== id) });
+  }
+
+  function handleRemoveKubiBlock(id: string) {
+    if (!report) return;
+    persist({ ...report, blocks: report.blocks.filter((block) => block.id !== id) });
+  }
+
+  function handleApproveKubiBlock(block: KubiInterpretationBlock) {
+    if (!report) return;
+    persist({ ...report, blocks: [...report.blocks, block] });
+  }
+
+  /**
+   * "현재 문맥으로 Kubi 분석" — 전역 Kubi drawer는 URL의 pathname+search에서 context를
+   * 읽으므로(`features/kubi/context.ts`), Report가 고정한 `datasetId`/`baseRunId`를 그대로
+   * `?dataset=&run=` 쿼리에 실어 보낸다. 최신 run으로 자동 전환하지 않는다(#258 §8/§6과
+   * 동일 불변식) — staleness가 STALE이어도 여기서 넘기는 값은 항상 이 Report의 기준값이다.
+   */
+  function handleOpenKubiForReportContext() {
+    if (!report) return;
+    const params = new URLSearchParams({ dataset: report.datasetId, run: report.baseRunId });
+    navigate(`/reports/${encodeURIComponent(report.id)}?${params.toString()}`, { replace: true });
+    openKubiDrawer();
+  }
+
+  async function handleRefreshEvidence() {
+    if (!report) return;
+    setRefreshing(true);
+    setRefreshError(null);
+    try {
+      const evidence = await fetchReportEvidence(report.datasetId, report.baseRunId);
+      const nextEvidenceBlocks = buildDeterministicSections(evidence);
+      const evidenceRefs = buildEvidenceRefs(evidence);
+      // deterministic(BUILDER_EVIDENCE) 블록만 새로 만든 것으로 교체하고, Kubi/사용자 블록은 그대로 둔다
+      // (#258 §9 — 자동 생성 영역과 사용자 작성 영역을 분리해 사용자 편집을 보존).
+      const keptBlocks = report.blocks.filter((block) => block.provenance !== "BUILDER_EVIDENCE");
+      const nextReport: ReportDraft = {
+        ...report,
+        evidenceFetchedAt: evidence.fetchedAt,
+        buildSpecDigest: evidence.run.ok ? evidence.run.value.spec_digest : report.buildSpecDigest,
+        blocks: [...nextEvidenceBlocks, ...keptBlocks],
+        evidenceRefs,
+      };
+      persist(nextReport);
+      runStalenessCheck(nextReport);
+    } catch (cause) {
+      setRefreshError(cause instanceof Error ? cause.message : "Evidence를 새로고침하지 못했습니다.");
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  async function handleCreateFromLatest() {
+    if (!report || !staleness?.latestRunId) return;
+    try {
+      const evidence = await fetchReportEvidence(report.datasetId, staleness.latestRunId);
+      const blocks = buildDeterministicSections(evidence);
+      const evidenceRefs = buildEvidenceRefs(evidence);
+      const datasetTitle = evidence.dataset.ok ? evidence.dataset.value.title : report.datasetId;
+      const { report: created, result } = createReport({
+        title: `${datasetTitle} · ${staleness.latestRunId} 보고서`,
+        datasetId: report.datasetId,
+        baseRunId: staleness.latestRunId,
+        buildSpecDigest: evidence.run.ok ? evidence.run.value.spec_digest : null,
+        evidenceFetchedAt: evidence.fetchedAt,
+        blocks,
+        evidenceRefs,
+      });
+      if (!result.ok) {
+        setRefreshError(result.reason);
+        return;
+      }
+      navigate(`/reports/${encodeURIComponent(created.id)}`);
+    } catch (cause) {
+      setRefreshError(cause instanceof Error ? cause.message : "새 Report를 만들지 못했습니다.");
+    }
+  }
+
+  if (report === undefined) {
+    return (
+      <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+        <p className="text-sm text-muted-foreground">불러오는 중…</p>
+      </main>
+    );
+  }
+
+  if (report === null) {
+    return (
+      <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+        <PageHeader eyebrow="Reports" title="Report를 찾을 수 없습니다" description="" />
+        <EmptyState
+          title="이 Report는 이 브라우저에 없습니다"
+          description="삭제되었거나 다른 브라우저/기기에서 만들어졌을 수 있습니다(로컬 저장소이므로 기기 간 동기화되지 않습니다)."
+          actionLabel="Report 목록으로"
+          actionHref="/reports"
+        />
+      </main>
+    );
+  }
+
+  const staleStatus = staleness?.status ?? null;
+
+  const evidenceBlocks = report.blocks.filter(
+    (block): block is BuilderEvidenceBlock => block.provenance === "BUILDER_EVIDENCE",
+  );
+  const kubiBlocks = report.blocks.filter(
+    (block): block is KubiInterpretationBlock => block.provenance === "KUBI_INTERPRETATION",
+  );
+  const userBlocks = report.blocks.filter((block): block is UserContentBlock => block.provenance === "USER_CONTENT");
+
+  return (
+    <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10" id="report-print-area">
+      <style>{`
+        @media print {
+          body * { visibility: hidden; }
+          #report-print-area, #report-print-area * { visibility: visible; }
+          #report-print-area { position: absolute; inset: 0; padding: 1.5rem; }
+          .print\\:hidden { display: none !important; }
+        }
+      `}</style>
+
+      <div className="print:hidden">
+        <PageHeader eyebrow="Reports" title="Report 편집" description={`${report.datasetId} · ${report.baseRunId}`} />
+      </div>
+
+      {/* Prototype SSOT(`docs/prototype/kpubdata_ui_prototype_v1.html`)의 `.report-layout`과
+          동일한 원칙: desktop은 문서(가변폭) + Report Context(고정폭) 2단, 좁은 viewport에서는
+          `grid-cols-1`로 collapse해 sidebar가 문서 아래로 내려온다. */}
+      <div
+        className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start"
+        data-testid="report-layout-grid"
+      >
+        <div className="flex min-w-0 flex-col gap-4">
+          <Card className="print:hidden">
+            <label className="text-xs font-medium text-muted-foreground" htmlFor="report-title">
+              제목
+            </label>
+            <TextInput
+              id="report-title"
+              className="mt-1 text-base font-semibold"
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              onBlur={handleTitleBlur}
+            />
+            <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+              <span>
+                저장됨 · revision {report.revision}
+                {lastSavedAt ? ` · 마지막 저장 ${new Date(lastSavedAt).toLocaleTimeString("ko-KR")}` : ""}
+              </span>
+              <div className="flex flex-wrap gap-2">
+                <Button size="sm" variant="secondary" onClick={handleRefreshEvidence} loading={refreshing}>
+                  Evidence 새로고침
+                </Button>
+                <Button size="sm" variant="secondary" onClick={() => downloadMarkdown(report, staleStatus)}>
+                  Markdown 다운로드
+                </Button>
+                <Button size="sm" variant="secondary" onClick={() => downloadHtml(report, staleStatus)}>
+                  HTML 다운로드
+                </Button>
+                <Button size="sm" variant="secondary" onClick={() => window.print()}>
+                  인쇄(Browser Print)
+                </Button>
+              </div>
+            </div>
+            {saveError ? <ErrorState className="mt-2 py-4" message={saveError} /> : null}
+            {refreshError ? <ErrorState className="mt-2 py-4" message={refreshError} /> : null}
+          </Card>
+
+          {/* 1~6. Builder evidence 기반 보고서 본문 — 문장 요약이 먼저 보이고, 표는 상세 근거로 접힌다. */}
+          {evidenceBlocks.map((block) => (
+            <BlockView key={block.id} block={block} />
+          ))}
+
+          {/* 7. Kubi 분석 */}
+          <div className="flex flex-col gap-3">
+            <h2 className="text-sm font-semibold text-foreground">7. Kubi 분석</h2>
+            {kubiBlocks.length === 0 ? (
+              <EmptyState
+                className="py-8"
+                title="아직 추가된 AI 분석이 없습니다"
+                description="Kubi에서 현재 Dataset/Run을 분석한 뒤 검토하여 보고서에 추가할 수 있습니다."
+              />
+            ) : (
+              kubiBlocks.map((block) => (
+                <BlockView
+                  key={block.id}
+                  block={block}
+                  reportEvidenceRefs={block.isSameContext ? report.evidenceRefs : undefined}
+                  onRemoveKubiBlock={handleRemoveKubiBlock}
+                />
+              ))
+            )}
+            <div className="print:hidden">
+              <Button variant="secondary" onClick={handleOpenKubiForReportContext}>
+                현재 문맥으로 Kubi 분석
+              </Button>
+            </div>
+            <div className="print:hidden">
+              <KubiInboxPanel
+                report={report}
+                onApprove={handleApproveKubiBlock}
+                onNotesChanged={refreshPendingKubiNoteCount}
+              />
+            </div>
+          </div>
+
+          {/* 8. 사용자 메모 */}
+          <div className="flex flex-col gap-3">
+            <h2 className="text-sm font-semibold text-foreground">8. 사용자 메모</h2>
+            {userBlocks.map((block) =>
+              editingUserBlockId === block.id ? (
+                <UserContentEditor
+                  key={block.id}
+                  initialHeading={block.heading}
+                  initialMarkdown={block.markdown}
+                  onSave={(heading, markdown) => handleEditUserBlock(block.id, heading, markdown)}
+                  onCancel={() => setEditingUserBlockId(null)}
+                />
+              ) : (
+                <BlockView
+                  key={block.id}
+                  block={block}
+                  onEditUserContent={() => setEditingUserBlockId(block.id)}
+                  onDeleteUserContent={handleDeleteUserBlock}
+                />
+              ),
+            )}
+            <div className="print:hidden">
+              {addingUserBlock ? (
+                <UserContentEditor onSave={handleAddUserBlock} onCancel={() => setAddingUserBlock(false)} />
+              ) : (
+                <Button variant="secondary" onClick={() => setAddingUserBlock(true)}>
+                  + 사용자 작성 블록 추가
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="print:hidden">
+          <ReportContextSidebar
+            report={report}
+            staleness={staleness}
+            stalenessLoading={stalenessLoading}
+            onRecheck={() => runStalenessCheck(report)}
+            onCreateFromLatest={staleness?.status === "stale" ? handleCreateFromLatest : undefined}
+            kubiBlockCount={kubiBlocks.length}
+            pendingKubiNoteCount={pendingKubiNoteCount}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/ReportEditorPage.tsx
+++ b/src/pages/ReportEditorPage.tsx
@@ -19,20 +19,22 @@ import { useNavigate, useParams } from "react-router-dom";
 import { buildDeterministicSections } from "@/features/reports/deterministicSections";
 import { buildEvidenceRefs, fetchReportEvidence } from "@/features/reports/evidence";
 import { downloadHtml, downloadMarkdown } from "@/features/reports/export";
+import { buildSectionSummaries } from "@/features/reports/narrativeSummary";
 import { createReport, getReport, saveReport } from "@/features/reports/repository";
 import { checkReportEvidenceStatus, type EvidenceStalenessResult } from "@/features/reports/staleness";
 import type {
   BuilderEvidenceBlock,
+  BuilderEvidenceSection,
   KubiInterpretationBlock,
   ReportDraft,
   UserContentBlock,
 } from "@/features/reports/types";
 import { BlockView } from "@/features/reports/components/BlockView";
 import { KubiInboxPanel } from "@/features/reports/components/KubiInboxPanel";
+import { KubiReportPanel } from "@/features/reports/components/KubiReportPanel";
 import { ReportContextSidebar } from "@/features/reports/components/ReportContextSidebar";
 import { UserContentEditor } from "@/features/reports/components/UserContentEditor";
 import { listKubiReportNotes } from "@/features/kubi/reportInbox";
-import { useUIStore } from "@/shared/hooks/useUIStore";
 import { Button, Card, EmptyState, ErrorState, PageHeader, TextInput } from "@/shared/ui";
 
 function newBlockId(): string {
@@ -43,7 +45,6 @@ function newBlockId(): string {
 export function ReportEditorPage() {
   const { reportId } = useParams<{ reportId: string }>();
   const navigate = useNavigate();
-  const openKubiDrawer = useUIStore((state) => state.openKubiDrawer);
 
   const [report, setReport] = useState<ReportDraft | null | undefined>(undefined);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -60,6 +61,11 @@ export function ReportEditorPage() {
 
   const [titleDraft, setTitleDraft] = useState("");
   const [pendingKubiNoteCount, setPendingKubiNoteCount] = useState(0);
+
+  // legacy summary(#258 legacy summary 수정): `summary`가 추가되기 전에 저장된 BUILDER_EVIDENCE
+  // 블록은 이 값이 없다. 저장된 draft 자체를 임의로 migration하지 않고, 화면 표현만 현재
+  // evidence 기준으로 보강한다 — evidence 재조회에 실패하면 null로 남아 기존처럼 표만 보인다.
+  const [legacySummaries, setLegacySummaries] = useState<Record<BuilderEvidenceSection, string> | null>(null);
 
   useEffect(() => {
     if (!reportId) {
@@ -101,6 +107,30 @@ export function ReportEditorPage() {
     // report/runStalenessCheck 자체는 매 렌더 새 참조가 될 수 있어 의도적으로 의존성에서 제외한다.
     // 이 재확인은 판정만 할 뿐 baseRunId를 절대 바꾸지 않는다(#258 §8 불변식) — STALE이어도
     // "최신 Run으로 새 Report 만들기"를 사용자가 명시적으로 눌러야만 별도 Report가 새로 생긴다.
+  }, [loadedReportId]);
+
+  useEffect(() => {
+    if (!report) return;
+    const hasLegacyBlock = report.blocks.some(
+      (block) => block.provenance === "BUILDER_EVIDENCE" && !block.summary,
+    );
+    if (!hasLegacyBlock) {
+      setLegacySummaries(null);
+      return;
+    }
+    const controller = new AbortController();
+    fetchReportEvidence(report.datasetId, report.baseRunId, controller.signal)
+      .then((evidence) => {
+        if (controller.signal.aborted) return;
+        setLegacySummaries(buildSectionSummaries(evidence));
+      })
+      .catch(() => {
+        // evidence 재조회 실패 — 저장된 draft(표만 있는 legacy 표시)를 그대로 유지한다.
+        // summary 생성 실패 때문에 Report 전체를 깨지 않는다(#258 legacy summary §1).
+      });
+    return () => controller.abort();
+    // report.id가 바뀔 때만 다시 계산한다 — 위 staleness 재확인과 동일한 이유로 report 객체
+    // 참조 자체는 의존성에서 제외한다(예: 제목만 바꿔도 재조회가 다시 일어나지 않게).
   }, [loadedReportId]);
 
   function persist(next: ReportDraft) {
@@ -164,19 +194,6 @@ export function ReportEditorPage() {
   function handleApproveKubiBlock(block: KubiInterpretationBlock) {
     if (!report) return;
     persist({ ...report, blocks: [...report.blocks, block] });
-  }
-
-  /**
-   * "현재 문맥으로 Kubi 분석" — 전역 Kubi drawer는 URL의 pathname+search에서 context를
-   * 읽으므로(`features/kubi/context.ts`), Report가 고정한 `datasetId`/`baseRunId`를 그대로
-   * `?dataset=&run=` 쿼리에 실어 보낸다. 최신 run으로 자동 전환하지 않는다(#258 §8/§6과
-   * 동일 불변식) — staleness가 STALE이어도 여기서 넘기는 값은 항상 이 Report의 기준값이다.
-   */
-  function handleOpenKubiForReportContext() {
-    if (!report) return;
-    const params = new URLSearchParams({ dataset: report.datasetId, run: report.baseRunId });
-    navigate(`/reports/${encodeURIComponent(report.id)}?${params.toString()}`, { replace: true });
-    openKubiDrawer();
   }
 
   async function handleRefreshEvidence() {
@@ -264,6 +281,14 @@ export function ReportEditorPage() {
   );
   const userBlocks = report.blocks.filter((block): block is UserContentBlock => block.provenance === "USER_CONTENT");
 
+  // legacy summary 보강: 저장된 블록의 summary는 그대로 두고, 화면에 보여줄 값만 현재
+  // evidence 기준 summary로 채운다(저장을 강제하지 않는다 — #258 legacy summary §1).
+  const displayEvidenceBlocks = evidenceBlocks.map((block) => {
+    if (block.summary) return block;
+    const fallback = legacySummaries?.[block.section];
+    return fallback ? { ...block, summary: fallback } : block;
+  });
+
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10" id="report-print-area">
       <style>{`
@@ -323,7 +348,7 @@ export function ReportEditorPage() {
           </Card>
 
           {/* 1~6. Builder evidence 기반 보고서 본문 — 문장 요약이 먼저 보이고, 표는 상세 근거로 접힌다. */}
-          {evidenceBlocks.map((block) => (
+          {displayEvidenceBlocks.map((block) => (
             <BlockView key={block.id} block={block} />
           ))}
 
@@ -347,9 +372,7 @@ export function ReportEditorPage() {
               ))
             )}
             <div className="print:hidden">
-              <Button variant="secondary" onClick={handleOpenKubiForReportContext}>
-                현재 문맥으로 Kubi 분석
-              </Button>
+              <KubiReportPanel report={report} onApprove={handleApproveKubiBlock} />
             </div>
             <div className="print:hidden">
               <KubiInboxPanel
@@ -393,7 +416,16 @@ export function ReportEditorPage() {
           </div>
         </div>
 
-        <div className="print:hidden">
+        {/* desktop에서는 App Shell header(`Layout.tsx`의 `sticky top-0` 헤더, 대략 4~4.5rem 높이)
+            아래에 이 sidebar도 같이 sticky로 고정한다(#258 sticky sidebar 수정) — 문서를
+            스크롤해도 Report Context가 계속 보이게 한다. sidebar가 viewport보다 길어질 수
+            있으므로 자체 높이를 viewport로 제한하고 내부 스크롤을 허용해, sticky 때문에 아래쪽
+            내용(Kubi 카드 등)이 영영 보이지 않는 상태가 되지 않게 한다. 좁은 viewport(`lg` 미만)
+            에서는 문서 아래로 collapse하는 기존 1단 레이아웃 그대로이므로 sticky를 걸지 않는다. */}
+        <div
+          className="print:hidden lg:sticky lg:top-20 lg:max-h-[calc(100vh-5.5rem)] lg:self-start lg:overflow-y-auto"
+          data-testid="report-context-sidebar-wrapper"
+        >
           <ReportContextSidebar
             report={report}
             staleness={staleness}

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -1,61 +1,295 @@
 /**
- * Reports 화면 (`/reports`) — placeholder (#247), Kubi 참고 노트 큐 표시만 추가 (#256).
+ * Reports 목록/생성 화면 (`/reports`, #258).
  *
- * 실제 리포트 생성/편집 구현은 #258에서 진행한다. 여기서는 그 전체 기능을 대신 만들지 않고,
- * Kubi의 ADD_REPORT_BLOCK 승인 결과가 어디로 가는지(`features/kubi/reportInbox.ts`)만
- * 읽기 전용으로 보여준다 — #258이 실제 편집 기능을 붙일 때 이 큐를 소비하면 된다.
+ * 저장된 Report Draft 목록을 관리(열기/이름변경/복제/삭제)하고, 기준 dataset/run을 골라
+ * Builder evidence 기반 deterministic Report를 새로 만든다. 실제 편집/블록 구성은
+ * `/reports/:reportId`(`ReportEditorPage`)에서 이어진다.
  */
 import { useEffect, useState } from "react";
-import { listKubiReportNotes, type KubiReportNote } from "@/features/kubi/reportInbox";
-import { Card, EmptyState, PageHeader } from "@/shared/ui";
+import { useNavigate } from "react-router-dom";
+import { listDatasetRuns, listDatasets } from "@/features/datasets/api";
+import { listKubiReportNotes } from "@/features/kubi/reportInbox";
+import { buildDeterministicSections } from "@/features/reports/deterministicSections";
+import { buildEvidenceRefs, fetchReportEvidence } from "@/features/reports/evidence";
+import {
+  createReport,
+  deleteReport,
+  duplicateReport,
+  listReportSummaries,
+  renameReport,
+} from "@/features/reports/repository";
+import type { ReportSummary } from "@/features/reports/types";
+import type { DatasetRunSummary, DatasetSummary } from "@/shared/lib/builderApi";
+import { Button, Card, EmptyState, ErrorState, PageHeader, Select } from "@/shared/ui";
+
+interface AsyncState<T> {
+  status: "idle" | "loading" | "loaded" | "error";
+  data?: T;
+  error?: string;
+}
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString("ko-KR");
+}
 
 export function ReportsPage() {
-  const [notes, setNotes] = useState<KubiReportNote[]>([]);
+  const navigate = useNavigate();
+  const [summaries, setSummaries] = useState<ReportSummary[]>([]);
+  const [pendingNoteCount, setPendingNoteCount] = useState(0);
+  const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
+  const [listError, setListError] = useState<string | null>(null);
+
+  const [datasetsState, setDatasetsState] = useState<AsyncState<DatasetSummary[]>>({ status: "loading" });
+  const [runsState, setRunsState] = useState<AsyncState<DatasetRunSummary[]>>({ status: "idle" });
+  const [selectedDatasetId, setSelectedDatasetId] = useState("");
+  const [selectedRunId, setSelectedRunId] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  function refresh() {
+    setSummaries(listReportSummaries());
+    setPendingNoteCount(listKubiReportNotes().length);
+  }
 
   useEffect(() => {
-    setNotes(listKubiReportNotes());
+    refresh();
   }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setDatasetsState({ status: "loading" });
+    listDatasets(100, controller.signal)
+      .then((datasets) => {
+        setDatasetsState({ status: "loaded", data: datasets });
+        if (datasets.length > 0) setSelectedDatasetId((current) => current || datasets[0].dataset_id);
+      })
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setDatasetsState({ status: "error", error: cause instanceof Error ? cause.message : "데이터셋 목록을 불러오지 못했습니다." });
+      });
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedDatasetId) {
+      setRunsState({ status: "idle" });
+      return;
+    }
+    const controller = new AbortController();
+    setRunsState({ status: "loading" });
+    listDatasetRuns(selectedDatasetId, 50, controller.signal)
+      .then((data) => {
+        setRunsState({ status: "loaded", data: data.runs });
+        setSelectedRunId(data.runs[0]?.run_id ?? "");
+      })
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setRunsState({ status: "error", error: cause instanceof Error ? cause.message : "run 목록을 불러오지 못했습니다." });
+      });
+    return () => controller.abort();
+  }, [selectedDatasetId]);
+
+  async function handleCreate() {
+    if (!selectedDatasetId || !selectedRunId) return;
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const evidence = await fetchReportEvidence(selectedDatasetId, selectedRunId);
+      const blocks = buildDeterministicSections(evidence);
+      const evidenceRefs = buildEvidenceRefs(evidence);
+      const datasetTitle = evidence.dataset.ok ? evidence.dataset.value.title : selectedDatasetId;
+      const { report, result } = createReport({
+        title: `${datasetTitle} · ${selectedRunId} 보고서`,
+        datasetId: selectedDatasetId,
+        baseRunId: selectedRunId,
+        buildSpecDigest: evidence.run.ok ? evidence.run.value.spec_digest : null,
+        evidenceFetchedAt: evidence.fetchedAt,
+        blocks,
+        evidenceRefs,
+      });
+      if (!result.ok) {
+        setCreateError(result.reason);
+        return;
+      }
+      navigate(`/reports/${encodeURIComponent(report.id)}`);
+    } catch (cause) {
+      setCreateError(cause instanceof Error ? cause.message : "Report를 만들지 못했습니다.");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  function handleRenameSubmit() {
+    if (!renameTarget) return;
+    const result = renameReport(renameTarget.id, renameTarget.title.trim() || "제목 없음");
+    if (!result.ok) {
+      setListError(result.reason);
+      return;
+    }
+    setRenameTarget(null);
+    refresh();
+  }
+
+  function handleDuplicate(id: string) {
+    const outcome = duplicateReport(id);
+    if (!outcome) return;
+    if (!outcome.result.ok) {
+      setListError(outcome.result.reason);
+      return;
+    }
+    refresh();
+  }
+
+  function handleDelete(id: string) {
+    if (!window.confirm("이 Report를 삭제하시겠습니까? 되돌릴 수 없습니다.")) return;
+    deleteReport(id);
+    refresh();
+  }
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
       <PageHeader
         eyebrow="Reports"
         title="리포트"
-        description="Kubi 분석 결과와 인사이트를 리포트로 기록하고 공유합니다."
+        description="Builder evidence를 기준으로 Report를 만들고, Kubi 해석을 참고 블록으로 덧붙여 편집·저장·내보냅니다."
       />
 
       <Card>
-        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          Kubi 참고 노트 대기열
+        <p className="text-sm font-semibold">새 Report 만들기</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          선택한 dataset/run이 이 Report의 기준으로 고정됩니다. 새 Run이 생겨도 이 Report는 자동으로 바뀌지 않습니다.
         </p>
-        {notes.length === 0 ? (
-          <EmptyState
-            className="py-8"
-            title="대기 중인 Kubi 노트가 없습니다"
-            description="Kubi 대화에서 '보고서에 추가' action을 승인하면 여기에 쌓입니다."
-          />
+        {datasetsState.status === "error" ? (
+          <ErrorState className="mt-3" message={datasetsState.error ?? "데이터셋 목록을 불러오지 못했습니다."} />
         ) : (
-          <ul className="mt-3 flex flex-col gap-3">
-            {notes.map((note, index) => (
-              <li key={index} className="rounded-lg border border-border p-3 text-sm">
-                <p className="text-foreground">{note.note}</p>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  {[note.context.datasetId, note.context.runId, note.context.stage].filter(Boolean).join(" · ") || "문맥 없음"}
-                  {" · "}
-                  {new Date(note.savedAt).toLocaleString("ko-KR")}
-                </p>
+          <div className="mt-3 flex flex-wrap items-end gap-3">
+            <div className="min-w-[220px]">
+              <label className="text-xs font-medium text-muted-foreground" htmlFor="report-dataset">
+                Dataset
+              </label>
+              <Select
+                id="report-dataset"
+                className="mt-1"
+                value={selectedDatasetId}
+                onChange={(e) => setSelectedDatasetId(e.target.value)}
+                disabled={datasetsState.status !== "loaded"}
+              >
+                {(datasetsState.data ?? []).map((dataset) => (
+                  <option key={dataset.dataset_id} value={dataset.dataset_id}>
+                    {dataset.title} ({dataset.dataset_id})
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <div className="min-w-[220px]">
+              <label className="text-xs font-medium text-muted-foreground" htmlFor="report-run">
+                Run
+              </label>
+              <Select
+                id="report-run"
+                className="mt-1"
+                value={selectedRunId}
+                onChange={(e) => setSelectedRunId(e.target.value)}
+                disabled={runsState.status !== "loaded" || (runsState.data ?? []).length === 0}
+              >
+                {(runsState.data ?? []).map((run) => (
+                  <option key={run.run_id} value={run.run_id}>
+                    {run.run_id} · {run.status}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <Button onClick={handleCreate} loading={creating} disabled={!selectedDatasetId || !selectedRunId}>
+              Report 만들기
+            </Button>
+          </div>
+        )}
+        {runsState.status === "loaded" && (runsState.data ?? []).length === 0 ? (
+          <p className="mt-2 text-xs text-muted-foreground">이 dataset에는 접근 가능한 run이 없습니다.</p>
+        ) : null}
+        {createError ? <ErrorState className="mt-3" message={createError} /> : null}
+      </Card>
+
+      {pendingNoteCount > 0 ? (
+        <Card className="border-indigo-200 bg-indigo-50 text-sm dark:border-indigo-900/60 dark:bg-indigo-950/30">
+          Kubi 참고 노트 {pendingNoteCount}건이 대기 중입니다. Report를 열어 "Kubi 참고 노트 대기열"에서 추가하거나
+          무시할 수 있습니다.
+        </Card>
+      ) : null}
+
+      {listError ? <ErrorState message={listError} /> : null}
+
+      <Card>
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">저장된 Report</p>
+        {summaries.length === 0 ? (
+          <EmptyState className="py-8" title="저장된 Report가 없습니다" description="위에서 dataset/run을 선택해 첫 Report를 만들어보세요." />
+        ) : (
+          <ul className="mt-3 flex flex-col divide-y divide-border">
+            {summaries.map((summary) => (
+              <li key={summary.id} className="flex flex-wrap items-center justify-between gap-3 py-3">
+                {renameTarget?.id === summary.id ? (
+                  <div className="flex flex-1 items-center gap-2">
+                    <input
+                      autoFocus
+                      className="w-full max-w-sm rounded-lg border border-input bg-card px-3 py-1.5 text-sm"
+                      value={renameTarget.title}
+                      onChange={(e) => setRenameTarget({ id: summary.id, title: e.target.value })}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handleRenameSubmit();
+                        if (e.key === "Escape") setRenameTarget(null);
+                      }}
+                    />
+                    <Button size="sm" onClick={handleRenameSubmit}>
+                      저장
+                    </Button>
+                    <Button size="sm" variant="secondary" onClick={() => setRenameTarget(null)}>
+                      취소
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="min-w-0">
+                    <button
+                      type="button"
+                      className="truncate text-left text-sm font-medium text-foreground underline-offset-2 hover:underline"
+                      onClick={() => navigate(`/reports/${encodeURIComponent(summary.id)}`)}
+                    >
+                      {summary.title}
+                    </button>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {summary.datasetId} · {summary.baseRunId} · 최근 수정 {formatDateTime(summary.updatedAt)}
+                    </p>
+                  </div>
+                )}
+                {renameTarget?.id !== summary.id ? (
+                  <div className="flex shrink-0 items-center gap-2 text-xs">
+                    <button
+                      type="button"
+                      className="text-muted-foreground underline hover:text-foreground"
+                      onClick={() => setRenameTarget({ id: summary.id, title: summary.title })}
+                    >
+                      이름변경
+                    </button>
+                    <button
+                      type="button"
+                      className="text-muted-foreground underline hover:text-foreground"
+                      onClick={() => handleDuplicate(summary.id)}
+                    >
+                      복제
+                    </button>
+                    <button
+                      type="button"
+                      className="text-red-700 underline hover:text-red-900 dark:text-red-400"
+                      onClick={() => handleDelete(summary.id)}
+                    >
+                      삭제
+                    </button>
+                  </div>
+                ) : null}
               </li>
             ))}
           </ul>
         )}
-      </Card>
-
-      <Card variant="dashed" className="flex flex-col items-center gap-2 py-16 text-center">
-        <p className="text-lg font-medium tracking-tight">아직 준비 중인 화면입니다</p>
-        <p className="mx-auto max-w-xl text-sm leading-6 text-muted-foreground">
-          리포트 편집·발행 기능은 #258에서 구현됩니다. 위 대기열은 그때 실제 리포트 문서에
-          반영됩니다.
-        </p>
       </Card>
     </main>
   );


### PR DESCRIPTION
## 개요

Closes #258

Builder의 Dataset/Run/Quality/Schema/Pipeline Evidence를 기준으로
편집 가능한 Report를 생성·저장·재열기·내보내기할 수 있도록 구현합니다.

수치와 판정은 Builder Evidence를 정본으로 사용하고,
Kubi는 현재 Report의 고정된 Dataset/Run을 기준으로 해석을 생성해
사용자 승인 후 별도 AI 블록으로 추가합니다.

> Depends on #256 / PR #277
>
> 이 PR은 `feat/issue-256-context-aware-kubi`를 base로 하는 stacked PR입니다.
> #256의 Kubi/BYOK/Evidence/ADD_REPORT_BLOCK 구현을 복제하지 않고 재사용합니다.

## 주요 변경사항

### Report 작성
- `/reports`, `/reports/:reportId` Report 목록·편집 화면 구현
- 기준 Dataset/Run을 고정한 Report Draft 생성
- Overview / Pipeline / Quality / Schema / Data Summary / Output 구성
- Builder Evidence 기반 deterministic 요약문 생성
- 요약문 우선 표시 + 상세 Evidence 표 펼치기
- Builder Evidence / Kubi Interpretation / User Content provenance 구분

### Evidence
- Dataset/Run/Stage/Quality/Schema/Output evidence 조회
- 일부 API 실패 시 확인 가능한 Report 내용 유지
- 없는 값을 `0`, `PASS`, `정상`으로 임의 대체하지 않음
- CURRENT / STALE / ORPHAN / UNAVAILABLE 상태 구분
- 새로운 Run이 생겨도 기존 Report의 `baseRunId` 자동 변경 없음

### Kubi 연동
- #256의 BYOK/provider/evidence pipeline 재사용
- Report 전용 AI 분석 UX 추가
- 종합 분석, 품질 문제, Pipeline 실패 원인, 활용 아이디어, 주의사항 preset 제공
- 현재 Report의 `datasetId` / `baseRunId` 기준으로 분석
- AI 응답 preview 후 사용자 승인 시에만 Report에 추가
- 기존 `ADD_REPORT_BLOCK` / reportInbox 흐름 유지
- Reports에서는 global Kubi Drawer 대신 inline 분석 UI 사용

### 저장 및 편집
- 브라우저 local persistence 기반 다중 Report Draft 저장
- reopen / rename / duplicate / delete 지원
- revision 기반 동시 수정 충돌 감지
- Builder Evidence는 read-only로 유지
- 사용자 작성 블록 추가·수정 지원
- 기존 legacy Report도 Evidence 재조회 시 narrative summary 표시

### 내보내기 및 보안
- Markdown 다운로드
- 안전한 HTML 다운로드
- Browser Print
- 화면과 동일하게 `요약 → 상세 Evidence` 구조로 export
- unsafe HTML/script 및 위험한 URL 차단
- API Key/Credential/Prompt를 Report에 저장하지 않음
- 지원하지 않는 PDF/DOCX export는 제공하지 않음

### UI
- Prototype 기준 Report document + Report Context 2단 IA 적용
- Report Context sidebar desktop sticky 처리
- 좁은 화면에서는 1단 layout으로 전환
- Dataset / Base Run / Evidence 상태 / Quality / Kubi 상태 표시

## 테스트

- Reports targeted tests: 통과
- 전체 Vitest: **79 files / 575 tests 통과**
- `npm run typecheck`: 통과
- `npm run lint`: 통과
- `npm run build`: 통과
- `git diff --check`: 통과

## 제외 범위

- Builder `/assist`
- server-side Report persistence
- Workspace #260 구현
- Auth #263 principal isolation
- PDF/DOCX renderer
- 실시간 공동 편집
- multi-tab 3-way merge

## ui 사진
<img width="1776" height="1209" alt="image" src="https://github.com/user-attachments/assets/5f873fea-4a3d-4e0a-b361-3e7e4a96848d" />
<img width="1784" height="1130" alt="image" src="https://github.com/user-attachments/assets/41e69ff8-85b7-437a-a7f1-d7ea6ebf9867" />
<img width="1782" height="1090" alt="image" src="https://github.com/user-attachments/assets/b5ec06c8-0ec5-4c53-9f48-1683ca2f46d0" />
<img width="1779" height="796" alt="image" src="https://github.com/user-attachments/assets/05ff37e5-c132-4a6c-ab32-00a8a04a0f8c" />
