### PR TITLE
feat: poll async build jobs from Builder (#245)

### DIFF
--- a/__tests__/asyncBuildJob.test.ts
+++ b/__tests__/asyncBuildJob.test.ts
@@ -1,0 +1,72 @@
+/**
+ * 비동기 build job 폴링 회귀 테스트 (#245).
+ *
+ * Builder async 표면(POST /builds + GET /builds/{run_id}, builder #480/#482)을
+ * MSW 모의 시퀀스(queued → running → terminal)로 검증한다 — 실연동
+ * executeBuild가 잡을 제출·폴링해 terminal 상태를 BuildRun으로 매핑하고,
+ * useBuildJob이 Builder 잡의 wire 상태를 노출하며, 취소(로컬 abort)가
+ * polling을 즉시 종료하는지 확인한다.
+ */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeBuild, type BuilderJobStatus } from "@/features/runs/api";
+import { useBuildJob } from "@/features/runs/useBuildJob";
+import type { BuildSpec } from "@/shared/lib/types";
+
+function specOf(datasetId: string): BuildSpec {
+  return {
+    datasetId,
+    title: datasetId,
+    description: "test spec",
+    sources: [{ provider: "datago", dataset: "air_quality" }],
+    exports: [],
+  } as unknown as BuildSpec;
+}
+
+beforeEach(() => {
+  vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+});
+afterEach(() => vi.unstubAllEnvs());
+
+describe("async build job polling (#245)", () => {
+  it("submits, polls through queued/running, and maps terminal success", async () => {
+    const observed: BuilderJobStatus[] = [];
+
+    const run = await executeBuild(specOf("success"), undefined, (status) =>
+      observed.push(status),
+    );
+
+    expect(run.status).toBe("succeeded");
+    expect(run.id.startsWith("success-")).toBe(true);
+    expect(observed[0]).toBe("queued");
+    expect(observed).toContain("running");
+    expect(observed[observed.length - 1]).toBe("succeeded");
+  });
+
+  it("maps a failed terminal job to a failed run with the job error", async () => {
+    const run = await executeBuild(specOf("fail_source"));
+
+    expect(run.status).toBe("failed");
+    expect(run.error).toBe("upstream API timeout");
+  });
+
+  it("exposes builder job status through useBuildJob and cancels polling locally", async () => {
+    const { result } = renderHook(() => useBuildJob());
+
+    let promise: Promise<void> = Promise.resolve();
+    act(() => {
+      promise = result.current.start(specOf("success"));
+    });
+    await waitFor(() => expect(result.current.status).toBe("running"));
+    await waitFor(() => expect(result.current.builderStatus).toBe("queued"));
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    await act(async () => {
+      await promise.catch(() => undefined);
+    });
+    expect(result.current.status).toBe("cancelled");
+  });
+});

--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -20,6 +20,8 @@ const EXPECTED_OPERATIONS = [
   "validate",
   "preview",
   "build",
+  "submitBuild",
+  "getBuildJob",
   "artifacts",
   "listBuilds",
   "catalog",
@@ -34,8 +36,8 @@ const EXPECTED_OPERATIONS = [
 ] as const;
 
 describe("Builder API contract conformance (#36)", () => {
-  it("pins the last-reviewed contract version Studio targets (builder #209, #504; drift beyond this — e.g. 1.8.0 provider credentials — is Studio #259/#521 scope, not auto-synced)", () => {
-    expect(API_CONTRACT_VERSION).toBe("1.7.0");
+  it("pins the last-reviewed contract version Studio targets (builder #209, #504, #480 async jobs; drift beyond this — e.g. provider credentials, monitoring — is Studio #259/#264 scope, not auto-synced)", () => {
+    expect(API_CONTRACT_VERSION).toBe("1.16.0");
   });
 
   it("exposes exactly the expected client operations", () => {

--- a/__tests__/msw/handlers.ts
+++ b/__tests__/msw/handlers.ts
@@ -102,7 +102,11 @@ export const handlers = [
       typeof body === "object" && body && "run_id" in body
         ? String((body as { run_id?: string }).run_id)
         : `run_async_${Date.now()}`;
-    asyncJobStates.set(runId, { pollCount: 0, failed: spec.includes("dataset_id: fail_source") });
+    // spec은 원시 YAML(e2e) 또는 JSON 직렬화(executeBuild→serializeSpec) 둘 다 올 수
+    // 있으므로 두 형태 모두 판별한다.
+    const failed =
+      spec.includes("dataset_id: fail_source") || spec.includes('"dataset_id":"fail_source"');
+    asyncJobStates.set(runId, { pollCount: 0, failed });
     return HttpResponse.json(
       {
         run_id: runId,

--- a/__tests__/msw/handlers.ts
+++ b/__tests__/msw/handlers.ts
@@ -10,6 +10,18 @@
 import { http, HttpResponse } from "msw";
 import { API_BASE } from "@/shared/config/env";
 
+/**
+ * 비동기 build job 모의 상태 시퀀스 (#245, builder #480/#482).
+ *
+ * POST /builds 제출 직후 queued로 시작해 GET /builds/{run_id} 폴링마다
+ * queued → running → terminal(succeeded/failed)로 진행한다. 실패 시나리오는
+ * spec에 `dataset_id: fail_source`가 포함된 경우로 판별한다(동기 /build 모의와
+ * 동일한 규칙).
+ */
+const asyncJobStates = new Map<string, { pollCount: number; failed: boolean }>();
+
+const ASYNC_JOB_TIMELINE = ["queued", "running"] as const;
+
 export const handlers = [
   /**
    * GET /version — Builder API 계약 버전 확인
@@ -77,6 +89,70 @@ export const handlers = [
       status: "valid" as const,
       dataset_id: "test_dataset",
       api_version: "1.0.0",
+    });
+  }),
+
+  /**
+   * POST /builds — 비동기 build job 제출 (#245, builder #480/#482)
+   */
+  http.post(`${API_BASE}/builds`, async ({ request }) => {
+    const body = await request.json();
+    const spec = typeof body === "object" && body && "spec" in body ? (body as { spec: string }).spec : "";
+    const runId =
+      typeof body === "object" && body && "run_id" in body
+        ? String((body as { run_id?: string }).run_id)
+        : `run_async_${Date.now()}`;
+    asyncJobStates.set(runId, { pollCount: 0, failed: spec.includes("dataset_id: fail_source") });
+    return HttpResponse.json(
+      {
+        run_id: runId,
+        status: "queued",
+        created_at: "2026-08-16T09:00:00+00:00",
+        updated_at: "2026-08-16T09:00:00+00:00",
+      },
+      { status: 202 },
+    );
+  }),
+
+  /**
+   * GET /builds/{run_id} — 비동기 build job 상태 polling (#245)
+   */
+  http.get<{ run_id: string }>(`${API_BASE}/builds/:run_id`, ({ params }) => {
+    const runId = params.run_id as string;
+    const state = asyncJobStates.get(runId);
+    if (!state) {
+      return HttpResponse.json({ error: `build job not found: ${runId}` }, { status: 404 });
+    }
+    state.pollCount += 1;
+    const timelineIndex = Math.min(state.pollCount - 1, ASYNC_JOB_TIMELINE.length - 1);
+    const failed = state.failed;
+    // 마지막 timeline 상태(running)보다 더 폴링되면 terminal로 종결한다.
+    if (state.pollCount > ASYNC_JOB_TIMELINE.length) {
+      const base = {
+        run_id: runId,
+        status: failed ? "failed" : "succeeded",
+        created_at: "2026-08-16T09:00:00+00:00",
+        updated_at: "2026-08-16T09:00:07+00:00",
+      };
+      if (failed) {
+        return HttpResponse.json({ ...base, error: "upstream API timeout" });
+      }
+      return HttpResponse.json({
+        ...base,
+        response: {
+          status: "ok",
+          run_id: runId,
+          outcomes: [],
+          manifest: `output/${runId}/manifest.json`,
+          api_version: "1.16.0",
+        },
+      });
+    }
+    return HttpResponse.json({
+      run_id: runId,
+      status: ASYNC_JOB_TIMELINE[timelineIndex],
+      created_at: "2026-08-16T09:00:00+00:00",
+      updated_at: "2026-08-16T09:00:01+00:00",
     });
   }),
 

--- a/__tests__/useBuildJob.test.tsx
+++ b/__tests__/useBuildJob.test.tsx
@@ -35,19 +35,44 @@ describe("executeBuild (#39)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("calls Builder /build in real mode and maps ok→succeeded", async () => {
+  it("submits an async job and polls it to a succeeded run in real mode (#245)", async () => {
     vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    let pollCount = 0;
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(
-        mockResponse(200, {
-          status: "ok",
+      vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/builds")) {
+          return mockResponse(202, {
+            run_id: "run42",
+            status: "queued",
+            created_at: "2026-08-16T09:00:00+00:00",
+            updated_at: "2026-08-16T09:00:00+00:00",
+          });
+        }
+        pollCount += 1;
+        if (pollCount === 1) {
+          return mockResponse(200, {
+            run_id: "run42",
+            status: "running",
+            created_at: "2026-08-16T09:00:00+00:00",
+            updated_at: "2026-08-16T09:00:01+00:00",
+          });
+        }
+        return mockResponse(200, {
           run_id: "run42",
-          outcomes: [],
-          manifest: "m",
-          api_version: "1.0.0",
-        }),
-      ),
+          status: "succeeded",
+          created_at: "2026-08-16T09:00:00+00:00",
+          updated_at: "2026-08-16T09:00:07+00:00",
+          response: {
+            status: "ok",
+            run_id: "run42",
+            outcomes: [],
+            manifest: "m",
+            api_version: "1.16.0",
+          },
+        });
+      }),
     );
     const run = await executeBuild(spec);
     expect(run.id).toBe("run42");
@@ -70,22 +95,39 @@ describe("useBuildJob (#39)", () => {
     expect(result.current.run?.id).toBe("mock-run");
   });
 
-  it("surfaces the per-source reason from outcomes[].error on a real 502 (#75)", async () => {
+  it("surfaces the derived failure summary on a partial build (#75, #245)", async () => {
     vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
-    // 실제 builder /build 502 와이어 형태: 최상위 error 없음, outcomes[].error에 사유.
+    // 성공한 잡의 최종 build 응답이 부분 실패인 wire — Builder는 첫 실패 outcome에서
+    // 파생한 최상위 error 요약을 항상 실는다(contract BuildFailureResponse).
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(
-        mockResponse(502, {
-          status: "failed",
+      vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/builds")) {
+          return mockResponse(202, {
+            run_id: "run-fail",
+            status: "queued",
+            created_at: "2026-08-16T09:00:00+00:00",
+            updated_at: "2026-08-16T09:00:00+00:00",
+          });
+        }
+        return mockResponse(200, {
           run_id: "run-fail",
-          manifest: "",
-          api_version: "1.0.0",
-          outcomes: [
-            { source_key: "datago:air", status: "failed", error: "upstream source failed" },
-          ],
-        }),
-      ),
+          status: "succeeded",
+          created_at: "2026-08-16T09:00:00+00:00",
+          updated_at: "2026-08-16T09:00:07+00:00",
+          response: {
+            status: "failed",
+            run_id: "run-fail",
+            manifest: "",
+            api_version: "1.16.0",
+            error: "upstream source failed",
+            outcomes: [
+              { source_key: "datago:air", status: "failed", error: "upstream source failed" },
+            ],
+          },
+        });
+      }),
     );
 
     const { result } = renderHook(() => useBuildJob());
@@ -95,28 +137,6 @@ describe("useBuildJob (#39)", () => {
 
     expect(result.current.status).toBe("failed");
     expect(result.current.error).toBe("upstream source failed");
-  });
-
-  it("prefers a top-level error over outcomes when present (backward compat, #75)", async () => {
-    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        mockResponse(502, {
-          status: "failed",
-          error: "top-level build error",
-          outcomes: [{ source_key: "datago:air", status: "failed", error: "ignored reason" }],
-        }),
-      ),
-    );
-
-    const { result } = renderHook(() => useBuildJob());
-    await act(async () => {
-      await result.current.start(spec);
-    });
-
-    expect(result.current.status).toBe("failed");
-    expect(result.current.error).toBe("top-level build error");
   });
 
   it("aborts an in-flight build on unmount (#73)", async () => {

--- a/__tests__/useBuildJob.test.tsx
+++ b/__tests__/useBuildJob.test.tsx
@@ -123,7 +123,12 @@ describe("useBuildJob (#39)", () => {
             api_version: "1.16.0",
             error: "upstream source failed",
             outcomes: [
-              { source_key: "datago:air", status: "failed", error: "upstream source failed" },
+              {
+                source_key: "datago:air",
+                status: "failed",
+                stages_completed: [],
+                error: "upstream source failed",
+              },
             ],
           },
         });

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -116,12 +116,14 @@ async function runAsyncBuild(
   }
 
   const finishedAt = job.updated_at;
+  // run_id는 서버 응답이 정본이다(제출값과 동일이지만 응답 기준으로 통일).
+  const finalRunId = job.run_id;
   if (job.status === "cancelled") {
-    return { id: runId, spec, status: "cancelled", startedAt, finishedAt };
+    return { id: finalRunId, spec, status: "cancelled", startedAt, finishedAt };
   }
   if (job.status === "failed") {
     return {
-      id: runId,
+      id: finalRunId,
       spec,
       status: "failed",
       startedAt,
@@ -138,7 +140,7 @@ async function runAsyncBuild(
     const reason =
       response.error || outcomeReason || "일부 소스 빌드가 실패했습니다.";
     return {
-      id: runId,
+      id: finalRunId,
       spec,
       status: "failed",
       startedAt,
@@ -146,7 +148,7 @@ async function runAsyncBuild(
       error: reason,
     };
   }
-  return { id: runId, spec, status: "succeeded", startedAt, finishedAt };
+  return { id: finalRunId, spec, status: "succeeded", startedAt, finishedAt };
 }
 
 /** 데모 카탈로그 항목을 목록/이력 UI용 BuildSpec으로 변환한다. */

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -131,15 +131,19 @@ async function runAsyncBuild(
   }
   const response = job.response;
   // 성공 잡의 최종 build 응답이 부분 실패(status: "failed", 502와 동일한 wire)일 수
-  // 있다 — terminal failure와 partial-result를 구분해 그대로 노출한다.
+  // 있다 — terminal failure와 partial-result를 구분하고, 사유 우선순위는 동기 /build
+  // 502와 동일하게 최상위 error → outcomes[].error → 기본 문구(#75)를 따른다.
   if (response && response.status !== "ok") {
+    const outcomeReason = response.outcomes.find((outcome) => outcome.error)?.error;
+    const reason =
+      response.error || outcomeReason || "일부 소스 빌드가 실패했습니다.";
     return {
       id: runId,
       spec,
       status: "failed",
       startedAt,
       finishedAt,
-      error: "일부 소스 빌드가 실패했습니다.",
+      error: reason,
     };
   }
   return { id: runId, spec, status: "succeeded", startedAt, finishedAt };

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -37,7 +37,20 @@ export function generateRunId(datasetId: string): string {
  * @param signal - 취소용 AbortSignal(선택).
  * @returns 생성된 빌드 실행 정보.
  */
-export async function executeBuild(spec: BuildSpec, signal?: AbortSignal): Promise<BuildRun> {
+/** Builder 잡 상태를 Studio 실행 상태로 매핑한다 (builder 1.16.0 #480). */
+export type BuilderJobStatus =
+  | "queued"
+  | "running"
+  | "cancelling"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+export async function executeBuild(
+  spec: BuildSpec,
+  signal?: AbortSignal,
+  onJobStatus?: (status: BuilderJobStatus) => void,
+): Promise<BuildRun> {
   if (!isRealBuilderEnabled()) {
     const mockRun: BuildRun = {
       id: "mock-run",
@@ -54,20 +67,82 @@ export async function executeBuild(spec: BuildSpec, signal?: AbortSignal): Promi
   // 실연동 모드에서는 실제 실행 시각을 기록한다(이력/상세 화면에서 잘못된 1970 값 방지).
   const runId = generateRunId(spec.datasetId);
   const startedAt = new Date().toISOString();
-  const result = await builderApi.build(serializeSpec(spec), runId, signal);
+  const result = await runAsyncBuild(spec, runId, startedAt, signal, onJobStatus);
 
   // Builder는 spec을 영속화하지 않으므로(#120), 이후 편집 화면이 기존 스펙을 복원할 수
   // 있도록 Studio가 실행 시점의 스펙을 run_id에 묶어 보관한다. 저장 실패는 무시되며
   // 빌드 결과에는 영향을 주지 않는다.
-  saveBuildSpec(result.run_id, spec);
+  saveBuildSpec(result.id, spec);
 
-  return {
-    id: result.run_id,
-    spec,
-    status: result.status === "ok" ? "succeeded" : "failed",
-    startedAt,
-    finishedAt: new Date().toISOString(),
-  };
+  return result;
+}
+
+const POLL_INTERVAL_MS = 800;
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        reject(new DOMException("aborted", "AbortError"));
+      },
+      { once: true },
+    );
+  });
+}
+
+async function runAsyncBuild(
+  spec: BuildSpec,
+  runId: string,
+  startedAt: string,
+  signal: AbortSignal | undefined,
+  onJobStatus: ((status: BuilderJobStatus) => void) | undefined,
+): Promise<BuildRun> {
+  const submitted = await builderApi.submitBuild(serializeSpec(spec), runId, signal);
+  onJobStatus?.(submitted.status);
+
+  // 제출 직후 이미 terminal인 경우(동일 run_id 재제출 등) 폴링 없이 바로 판정한다.
+  let job = submitted;
+  while (job.status !== "succeeded" && job.status !== "failed" && job.status !== "cancelled") {
+    await sleep(POLL_INTERVAL_MS, signal);
+    job = await builderApi.getBuildJob(runId, signal);
+    onJobStatus?.(job.status);
+  }
+
+  const finishedAt = job.updated_at;
+  if (job.status === "cancelled") {
+    return { id: runId, spec, status: "cancelled", startedAt, finishedAt };
+  }
+  if (job.status === "failed") {
+    return {
+      id: runId,
+      spec,
+      status: "failed",
+      startedAt,
+      finishedAt,
+      error: job.error ?? "빌드 잡이 실패했습니다.",
+    };
+  }
+  const response = job.response;
+  // 성공 잡의 최종 build 응답이 부분 실패(status: "failed", 502와 동일한 wire)일 수
+  // 있다 — terminal failure와 partial-result를 구분해 그대로 노출한다.
+  if (response && response.status !== "ok") {
+    return {
+      id: runId,
+      spec,
+      status: "failed",
+      startedAt,
+      finishedAt,
+      error: "일부 소스 빌드가 실패했습니다.",
+    };
+  }
+  return { id: runId, spec, status: "succeeded", startedAt, finishedAt };
 }
 
 /** 데모 카탈로그 항목을 목록/이력 UI용 BuildSpec으로 변환한다. */

--- a/src/features/runs/useBuildJob.ts
+++ b/src/features/runs/useBuildJob.ts
@@ -2,11 +2,12 @@
  * 빌드 실행을 비동기 job으로 관리하는 훅 (#39).
  *
  * idle → running → succeeded/failed/cancelled 상태 머신과 취소(AbortController)를
- * 제공한다. Builder의 /build가 동기식인 현재는 단일 호출을 감싸지만, Builder에 job
- * 제출/폴링 엔드포인트가 생기면 이 훅 내부만 폴링으로 확장하면 된다(호출부 변경 없음).
+ * 제공한다. 실연동 모드에서는 Builder 비동기 job 표면(POST /builds + GET
+ * /builds/{run_id} 폴링, builder #480/#482)을 사용하고, 폴링 중인 잡의 wire
+ * 상태(queued/running/...)를 builderStatus로 노출한다(#245).
  */
 import { useCallback, useEffect, useRef, useState } from "react";
-import { executeBuild } from "@/features/runs/api";
+import { executeBuild, type BuilderJobStatus } from "@/features/runs/api";
 import { ApiError, extractErrorMessage } from "@/shared/lib/builderApi";
 import type { BuildRun, BuildSpec } from "@/shared/lib/types";
 
@@ -15,6 +16,8 @@ export type BuildJobStatus = "idle" | "running" | "succeeded" | "failed" | "canc
 export interface BuildJob {
   /** 현재 job 상태 */
   status: BuildJobStatus;
+  /** Builder 잡의 최신 wire 상태(queued/running/cancelling — 실연동 폴링 중) */
+  builderStatus?: BuilderJobStatus;
   /** 완료된 실행 결과(성공/실패 시) */
   run?: BuildRun;
   /** 실패 시 오류 메시지 */
@@ -32,6 +35,7 @@ export interface BuildJob {
  */
 export function useBuildJob(): BuildJob {
   const [status, setStatus] = useState<BuildJobStatus>("idle");
+  const [builderStatus, setBuilderStatus] = useState<BuilderJobStatus>();
   const [run, setRun] = useState<BuildRun>();
   const [error, setError] = useState<string>();
   const controllerRef = useRef<AbortController | null>(null);
@@ -40,14 +44,17 @@ export function useBuildJob(): BuildJob {
     const controller = new AbortController();
     controllerRef.current = controller;
     setStatus("running");
+    setBuilderStatus(undefined);
     setError(undefined);
     setRun(undefined);
     try {
-      const result = await executeBuild(spec, controller.signal);
+      const result = await executeBuild(spec, controller.signal, (jobStatus) => {
+        if (!controller.signal.aborted) setBuilderStatus(jobStatus);
+      });
       if (controller.signal.aborted) return;
       setRun(result);
       setStatus(result.status === "succeeded" ? "succeeded" : "failed");
-      if (result.status !== "succeeded") setError("일부 소스 빌드가 실패했습니다.");
+      if (result.status !== "succeeded") setError(result.error ?? "일부 소스 빌드가 실패했습니다.");
     } catch (cause) {
       if (controller.signal.aborted) {
         setStatus("cancelled");
@@ -75,5 +82,5 @@ export function useBuildJob(): BuildJob {
   // 언마운트 시 진행 중인 실행을 중단해 unmount 이후 setState를 방지한다(#73).
   useEffect(() => () => controllerRef.current?.abort(), []);
 
-  return { status, run, error, start, cancel };
+  return { status, builderStatus, run, error, start, cancel };
 }

--- a/src/shared/lib/builderApi.schema.ts
+++ b/src/shared/lib/builderApi.schema.ts
@@ -96,6 +96,25 @@ export const buildResponseSchema = z.discriminatedUnion("status", [
 ]);
 
 /**
+ * 비동기 build job 스냅샷 — GET /builds/{run_id} / POST /builds 응답 (#245, builder 1.16.0 #480).
+ *
+ * `cancelling`/`cancelled`는 builder #481 cooperative cancellation 착지 전 예약
+ * vocabulary다(현재 전이를 일으키는 endpoint는 없음). `response`는 성공한 잡의
+ * 최종 build 응답 본문이다.
+ */
+export const buildJobSchema = z.object({
+  run_id: z.string(),
+  status: z.enum(["queued", "running", "cancelling", "succeeded", "failed", "cancelled"]),
+  created_at: z.string(),
+  updated_at: z.string(),
+  created_by: z.string().nullable().optional(),
+  response: buildResponseSchema.nullable().optional(),
+  error: z.string().nullable().optional(),
+});
+
+export type BuildJob = z.infer<typeof buildJobSchema>;
+
+/**
  * GET /artifacts/{run_id} 응답 스키마
  */
 export const artifactsResponseSchema = z.object({

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -26,13 +26,14 @@ import { z } from "zod";
  * 동일"이 아니다). 1.6.0 -> 1.7.0: Silver/Gold read-only `/query` 추가(#504, additive —
  * 기존 엔드포인트는 변경 없음).
  *
- * Builder는 additive 변경마다 이 값을 계속 올린다(예: 1.8.0 — per-user provider
- * credentials). Studio는 그 operation을 아직 구현하지 않았으므로(Provider API 연동은
- * Studio #259 범위) 여기서 숫자만 따라 올리지 않는다 — 그러면 아직 없는 기능을
- * 지원한다고 오인시킨다. exact-equality pin 정책 자체(버전마다 무조건 맞출지,
- * capability 기준으로 협상할지)는 builder #521에서 논의 중이며 여기서 선결하지 않는다.
+ * Builder는 additive 변경마다 이 값을 계속 올린다. Studio는 자신이 실제로 검토·
+ * 연동한 버전만 고정한다 — 현재는 async build job 표면(POST /builds, GET
+ * /builds/{run_id}, builder #480/#482)까지 검토·연동했다. 미연동 operation(예:
+ * provider credentials 1.8.0, monitoring 1.11.0)은 여기 숫자에 반영해도 실제
+ * 호출이 없으므로 따로 올리지 않는다. pin 정책 자체는 builder ADR 0013(#521)의
+ * 기능별 최소 SemVer 판정으로 전환 중이다.
  */
-export const API_CONTRACT_VERSION = "1.7.0";
+export const API_CONTRACT_VERSION = "1.16.0";
 
 /** 실제 Builder 호출 활성화 여부(미설정 시 mock 사용). */
 export function isRealBuilderEnabled(): boolean {
@@ -411,6 +412,27 @@ export const builderApi = {
         retries: 0,
       },
       schemas.buildResponseSchema,
+    ),
+
+  /** POST /builds — 비동기 build job 제출 (#245, builder #482/#480). 재시도하지 않는다. */
+  submitBuild: (specYaml: string, runId?: string, signal?: AbortSignal) =>
+    apiFetch(
+      "/builds",
+      {
+        method: "POST",
+        body: runId ? { spec: specYaml, run_id: runId } : { spec: specYaml },
+        signal,
+        retries: 0,
+      },
+      schemas.buildJobSchema,
+    ),
+
+  /** GET /builds/{run_id} — 비동기 build job 상태 polling (#245, builder #482/#480). */
+  getBuildJob: (runId: string, signal?: AbortSignal) =>
+    apiFetch(
+      `/builds/${encodeURIComponent(runId)}`,
+      { signal, retries: 1 },
+      schemas.buildJobSchema,
     ),
 
   /** GET /artifacts/{runId} — 실행 산출물 파일 목록. */

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -173,6 +173,8 @@ export interface BuildRun {
   startedAt: string;
   /** 실행 종료 시각 ISO 문자열 */
   finishedAt?: string;
+  /** 실패/취소 사유 (실패·부분 실패 잡의 terminal 상태에서만) */
+  error?: string;
 }
 
 /**


### PR DESCRIPTION
Closes #245

- 실연동 모드에서 `POST /builds` 제출 + `GET /builds/{run_id}` 폴링으로 전환(builder 계약 1.16.0, #480/#482)
- terminal 상태 매핑: 성공 / 실패(잡 error) / 부분 실패(성공 잡의 최종 응답이 failed outcomes) / 취소 — DoD의 상태 구분 충족
- `useBuildJob`이 폴링 중 Builder 잡 wire 상태(queued/running/cancelling)를 `builderStatus`로 노출, 로컬 취소는 polling 즉시 중단
- 동기 `POST /build` operation과 mock 모드는 유지(하위 호환)
- conformance pin 1.7.0 → 1.16.0(async 표면 검토·연동), MSW 폴링 시퀀스 테스트 추가