### PR TITLE
[Monitoring][P1] 시스템 리소스·Build 통계 Monitoring 화면 구현 (#264)

### DIFF
--- a/__tests__/newIaPages.test.tsx
+++ b/__tests__/newIaPages.test.tsx
@@ -23,11 +23,16 @@ describe("새 IA placeholder 화면 (#247)", () => {
     [<WorkspacePage />, "작업대"],
     [<AddDataPage />, "데이터 추가"],
     [<ProviderPage />, "Provider"],
-    [<MonitoringPage />, "모니터링"],
   ])("renders its title and a 준비 중 안내 without crashing", (element, title) => {
     renderPage(element);
     expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
     expect(screen.getByText("아직 준비 중인 화면입니다")).toBeInTheDocument();
+  });
+
+  it("Monitoring is replaced with the real Builder-backed system/build stats screen (#264)", () => {
+    renderPage(<MonitoringPage />);
+    expect(screen.getByRole("heading", { name: "모니터링" })).toBeInTheDocument();
+    expect(screen.queryByText("아직 준비 중인 화면입니다")).not.toBeInTheDocument();
   });
 
   it("Reports is replaced with the real Builder evidence-based Report screen (#258)", () => {

--- a/src/features/monitoring/BuildStatistics.tsx
+++ b/src/features/monitoring/BuildStatistics.tsx
@@ -3,7 +3,7 @@
  *
  * 시간대별 build 수와 상태별 카운트를 표시합니다.
  */
-import type { BuildStats } from "../api/types";
+import type { BuildStats } from "./api/types";
 
 interface BuildStatsProps {
   data: BuildStats;

--- a/src/features/monitoring/BuildStatistics.tsx
+++ b/src/features/monitoring/BuildStatistics.tsx
@@ -1,0 +1,107 @@
+/**
+ * 빌드 통계 UI 컴포넌트 (#264).
+ *
+ * 시간대별 build 수와 상태별 카운트를 표시합니다.
+ */
+import type { BuildStats } from "../api/types";
+
+interface BuildStatsProps {
+  data: BuildStats;
+}
+
+export function BuildStatistics({ data }: BuildStatsProps) {
+  const formatTime = (isoString: string) => {
+    const date = new Date(isoString);
+    return `${date.getHours().toString().padStart(2, "0")}:${date.getMinutes().toString().padStart(2, "0")}`;
+  };
+
+  const formatPercentage = (value: number, total: number) => {
+    if (total === 0) return "0.0%";
+    return `${((value / total) * 100).toFixed(1)}%`;
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* 요약 통계 */}
+      <div className="bg-white p-4 rounded-lg border border-gray-200 shadow-sm">
+        <h3 className="text-lg font-semibold mb-3">빌드 통계 요약</h3>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="text-center">
+            <div className="text-3xl font-bold text-blue-600">{data.summary.total_count}</div>
+            <div className="text-sm text-gray-600">전체</div>
+          </div>
+          <div className="text-center">
+            <div className="text-3xl font-bold text-green-600">{data.summary.success_count}</div>
+            <div className="text-sm text-gray-600">성공</div>
+            <div className="text-xs text-gray-500">
+              {formatPercentage(data.summary.success_count, data.summary.total_count)}
+            </div>
+          </div>
+          <div className="text-center">
+            <div className="text-3xl font-bold text-red-600">{data.summary.fail_count}</div>
+            <div className="text-sm text-gray-600">실패</div>
+            <div className="text-xs text-gray-500">
+              {formatPercentage(data.summary.fail_count, data.summary.total_count)}
+            </div>
+          </div>
+          <div className="text-center">
+            <div className="text-3xl font-bold text-yellow-600">{data.summary.cancelled_count}</div>
+            <div className="text-sm text-gray-600">취소</div>
+            <div className="text-xs text-gray-500">
+              {formatPercentage(data.summary.cancelled_count, data.summary.total_count)}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 시간대별 통계 */}
+      <div className="bg-white p-4 rounded-lg border border-gray-200 shadow-sm">
+        <h3 className="text-lg font-semibold mb-3">시간대별 빌드 통계</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200">
+                <th className="text-left py-2 px-3 font-medium text-gray-700">시간</th>
+                <th className="text-right py-2 px-3 font-medium text-gray-700">전체</th>
+                <th className="text-right py-2 px-3 font-medium text-gray-700">성공</th>
+                <th className="text-right py-2 px-3 font-medium text-gray-700">실패</th>
+                <th className="text-right py-2 px-3 font-medium text-gray-700">취소</th>
+                <th className="text-left py-2 px-3 font-medium text-gray-700">성공률</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.entries.map((entry, index) => (
+                <tr key={index} className="border-b border-gray-100 hover:bg-gray-50">
+                  <td className="py-2 px-3 text-gray-900">{formatTime(entry.timestamp)}</td>
+                  <td className="py-2 px-3 text-right text-gray-900">{entry.total_count}</td>
+                  <td className="py-2 px-3 text-right text-green-600">{entry.success_count}</td>
+                  <td className="py-2 px-3 text-right text-red-600">{entry.fail_count}</td>
+                  <td className="py-2 px-3 text-right text-yellow-600">{entry.cancelled_count}</td>
+                  <td className="py-2 px-3 text-gray-700">
+                    {entry.total_count > 0 ? (
+                      <div className="flex items-center">
+                        <div className="w-20 bg-gray-200 rounded-full h-2 mr-2">
+                          <div
+                            className="bg-green-600 h-2 rounded-full"
+                            style={{
+                              width: `${(entry.success_count / entry.total_count) * 100}%`
+                            }}
+                          />
+                        </div>
+                        <span className="text-xs">
+                          {formatPercentage(entry.success_count, entry.total_count)}
+                        </span>
+                      </div>
+                    ) : (
+                      <span className="text-xs text-gray-500">-</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/monitoring/RecentBuildsList.tsx
+++ b/src/features/monitoring/RecentBuildsList.tsx
@@ -3,10 +3,10 @@
  *
  * Build 상세 화면으로 네비게이션할 수 있는 최근 빌드 정보를 표시합니다.
  */
-import type { RecentBuilds } from "../api/types";
+import type { RecentBuilds } from "./api/types";
 
 interface RecentBuildsListProps {
-  builds: RecentBuilds;
+  builds: RecentBuilds | null;
   isLoading: boolean;
   error: Error | null;
   onNavigateToBuild: (runId: string) => void;

--- a/src/features/monitoring/RecentBuildsList.tsx
+++ b/src/features/monitoring/RecentBuildsList.tsx
@@ -1,0 +1,155 @@
+/**
+ * 최근 빌드 목록 UI 컴포넌트 (#264).
+ *
+ * Build 상세 화면으로 네비게이션할 수 있는 최근 빌드 정보를 표시합니다.
+ */
+import type { RecentBuilds } from "../api/types";
+
+interface RecentBuildsListProps {
+  builds: RecentBuilds;
+  isLoading: boolean;
+  error: Error | null;
+  onNavigateToBuild: (runId: string) => void;
+  onRefresh: () => void;
+}
+
+export function RecentBuildsList({ builds, isLoading, error, onNavigateToBuild, onRefresh }: RecentBuildsListProps) {
+  const formatTime = (isoString: string | null) => {
+    if (!isoString) return "-";
+    const date = new Date(isoString);
+    return `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, "0")}-${date.getDate().toString().padStart(2, "0")} ${date.getHours().toString().padStart(2, "0")}:${date.getMinutes().toString().padStart(2, "0")}`;
+  };
+
+  const getStatusBadge = (status: string) => {
+    const baseClass = "px-2 py-1 rounded text-xs font-medium";
+    switch (status) {
+      case "ok":
+        return `${baseClass} bg-green-100 text-green-800`;
+      case "failed":
+        return `${baseClass} bg-red-100 text-red-800`;
+      case "cancelled":
+        return `${baseClass} bg-yellow-100 text-yellow-800`;
+      default:
+        return `${baseClass} bg-gray-100 text-gray-800`;
+    }
+  };
+
+  const getStatusText = (status: string) => {
+    switch (status) {
+      case "ok":
+        return "성공";
+      case "failed":
+        return "실패";
+      case "cancelled":
+        return "취소";
+      default:
+        return status;
+    }
+  };
+
+  if (isLoading && !builds) {
+    return (
+      <div className="bg-white p-4 rounded-lg border border-gray-200 shadow-sm">
+        <div className="flex items-center justify-center py-8">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white p-4 rounded-lg border border-gray-200 shadow-sm">
+        <div className="flex flex-col items-center py-8">
+          <div className="text-red-600 mb-2">
+            <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <p className="text-sm text-gray-600 mb-3">{error.message}</p>
+          <button
+            onClick={onRefresh}
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+          >
+            다시 시도
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!builds || builds.builds.length === 0) {
+    return (
+      <div className="bg-white p-4 rounded-lg border border-gray-200 shadow-sm">
+        <div className="flex flex-col items-center py-8">
+          <div className="text-gray-400 mb-2">
+            <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+            </svg>
+          </div>
+          <p className="text-sm text-gray-600">최근 빌드가 없습니다</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white p-4 rounded-lg border border-gray-200 shadow-sm">
+      <div className="flex justify-between items-center mb-3">
+        <h3 className="text-lg font-semibold">최근 빌드</h3>
+        <button
+          onClick={onRefresh}
+          className="text-sm text-blue-600 hover:text-blue-800 transition-colors"
+          disabled={isLoading}
+        >
+          {isLoading ? "로딩 중..." : "새로고침"}
+        </button>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-200">
+              <th className="text-left py-2 px-3 font-medium text-gray-700">빌드 ID</th>
+              <th className="text-left py-2 px-3 font-medium text-gray-700">데이터셋</th>
+              <th className="text-center py-2 px-3 font-medium text-gray-700">상태</th>
+              <th className="text-right py-2 px-3 font-medium text-gray-700">시작 시간</th>
+              <th className="text-right py-2 px-3 font-medium text-gray-700">완료 시간</th>
+              <th className="text-right py-2 px-3 font-medium text-gray-700">동작</th>
+            </tr>
+          </thead>
+          <tbody>
+            {builds.builds.map((build) => (
+              <tr key={build.run_id} className="border-b border-gray-100 hover:bg-gray-50">
+                <td className="py-2 px-3 text-gray-900 font-mono text-xs">
+                  {build.run_id}
+                </td>
+                <td className="py-2 px-3 text-gray-900">
+                  {build.dataset_id || "-"}
+                </td>
+                <td className="py-2 px-3 text-center">
+                  <span className={getStatusBadge(build.status)}>
+                    {getStatusText(build.status)}
+                  </span>
+                </td>
+                <td className="py-2 px-3 text-right text-gray-600">
+                  {formatTime(build.started_at)}
+                </td>
+                <td className="py-2 px-3 text-right text-gray-600">
+                  {formatTime(build.finished_at)}
+                </td>
+                <td className="py-2 px-3 text-right">
+                  <button
+                    onClick={() => onNavigateToBuild(build.run_id)}
+                    className="text-blue-600 hover:text-blue-800 text-xs font-medium transition-colors"
+                  >
+                    상세 보기
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/features/monitoring/SystemResources.tsx
+++ b/src/features/monitoring/SystemResources.tsx
@@ -3,7 +3,7 @@
  *
  * Builder API health, queue status, workers, artifact store 상태를 표시합니다.
  */
-import type { SystemResource } from "../api/types";
+import type { SystemResource } from "./api/types";
 
 interface SystemResourcesProps {
   data: SystemResource;

--- a/src/features/monitoring/SystemResources.tsx
+++ b/src/features/monitoring/SystemResources.tsx
@@ -1,0 +1,183 @@
+/**
+ * 시스템 리소스 모니터링 UI 컴포넌트 (#264).
+ *
+ * Builder API health, queue status, workers, artifact store 상태를 표시합니다.
+ */
+import type { SystemResource } from "../api/types";
+
+interface SystemResourcesProps {
+  data: SystemResource;
+  lastUpdated: string;
+}
+
+export function SystemResources({ data, lastUpdated }: SystemResourcesProps) {
+  const formatTime = (isoString: string) => {
+    return new Date(isoString).toLocaleString("ko-KR");
+  };
+
+  const formatLatency = (ms: number | null) => {
+    if (ms === null) return "데이터 없음";
+    if (ms < 1000) return `${ms}ms`;
+    return `${(ms / 1000).toFixed(2)}s`;
+  };
+
+  const formatPercentage = (value: number) => {
+    return `${(value * 100).toFixed(1)}%`;
+  };
+
+  const getHealthColor = (health: string) => {
+    switch (health) {
+      case "healthy":
+        return "text-green-600";
+      case "degraded":
+        return "text-yellow-600";
+      case "unavailable":
+        return "text-red-600";
+      default:
+        return "text-gray-600";
+    }
+  };
+
+  const getHealthBgColor = (health: string) => {
+    switch (health) {
+      case "healthy":
+        return "bg-green-100 border-green-200";
+      case "degraded":
+        return "bg-yellow-100 border-yellow-200";
+      case "unavailable":
+        return "bg-red-100 border-red-200";
+      default:
+        return "bg-gray-100 border-gray-200";
+    }
+  };
+
+  const getStoreStatusColor = (status: string) => {
+    switch (status) {
+      case "available":
+        return "text-green-600";
+      case "degraded":
+        return "text-yellow-600";
+      case "unavailable":
+        return "text-red-600";
+      default:
+        return "text-gray-600";
+    }
+  };
+
+  const getProviderStatusColor = (status: string) => {
+    switch (status) {
+      case "available":
+        return "text-green-600";
+      case "degraded":
+        return "text-yellow-600";
+      case "unavailable":
+        return "text-red-600";
+      default:
+        return "text-gray-600";
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* API Health */}
+      <div className={`p-4 rounded-lg border ${getHealthBgColor(data.health)}`}>
+        <h3 className="text-lg font-semibold mb-2">Builder API 상태</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <span className="text-sm text-gray-600">Health:</span>
+            <span className={`ml-2 font-medium ${getHealthColor(data.health)}`}>
+              {data.health.toUpperCase()}
+            </span>
+          </div>
+          <div>
+            <span className="text-sm text-gray-600">P95 Latency:</span>
+            <span className="ml-2 font-medium">
+              {formatLatency(data.p95_latency)}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Queue Status */}
+      <div className="bg-white p-4 rounded-lg border border-gray-200 shadow-sm">
+        <h3 className="text-lg font-semibold mb-3">큐 상태</h3>
+        <div className="grid grid-cols-3 gap-4">
+          <div className="text-center">
+            <div className="text-2xl font-bold text-blue-600">{data.queue.queued}</div>
+            <div className="text-sm text-gray-600">Queued</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-green-600">{data.queue.running}</div>
+            <div className="text-sm text-gray-600">Running</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-gray-600">{data.queue.total}</div>
+            <div className="text-sm text-gray-600">Total</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Workers Status */}
+      <div className="bg-white p-4 rounded-lg border border-gray-200 shadow-sm">
+        <h3 className="text-lg font-semibold mb-3">워커 상태</h3>
+        <div className="space-y-3">
+          <div className="flex justify-between items-center">
+            <span className="text-sm text-gray-600">Active Workers:</span>
+            <span className="font-medium">{data.workers.active} / {data.workers.capacity}</span>
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-4">
+            <div
+              className="bg-blue-600 h-4 rounded-full transition-all"
+              style={{ width: `${data.workers.utilization * 100}%` }}
+            />
+          </div>
+          <div className="flex justify-between items-center">
+            <span className="text-sm text-gray-600">Utilization:</span>
+            <span className="font-medium">{formatPercentage(data.workers.utilization)}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Artifact Store Status */}
+      <div className="bg-white p-4 rounded-lg border border-gray-200 shadow-sm">
+        <h3 className="text-lg font-semibold mb-3">Artifact Store 상태</h3>
+        <div className="space-y-2">
+          <div className="flex justify-between items-center">
+            <span className="text-sm text-gray-600">Status:</span>
+            <span className={`font-medium ${getStoreStatusColor(data.artifact_store.status)}`}>
+              {data.artifact_store.status.toUpperCase()}
+            </span>
+          </div>
+          <div className="flex justify-between items-center">
+            <span className="text-sm text-gray-600">Last Write:</span>
+            <span className="font-medium">
+              {data.artifact_store.last_write ? formatTime(data.artifact_store.last_write) : "데이터 없음"}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Provider Status */}
+      {data.provider_status && Object.keys(data.provider_status).length > 0 && (
+        <div className="bg-white p-4 rounded-lg border border-gray-200 shadow-sm">
+          <h3 className="text-lg font-semibold mb-3">Provider 상태</h3>
+          <div className="space-y-2">
+            {Object.entries(data.provider_status).map(([provider, status]) => (
+              <div key={provider} className="flex justify-between items-center">
+                <span className="text-sm text-gray-600">{provider}:</span>
+                <span className={`font-medium ${getProviderStatusColor(status)}`}>
+                  {status.toUpperCase()}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Last Updated */}
+      <div className="text-sm text-gray-500 text-center">
+        마지막 업데이트: {formatTime(lastUpdated)}
+      </div>
+    </div>
+  );
+}

--- a/src/features/monitoring/api/index.ts
+++ b/src/features/monitoring/api/index.ts
@@ -4,7 +4,7 @@
  * Builder #516 시스템/집계 monitoring API와 통신합니다.
  * 실연동 모드와 mock 모드를 모두 지원합니다.
  */
-import { builderApi, isRealBuilderEnabled, type ApiError } from "@/shared/lib/builderApi";
+import { apiFetch, isRealBuilderEnabled, type ApiError } from "@/shared/lib/builderApi";
 import {
   buildStatsSchema,
   monitoringResponseSchema,
@@ -17,6 +17,8 @@ import type {
   RecentBuilds,
   SystemResource,
 } from "./types";
+
+export type { BuildStats, MonitoringAvailability, MonitoringResponse, RecentBuilds, SystemResource } from "./types";
 
 /**
  * 시스템 리소스 상태를 조회합니다 (#264).
@@ -32,7 +34,7 @@ export async function getSystemResources(signal?: AbortSignal): Promise<SystemRe
 
   // 실연동 모드에서 Builder API 호출
   // Builder #516 endpoint 형태: GET /monitoring/system
-  return builderApi.apiFetch<SystemResource>(
+  return apiFetch<SystemResource>(
     "/monitoring/system",
     { signal, skipAuth: false },
     systemResourceSchema,
@@ -54,7 +56,7 @@ export async function getBuildStats(limit?: number, signal?: AbortSignal): Promi
 
   const query = limit !== undefined ? `?limit=${limit}` : "";
   // Builder #516 endpoint 형태: GET /monitoring/build-stats?limit=N
-  return builderApi.apiFetch<BuildStats>(
+  return apiFetch<BuildStats>(
     `/monitoring/build-stats${query}`,
     { signal, skipAuth: false },
     buildStatsSchema,
@@ -74,7 +76,7 @@ export async function getMonitoringData(signal?: AbortSignal): Promise<Monitorin
   }
 
   // Builder #516 endpoint 형태: GET /monitoring
-  return builderApi.apiFetch<MonitoringResponse>(
+  return apiFetch<MonitoringResponse>(
     "/monitoring",
     { signal, skipAuth: false },
     monitoringResponseSchema,
@@ -98,7 +100,7 @@ export async function getRecentBuilds(limit = 10, signal?: AbortSignal): Promise
 
   const query = `?limit=${limit}`;
   // 기존 GET /builds endpoint 재사용
-  const response = await builderApi.apiFetch<{ builds: Array<{
+  const response = await apiFetch<{ builds: Array<{
     run_id: string;
     status: "ok" | "failed" | "cancelled";
     started_at: string | null;
@@ -133,7 +135,7 @@ export async function checkMonitoringAvailability(
   }
 
   try {
-    const response = await builderApi.apiFetch<{ availability: MonitoringAvailability }>(
+    const response = await apiFetch<{ availability: MonitoringAvailability }>(
       "/monitoring/availability",
       { signal, skipAuth: false },
     );

--- a/src/features/monitoring/api/index.ts
+++ b/src/features/monitoring/api/index.ts
@@ -1,0 +1,258 @@
+/**
+ * Monitoring API 클라이언트 (#264).
+ *
+ * Builder #516 시스템/집계 monitoring API와 통신합니다.
+ * 실연동 모드와 mock 모드를 모두 지원합니다.
+ */
+import { builderApi, isRealBuilderEnabled, type ApiError } from "@/shared/lib/builderApi";
+import {
+  buildStatsSchema,
+  monitoringResponseSchema,
+  systemResourceSchema,
+} from "./types";
+import type {
+  BuildStats,
+  MonitoringAvailability,
+  MonitoringResponse,
+  RecentBuilds,
+  SystemResource,
+} from "./types";
+
+/**
+ * 시스템 리소스 상태를 조회합니다 (#264).
+ *
+ * @param signal - 취소용 AbortSignal (선택).
+ * @returns 시스템 리소스 상태.
+ * @throws ApiError - API 요청이 실패한 경우.
+ */
+export async function getSystemResources(signal?: AbortSignal): Promise<SystemResource> {
+  if (!isRealBuilderEnabled()) {
+    return mockSystemResources();
+  }
+
+  // 실연동 모드에서 Builder API 호출
+  // Builder #516 endpoint 형태: GET /monitoring/system
+  return builderApi.apiFetch<SystemResource>(
+    "/monitoring/system",
+    { signal, skipAuth: false },
+    systemResourceSchema,
+  );
+}
+
+/**
+ * 빌드 통계를 조회합니다 (#264).
+ *
+ * @param limit - 조회할 시간대 수 (선택).
+ * @param signal - 취소용 AbortSignal (선택).
+ * @returns 빌드 통계.
+ * @throws ApiError - API 요청이 실패한 경우.
+ */
+export async function getBuildStats(limit?: number, signal?: AbortSignal): Promise<BuildStats> {
+  if (!isRealBuilderEnabled()) {
+    return mockBuildStats();
+  }
+
+  const query = limit !== undefined ? `?limit=${limit}` : "";
+  // Builder #516 endpoint 형태: GET /monitoring/build-stats?limit=N
+  return builderApi.apiFetch<BuildStats>(
+    `/monitoring/build-stats${query}`,
+    { signal, skipAuth: false },
+    buildStatsSchema,
+  );
+}
+
+/**
+ * 전체 monitoring 데이터를 조회합니다 (#264).
+ *
+ * @param signal - 취소용 AbortSignal (선택).
+ * @returns monitoring 응답.
+ * @throws ApiError - API 요청이 실패한 경우.
+ */
+export async function getMonitoringData(signal?: AbortSignal): Promise<MonitoringResponse> {
+  if (!isRealBuilderEnabled()) {
+    return mockMonitoringData();
+  }
+
+  // Builder #516 endpoint 형태: GET /monitoring
+  return builderApi.apiFetch<MonitoringResponse>(
+    "/monitoring",
+    { signal, skipAuth: false },
+    monitoringResponseSchema,
+  );
+}
+
+/**
+ * 최근 빌드 목록을 조회합니다 (#264).
+ *
+ * Build 화면으로 네비게이션하기 위한 최근 빌드 정보입니다.
+ *
+ * @param limit - 조회할 빌드 수 (선택, 기본값 10).
+ * @param signal - 취소용 AbortSignal (선택).
+ * @returns 최근 빌드 목록.
+ * @throws ApiError - API 요청이 실패한 경우.
+ */
+export async function getRecentBuilds(limit = 10, signal?: AbortSignal): Promise<RecentBuilds> {
+  if (!isRealBuilderEnabled()) {
+    return mockRecentBuilds();
+  }
+
+  const query = `?limit=${limit}`;
+  // 기존 GET /builds endpoint 재사용
+  const response = await builderApi.apiFetch<{ builds: Array<{
+    run_id: string;
+    status: "ok" | "failed" | "cancelled";
+    started_at: string | null;
+    finished_at: string | null;
+  }> }>(
+    `/builds${query}`,
+    { signal, skipAuth: false },
+  );
+
+  return {
+    builds: response.builds.map(build => ({
+      run_id: build.run_id,
+      status: build.status,
+      started_at: build.started_at,
+      finished_at: build.finished_at,
+      dataset_id: null, // 기존 API는 dataset_id를 제공하지 않음
+    })),
+  };
+}
+
+/**
+ * Monitoring 데이터 가용성을 확인합니다 (#264).
+ *
+ * @param signal - 취소용 AbortSignal (선택).
+ * @returns 데이터 가용성 상태.
+ */
+export async function checkMonitoringAvailability(
+  signal?: AbortSignal,
+): Promise<MonitoringAvailability> {
+  if (!isRealBuilderEnabled()) {
+    return "available";
+  }
+
+  try {
+    const response = await builderApi.apiFetch<{ availability: MonitoringAvailability }>(
+      "/monitoring/availability",
+      { signal, skipAuth: false },
+    );
+    return response.availability;
+  } catch (error) {
+    const apiError = error as ApiError;
+    if (apiError.status === 401 || apiError.status === 403) {
+      return "unavailable";
+    }
+    if (apiError.status === 503) {
+      return "partial";
+    }
+    return "unavailable";
+  }
+}
+
+// ===== Mock 데이터 =====
+
+const MOCK_TIME = new Date().toISOString();
+
+function mockSystemResources(): SystemResource {
+  return {
+    health: "healthy",
+    p95_latency: 150,
+    queue: {
+      queued: 2,
+      running: 3,
+      total: 5,
+    },
+    workers: {
+      active: 3,
+      capacity: 10,
+      utilization: 0.3,
+    },
+    artifact_store: {
+      status: "available",
+      last_write: MOCK_TIME,
+    },
+    provider_status: {
+      datago: "available",
+      seoul: "degraded",
+    },
+  };
+}
+
+function mockBuildStats(): BuildStats {
+  const now = new Date();
+  const entries: Array<{
+    timestamp: string;
+    success_count: number;
+    fail_count: number;
+    cancelled_count: number;
+    total_count: number;
+  }> = [];
+
+  // 최근 24시간 데이터 생성 (1시간 간격)
+  for (let i = 23; i >= 0; i--) {
+    const timestamp = new Date(now.getTime() - i * 60 * 60 * 1000).toISOString();
+    const success = Math.floor(Math.random() * 5);
+    const fail = Math.floor(Math.random() * 2);
+    const cancelled = Math.floor(Math.random() * 1);
+    
+    entries.push({
+      timestamp,
+      success_count: success,
+      fail_count: fail,
+      cancelled_count: cancelled,
+      total_count: success + fail + cancelled,
+    });
+  }
+
+  const totalSuccess = entries.reduce((sum, entry) => sum + entry.success_count, 0);
+  const totalFail = entries.reduce((sum, entry) => sum + entry.fail_count, 0);
+  const totalCancelled = entries.reduce((sum, entry) => sum + entry.cancelled_count, 0);
+
+  return {
+    entries,
+    summary: {
+      success_count: totalSuccess,
+      fail_count: totalFail,
+      cancelled_count: totalCancelled,
+      total_count: totalSuccess + totalFail + totalCancelled,
+    },
+  };
+}
+
+function mockMonitoringData(): MonitoringResponse {
+  return {
+    system: mockSystemResources(),
+    build_stats: mockBuildStats(),
+    availability: "available",
+    last_updated: MOCK_TIME,
+  };
+}
+
+function mockRecentBuilds(): RecentBuilds {
+  const now = new Date();
+  const builds: Array<{
+    run_id: string;
+    status: "ok" | "failed" | "cancelled";
+    started_at: string | null;
+    finished_at: string | null;
+    dataset_id: string | null;
+  }> = [];
+
+  const statuses: Array<"ok" | "failed" | "cancelled"> = ["ok", "ok", "ok", "failed", "cancelled"];
+  
+  for (let i = 0; i < 10; i++) {
+    const startedAt = new Date(now.getTime() - i * 30 * 60 * 1000).toISOString();
+    const finishedAt = new Date(now.getTime() - (i * 30 * 60 * 1000) + (15 * 60 * 1000)).toISOString();
+    
+    builds.push({
+      run_id: `build-${Date.now() - i * 10000}`,
+      status: statuses[i % statuses.length],
+      started_at: startedAt,
+      finished_at: finishedAt,
+      dataset_id: `dataset-${i}`,
+    });
+  }
+
+  return { builds };
+}

--- a/src/features/monitoring/api/types.ts
+++ b/src/features/monitoring/api/types.ts
@@ -1,0 +1,126 @@
+/**
+ * Monitoring API 타입 및 스키마 (#264).
+ *
+ * Builder #516 시스템/집계 monitoring API의 응답 스키마와 타입 정의입니다.
+ */
+
+import { z } from "zod";
+
+/**
+ * 시스템 리소스 스키마 (#264).
+ *
+ * Builder API health, queue status, workers, artifact store 상태를 포함합니다.
+ */
+export const systemResourceSchema = z.object({
+  /** Builder API health 상태 */
+  health: z.enum(["healthy", "degraded", "unavailable"]),
+  /** p95 지연 시간 (ms) */
+  p95_latency: z.number().nonnegative().nullable(),
+  /** 큐 상태 */
+  queue: z.object({
+    queued: z.number().nonnegative(),
+    running: z.number().nonnegative(),
+    total: z.number().nonnegative(),
+  }),
+  /** 워커 상태 */
+  workers: z.object({
+    active: z.number().nonnegative(),
+    capacity: z.number().nonnegative(),
+    utilization: z.number().min(0).max(1),
+  }),
+  /** Artifact Store 상태 */
+  artifact_store: z.object({
+    status: z.enum(["available", "unavailable", "degraded"]),
+    last_write: z.string().nullable(),
+  }),
+  /** Provider 상태 (optional) */
+  provider_status: z.record(z.string(), z.enum(["available", "unavailable", "degraded"])).optional(),
+});
+
+/**
+ * Build 통계 스키마 (#264).
+ *
+ * 시간대별 build 수와 상태별 카운트를 포함합니다.
+ */
+export const buildStatsEntrySchema = z.object({
+  /** 시간대 (ISO 8601 timestamp) */
+  timestamp: z.string(),
+  /** 성공한 빌드 수 */
+  success_count: z.number().nonnegative(),
+  /** 실패한 빌드 수 */
+  fail_count: z.number().nonnegative(),
+  /** 취소된 빌드 수 */
+  cancelled_count: z.number().nonnegative(),
+  /** 전체 빌드 수 */
+  total_count: z.number().nonnegative(),
+});
+
+export const buildStatsSchema = z.object({
+  /** 시간대별 빌드 통계 */
+  entries: z.array(buildStatsEntrySchema),
+  /** 기간 내 전체 통계 */
+  summary: z.object({
+    success_count: z.number().nonnegative(),
+    fail_count: z.number().nonnegative(),
+    cancelled_count: z.number().nonnegative(),
+    total_count: z.number().nonnegative(),
+  }),
+});
+
+/**
+ * Monitoring 응답 스키마 (#264).
+ *
+ * 시스템 리소스와 빌드 통계를 포함하는 전체 응답입니다.
+ */
+export const monitoringResponseSchema = z.object({
+  /** 시스템 리소스 상태 */
+  system: systemResourceSchema,
+  /** 빌드 통계 */
+  build_stats: buildStatsSchema,
+  /** 데이터 가용성 */
+  availability: z.enum(["available", "partial", "unavailable"]),
+  /** 마지막 업데이트 시간 */
+  last_updated: z.string(),
+});
+
+/**
+ * 최근 빌드 요약 스키마 (#264).
+ *
+ * Build 화면으로 네비게이션하기 위한 최근 빌드 정보입니다.
+ */
+export const recentBuildSchema = z.object({
+  /** 빌드 실행 ID */
+  run_id: z.string(),
+  /** 빌드 상태 */
+  status: z.enum(["ok", "failed", "cancelled"]),
+  /** 시작 시간 */
+  started_at: z.string().nullable(),
+  /** 완료 시간 */
+  finished_at: z.string().nullable(),
+  /** 데이터셋 ID (optional) */
+  dataset_id: z.string().nullable(),
+});
+
+export const recentBuildsSchema = z.object({
+  builds: z.array(recentBuildSchema),
+});
+
+/**
+ * 타입 추출
+ */
+export type SystemResource = z.infer<typeof systemResourceSchema>;
+export type BuildStatsEntry = z.infer<typeof buildStatsEntrySchema>;
+export type BuildStats = z.infer<typeof buildStatsSchema>;
+export type MonitoringResponse = z.infer<typeof monitoringResponseSchema>;
+export type RecentBuild = z.infer<typeof recentBuildSchema>;
+export type RecentBuilds = z.infer<typeof recentBuildsSchema>;
+
+/**
+ * 데이터 가용성
+ */
+export type MonitoringAvailability = "available" | "partial" | "unavailable";
+
+/**
+ * 시스템 상태
+ */
+export type SystemHealth = "healthy" | "degraded" | "unavailable";

--- a/src/features/monitoring/hooks.ts
+++ b/src/features/monitoring/hooks.ts
@@ -1,0 +1,190 @@
+/**
+ * Monitoring 데이터 관리용 React hooks (#264).
+ *
+ * 시스템 리소스, 빌드 통계, 최근 빌드 데이터를 가져오고 상태를 관리합니다.
+ * 폴링, 에러 처리, unavailable 상태 처리를 포함합니다.
+ */
+import { useEffect, useState, useCallback, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  checkMonitoringAvailability,
+  getMonitoringData,
+  getRecentBuilds,
+  type MonitoringAvailability,
+  type MonitoringResponse,
+  type RecentBuilds,
+} from "./api";
+import type { ApiError } from "@/shared/lib/builderApi";
+
+/**
+ * 폴링 인터벌 (ms) - 30초마다 업데이트
+ */
+const POLLING_INTERVAL_MS = 30_000;
+
+/**
+ * 탭 타입
+ */
+export type MonitoringTab = "system" | "build";
+
+/**
+ * Monitoring 데이터 상태를 관리하는 hook (#264).
+ *
+ * @returns Monitoring 데이터 및 관련 상태/메서드.
+ */
+export function useMonitoringData() {
+  const [data, setData] = useState<MonitoringResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [availability, setAvailability] = useState<MonitoringAvailability>("available");
+  const [activeTab, setActiveTab] = useState<MonitoringTab>("system");
+  
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const pollingIntervalRef = useRef<number | null>(null);
+  const isPageHidden = useRef(false);
+
+  const fetchData = useCallback(async () => {
+    // 페이지가 숨겨져 있으면 데이터 갱신 중단
+    if (isPageHidden.current) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    // 이전 요청 취소
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+
+    abortControllerRef.current = new AbortController();
+
+    try {
+      const [availabilityCheck, monitoringData] = await Promise.all([
+        checkMonitoringAvailability(abortControllerRef.current.signal),
+        getMonitoringData(abortControllerRef.current.signal),
+      ]);
+
+      setAvailability(availabilityCheck);
+      setData(monitoringData);
+      setIsLoading(false);
+    } catch (err) {
+      const apiError = err as ApiError;
+      if (apiError.name === "AbortError") {
+        return; // 취소된 경우 무시
+      }
+      
+      // 401/403은 unavailable 상태로 처리
+      if (apiError.status === 401 || apiError.status === 403) {
+        setAvailability("unavailable");
+        setError(new Error("인증이 필요하거나 권한이 없습니다."));
+      } else if (apiError.status === 503) {
+        setAvailability("partial");
+        setError(new Error("서비스 일시적 장애가 있습니다."));
+      } else {
+        setError(apiError);
+        setAvailability("unavailable");
+      }
+      setIsLoading(false);
+    }
+  }, []);
+
+  // 페이지 가시성 감지 및 폴링 관리
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      isPageHidden.current = document.hidden;
+      
+      // 페이지가 다시 보이면 즉시 데이터 갱신
+      if (!document.hidden && data) {
+        fetchData();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    // 초기 데이터 로드
+    fetchData();
+
+    // 폴링 설정
+    pollingIntervalRef.current = window.setInterval(() => {
+      if (!document.hidden) {
+        fetchData();
+      }
+    }, POLLING_INTERVAL_MS);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      if (pollingIntervalRef.current) {
+        clearInterval(pollingIntervalRef.current);
+      }
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+    };
+  }, [fetchData, data]);
+
+  const refreshData = useCallback(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return {
+    data,
+    isLoading,
+    error,
+    availability,
+    activeTab,
+    setActiveTab,
+    refreshData,
+  };
+}
+
+/**
+ * 최근 빌드 목록을 관리하는 hook (#264).
+ *
+ * @returns 최근 빌드 데이터 및 관련 상태/메서드.
+ */
+export function useRecentBuilds(limit = 10) {
+  const [builds, setBuilds] = useState<RecentBuilds | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const navigate = useNavigate();
+
+  const fetchBuilds = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    const abortController = new AbortController();
+
+    try {
+      const data = await getRecentBuilds(limit, abortController.signal);
+      setBuilds(data);
+      setIsLoading(false);
+    } catch (err) {
+      const apiError = err as ApiError;
+      if (apiError.name !== "AbortError") {
+        setError(apiError);
+      }
+      setIsLoading(false);
+    }
+
+    return () => abortController.abort();
+  }, [limit]);
+
+  useEffect(() => {
+    const cleanup = fetchBuilds();
+    return () => {
+      cleanup.then(cleanupFn => cleanupFn?.());
+    };
+  }, [fetchBuilds]);
+
+  const navigateToBuild = useCallback((runId: string) => {
+    navigate(`/builds/${runId}`);
+  }, [navigate]);
+
+  return {
+    builds,
+    isLoading,
+    error,
+    navigateToBuild,
+    refreshBuilds: fetchBuilds,
+  };
+}

--- a/src/pages/MonitoringPage.tsx
+++ b/src/pages/MonitoringPage.tsx
@@ -1,17 +1,208 @@
 /**
- * Monitoring 화면 (`/monitoring`) — placeholder (#247).
+ * Monitoring 화면 (`/monitoring`) — 시스템 리소스와 빌드 통계 모니터링 (#264).
  *
- * 실행 이력/시스템 상태 모니터링의 실제 구현은 #264에서 진행한다.
+ * Builder #516 시스템/집계 monitoring API를 사용하여 시스템 상태와 빌드 통계를 실시간으로 확인합니다.
+ * 시스템 리소스와 빌드 통계 두 개의 탭을 제공하며, 최근 빌드 목록도 포함합니다.
  */
-import { PlaceholderPage } from "@/shared/ui";
+import { useMonitoringData, useRecentBuilds, MonitoringTab } from "@/features/monitoring/hooks";
+import { SystemResources } from "@/features/monitoring/SystemResources";
+import { BuildStatistics } from "@/features/monitoring/BuildStatistics";
+import { RecentBuildsList } from "@/features/monitoring/RecentBuildsList";
 
 export function MonitoringPage() {
+  const {
+    data,
+    isLoading,
+    error,
+    availability,
+    activeTab,
+    setActiveTab,
+    refreshData,
+  } = useMonitoringData();
+
+  const {
+    builds,
+    isLoading: buildsLoading,
+    error: buildsError,
+    navigateToBuild,
+    refreshBuilds,
+  } = useRecentBuilds();
+
+  const formatAvailability = (avail: string) => {
+    switch (avail) {
+      case "available":
+        return "데이터 이용 가능";
+      case "partial":
+        return "일부 데이터 이용 가능";
+      case "unavailable":
+        return "데이터 이용 불가";
+      default:
+        return avail;
+    }
+  };
+
+  const getAvailabilityColor = (avail: string) => {
+    switch (avail) {
+      case "available":
+        return "text-green-600";
+      case "partial":
+        return "text-yellow-600";
+      case "unavailable":
+        return "text-red-600";
+      default:
+        return "text-gray-600";
+    }
+  };
+
   return (
-    <PlaceholderPage
-      eyebrow="Monitoring"
-      title="모니터링"
-      description="실행 이력과 시스템 상태를 모니터링합니다."
-      note="Monitoring 화면은 #264에서 구현됩니다."
-    />
+    <div className="p-6 max-w-7xl mx-auto">
+      {/* 헤더 */}
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold mb-2">모니터링</h1>
+        <p className="text-gray-600">시스템 리소스와 빌드 통계를 실시간으로 확인합니다.</p>
+      </div>
+
+      {/* 데이터 가용성 표시 */}
+      <div className={`mb-4 p-3 rounded-lg border ${
+        availability === "available"
+          ? "bg-green-50 border-green-200"
+          : availability === "partial"
+          ? "bg-yellow-50 border-yellow-200"
+          : "bg-red-50 border-red-200"
+      }`}>
+        <div className="flex justify-between items-center">
+          <span className={`text-sm font-medium ${getAvailabilityColor(availability)}`}>
+            {formatAvailability(availability)}
+          </span>
+          <button
+            onClick={refreshData}
+            className="text-sm text-blue-600 hover:text-blue-800 transition-colors"
+            disabled={isLoading}
+          >
+            {isLoading ? "로딩 중..." : "새로고침"}
+          </button>
+        </div>
+      </div>
+
+      {/* 에러 상태 */}
+      {error && availability === "unavailable" && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+          <div className="flex items-start">
+            <div className="text-red-600 mr-3">
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+            </div>
+            <div>
+              <h3 className="font-semibold text-red-900 mb-1">모니터링 데이터를 가져올 수 없습니다</h3>
+              <p className="text-sm text-red-700">{error.message}</p>
+              {error.message.includes("인증") && (
+                <p className="text-sm text-red-700 mt-2">
+                  로그인이 필요하거나 권한이 없습니다. 관리자에게 문의하세요.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 부분 데이터 상태 */}
+      {availability === "partial" && (
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6">
+          <div className="flex items-start">
+            <div className="text-yellow-600 mr-3">
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+            </div>
+            <div>
+              <h3 className="font-semibold text-yellow-900 mb-1">일부 데이터만 표시됩니다</h3>
+              <p className="text-sm text-yellow-700">
+                서비스 일시적 장애로 인해 일부 데이터를 가져오지 못했습니다.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 로딩 상태 */}
+      {isLoading && !data && (
+        <div className="flex items-center justify-center py-12">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600" />
+        </div>
+      )}
+
+      {/* 메인 컨텐츠 */}
+      {data && availability !== "unavailable" && (
+        <>
+          {/* 탭 네비게이션 */}
+          <div className="mb-6 border-b border-gray-200">
+            <nav className="flex space-x-8">
+              <button
+                onClick={() => setActiveTab("system" as MonitoringTab)}
+                className={`py-2 px-1 border-b-2 font-medium text-sm transition-colors ${
+                  activeTab === "system"
+                    ? "border-blue-600 text-blue-600"
+                    : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+                }`}
+              >
+                시스템 리소스
+              </button>
+              <button
+                onClick={() => setActiveTab("build" as MonitoringTab)}
+                className={`py-2 px-1 border-b-2 font-medium text-sm transition-colors ${
+                  activeTab === "build"
+                    ? "border-blue-600 text-blue-600"
+                    : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+                }`}
+              >
+                빌드 통계
+              </button>
+            </nav>
+          </div>
+
+          {/* 탭 컨텐츠 */}
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            {/* 메인 탭 영역 */}
+            <div className="lg:col-span-2">
+              {activeTab === "system" && data.system ? (
+                <SystemResources data={data.system} lastUpdated={data.last_updated} />
+              ) : activeTab === "build" && data.build_stats ? (
+                <BuildStatistics data={data.build_stats} />
+              ) : (
+                <div className="bg-white p-4 rounded-lg border border-gray-200 shadow-sm">
+                  <div className="text-center py-8 text-gray-500">
+                    데이터를 가져오는 중입니다...
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* 최근 빌드 사이드바 */}
+            <div className="lg:col-span-1">
+              <RecentBuildsList
+                builds={builds}
+                isLoading={buildsLoading}
+                error={buildsError}
+                onNavigateToBuild={navigateToBuild}
+                onRefresh={refreshBuilds}
+              />
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* 비고 */}
+      <div className="mt-6 p-4 bg-gray-50 rounded-lg border border-gray-200">
+        <h4 className="font-semibold text-sm text-gray-700 mb-2">참고사항</h4>
+        <ul className="text-xs text-gray-600 space-y-1">
+          <li>• 데이터는 30초마다 자동으로 새로고침됩니다.</li>
+          <li>• 페이지가 백그라운드로 전환되면 폴링이 중단됩니다.</li>
+          <li>• p95 지연 시간은 최근 1시간 기준입니다.</li>
+          <li>• 최근 빌드 목록에서 상세 보기를 클릭하면 빌드 상세 페이지로 이동합니다.</li>
+          <li>• 데이터 가용성 상태에 따라 일부 정보가 표시되지 않을 수 있습니다.</li>
+        </ul>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## 목적
Monitoring 화면에서 **시스템 리소스와 Build 통계**를 실제 Builder monitoring API로 확인한다.

Run Event Timeline은 #255/Builder #496 영역이고, 이 이슈는 Builder #516 시스템/집계 monitoring만 사용한다.

## 화면
### 시스템 리소스
- Builder API Healthy/Degraded + p95 latency
- Queue queued/running/total
- Workers active/capacity/utilization
- Artifact Store 상태/last write
- Provider status는 제공 가능한 경우만

### Build 통계
- 시간대별 Build 수
- success/fail/cancelled
- 최근 Runs → #255

## 범위
- /monitoring
- system/build tabs
- Builder #516 API client/Zod
- unavailable을 0/정상으로 표시하지 않음
- loading/error/partial-data
- polling lifecycle/page hidden 완화
- unauthorized/monitoring-disabled 처리
- chart/recent run navigation tests

## 제외 범위
- Run Event Timeline — Builder #496 / Studio #255
- Grafana/Prometheus embed
- alert notification
- OS 전체 process monitor

## 의존 관계
- Parent: #246
- Backend: yeongseon/kpubdata-builder#516
- Related: #255, #259

## 완료 조건
- 실제 시스템 상태/Build 통계를 확인 가능
- recent run에서 Runs 상세로 이동 가능
- unavailable/partial을 정상으로 오인하지 않음