### PR TITLE
feat: 이메일/비밀번호 Login/Signup + generic AuthProvider 전환 (#263)

### DIFF
--- a/__tests__/LoginPage.test.tsx
+++ b/__tests__/LoginPage.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * LoginPage (#263) — 이메일/비밀번호 입력, 로그인 버튼, 계정 만들기 링크, 실패 메시지를
+ * 확인한다.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { LoginPage } from "@/pages/LoginPage";
+import { useAuthStore } from "@/features/auth/store";
+
+const navigateMock = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+function renderLogin() {
+  return render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  useAuthStore.getState().clear();
+  navigateMock.mockClear();
+});
+
+describe("LoginPage", () => {
+  it("renders email/password inputs, a login button, and a link to create an account", () => {
+    renderLogin();
+    expect(screen.getByLabelText("이메일", { exact: false })).toBeInTheDocument();
+    expect(screen.getByLabelText("비밀번호", { exact: false })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "로그인" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "계정 만들기" })).toHaveAttribute("href", "/signup");
+  });
+
+  it("on success, sets the session and navigates home — the password never reaches the store", async () => {
+    renderLogin();
+    fireEvent.change(screen.getByLabelText("이메일", { exact: false }), { target: { value: "user@example.com" } });
+    fireEvent.change(screen.getByLabelText("비밀번호", { exact: false }), { target: { value: "hunter2" } });
+    fireEvent.click(screen.getByRole("button", { name: "로그인" }));
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/", { replace: true }));
+    expect(useAuthStore.getState().email).toBe("user@example.com");
+    expect(JSON.stringify(useAuthStore.getState())).not.toMatch(/hunter2/);
+  });
+
+  it("shows a failure message and does not navigate when the mock provider rejects", async () => {
+    renderLogin();
+    fireEvent.change(screen.getByLabelText("이메일", { exact: false }), { target: { value: "user@example.com" } });
+    fireEvent.change(screen.getByLabelText("비밀번호", { exact: false }), { target: { value: "ab" } });
+    fireEvent.click(screen.getByRole("button", { name: "로그인" }));
+
+    expect(await screen.findByText("이메일 또는 비밀번호가 올바르지 않습니다.")).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+});

--- a/__tests__/SignupPage.test.tsx
+++ b/__tests__/SignupPage.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * SignupPage (#263) — 이름/이메일/비밀번호, 개인 vs 팀·기관 선택, 기관/팀명(optional),
+ * 계정 만들기 버튼, 로그인 링크, email verification 안내를 확인한다.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { SignupPage } from "@/pages/SignupPage";
+import { useAuthStore } from "@/features/auth/store";
+
+function renderSignup() {
+  return render(
+    <MemoryRouter>
+      <SignupPage />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  useAuthStore.getState().clear();
+});
+
+describe("SignupPage", () => {
+  it("renders name/email/password, account type choice, and a link back to login", () => {
+    renderSignup();
+    expect(screen.getByLabelText("이름", { exact: false })).toBeInTheDocument();
+    expect(screen.getByLabelText("이메일", { exact: false })).toBeInTheDocument();
+    expect(screen.getByLabelText("비밀번호", { exact: false })).toBeInTheDocument();
+    expect(screen.getByLabelText("개인")).toBeChecked();
+    expect(screen.getByLabelText("팀 · 기관")).not.toBeChecked();
+    expect(screen.getByRole("button", { name: "계정 만들기" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "로그인" })).toHaveAttribute("href", "/login");
+  });
+
+  it("does not show the organization name field until 팀 · 기관 is selected (it is optional)", () => {
+    renderSignup();
+    expect(screen.queryByLabelText("기관/팀명")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("팀 · 기관"));
+    expect(screen.getByLabelText("기관/팀명")).toBeInTheDocument();
+  });
+
+  it("on submit, does not sign the user in yet — it shows an email verification notice instead", async () => {
+    renderSignup();
+    fireEvent.change(screen.getByLabelText("이름", { exact: false }), { target: { value: "홍길동" } });
+    fireEvent.change(screen.getByLabelText("이메일", { exact: false }), { target: { value: "new@example.com" } });
+    fireEvent.change(screen.getByLabelText("비밀번호", { exact: false }), { target: { value: "hunter2" } });
+    fireEvent.click(screen.getByRole("button", { name: "계정 만들기" }));
+
+    expect(await screen.findByRole("heading", { name: "이메일을 확인해주세요" })).toBeInTheDocument();
+    expect(screen.getByText("new@example.com", { exact: false })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "로그인하러 가기" })).toHaveAttribute("href", "/login");
+
+    // 이메일 인증 전이므로 아직 로그인 세션을 만들지 않는다.
+    expect(useAuthStore.getState().token).toBeNull();
+    // password는 어디에도 남지 않는다.
+    expect(document.body.innerHTML).not.toMatch(/hunter2/);
+  });
+});

--- a/__tests__/settingsVersionCheck.test.tsx
+++ b/__tests__/settingsVersionCheck.test.tsx
@@ -5,6 +5,7 @@
  * 경고가 표면화되는지, 일치하면 경고가 없는지를 검증한다.
  */
 import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const version = vi.fn();
@@ -32,7 +33,11 @@ afterEach(() => {
 describe("SettingsPage version check", () => {
   it("surfaces a warning when builder api_version mismatches the studio contract", async () => {
     version.mockResolvedValue({ service: "builder", api_version: "2.0.0" });
-    render(<SettingsPage />);
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>,
+    );
 
     const warning = await screen.findByRole("alert");
     expect(warning.textContent).toContain("계약 버전 불일치");
@@ -41,7 +46,11 @@ describe("SettingsPage version check", () => {
 
   it("shows no mismatch warning when versions agree", async () => {
     version.mockResolvedValue({ service: "builder", api_version: API_CONTRACT_VERSION });
-    render(<SettingsPage />);
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>,
+    );
 
     await waitFor(() =>
       expect(screen.getByText(new RegExp(`Builder API 버전 ${API_CONTRACT_VERSION}`))).toBeInTheDocument(),

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -19,6 +19,7 @@ import { DatasetDetailPage } from "@/pages/DatasetDetailPage";
 import { DiscoverPage } from "@/pages/DiscoverPage";
 import { HomePage } from "@/pages/HomePage";
 import { KubiPage } from "@/pages/KubiPage";
+import { LoginPage } from "@/pages/LoginPage";
 import { MonitoringPage } from "@/pages/MonitoringPage";
 import { NewBuildPage } from "@/pages/NewBuildPage";
 import { PreviewPage } from "@/pages/PreviewPage";
@@ -27,6 +28,7 @@ import { QualityPage } from "@/pages/QualityPage";
 import { ReportEditorPage } from "@/pages/ReportEditorPage";
 import { ReportsPage } from "@/pages/ReportsPage";
 import { SettingsPage } from "@/pages/SettingsPage";
+import { SignupPage } from "@/pages/SignupPage";
 import { ValidatePage } from "@/pages/ValidatePage";
 import { WorkspacePage } from "@/pages/WorkspacePage";
 
@@ -51,6 +53,16 @@ function withFeatureBoundary(feature: string, element: ReactElement): ReactEleme
  * @returns 각 경로별 렌더링 규칙을 담은 브라우저 라우터 인스턴스.
  */
 export const router = createBrowserRouter([
+    // Login/Signup(#263)은 App Shell(사이드바/헤더) 밖의 독립 화면이라 Layout의 children이
+    // 아니라 최상위 형제 라우트로 둔다 — 로그인 전 상태에는 아직 보여줄 워크스페이스 셸이 없다.
+    {
+      path: "/login",
+      element: <LoginPage />,
+    },
+    {
+      path: "/signup",
+      element: <SignupPage />,
+    },
     {
       path: "/",
       element: <Layout />,

--- a/src/features/auth/LoginGate.tsx
+++ b/src/features/auth/LoginGate.tsx
@@ -6,6 +6,7 @@
  * 데모가 깨지지 않는 것이 핵심 — 리뷰 시 Pages 데모 동작 확인 필수.
  */
 import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
 import { isRealBuilderEnabled } from "@/shared/lib/builderApi";
 import { useAuthStore } from "./store";
 
@@ -21,8 +22,11 @@ export function LoginGate({ children }: { children: ReactNode }) {
       <div className="flex flex-1 flex-col items-center justify-center gap-4 px-5 py-20">
         <p className="text-lg font-semibold text-foreground">로그인이 필요합니다</p>
         <p className="max-w-md text-center text-sm text-muted-foreground">
-          실연동 모드에서는 Builder API 호출을 위해 Google 계정 로그인이 필요합니다.
+          실연동 모드에서는 Builder API 호출을 위해 로그인이 필요합니다.
         </p>
+        <Link to="/login" className="text-sm font-medium text-accent-subtle-foreground underline">
+          로그인 페이지로 이동
+        </Link>
       </div>
     );
   }

--- a/src/features/auth/mockAuthProvider.test.ts
+++ b/src/features/auth/mockAuthProvider.test.ts
@@ -1,0 +1,84 @@
+/**
+ * mockAuthProvider (#263) 테스트.
+ *
+ * generic AuthProvider 계약(signIn/signUp/signOut)이 mock 모드에서 동작하는지, 실패
+ * 메시지 경로가 있는지, 그리고 반환된 AuthSession에 password가 절대 섞여 들어가지
+ * 않는지 확인한다.
+ */
+import { describe, expect, it } from "vitest";
+import { mockAuthProvider } from "./mockAuthProvider";
+import { AuthError } from "./types";
+
+describe("mockAuthProvider", () => {
+  it("has a stable provider id", () => {
+    expect(mockAuthProvider.id).toBe("mock");
+  });
+
+  describe("signIn", () => {
+    it("succeeds and returns a session that never includes the password", async () => {
+      const session = await mockAuthProvider.signIn({ email: "user@example.com", password: "hunter2" });
+      expect(session).toMatchObject({ email: "user@example.com", name: null, provider: "mock" });
+      expect(session.token).toBeTruthy();
+      expect(JSON.stringify(session)).not.toMatch(/hunter2/);
+    });
+
+    it("issues a different token per call (not a fixed/shared demo token)", async () => {
+      const first = await mockAuthProvider.signIn({ email: "a@example.com", password: "abcd" });
+      const second = await mockAuthProvider.signIn({ email: "a@example.com", password: "abcd" });
+      expect(first.token).not.toBe(second.token);
+    });
+
+    it("rejects with an AuthError (실패 메시지 경로) for a too-short password", async () => {
+      await expect(
+        mockAuthProvider.signIn({ email: "user@example.com", password: "ab" }),
+      ).rejects.toBeInstanceOf(AuthError);
+    });
+
+    it("AuthError carries a Korean user-facing message", async () => {
+      await expect(mockAuthProvider.signIn({ email: "user@example.com", password: "" })).rejects.toThrow(
+        "이메일 또는 비밀번호가 올바르지 않습니다.",
+      );
+    });
+  });
+
+  describe("signUp", () => {
+    it("returns a session carrying the provided name, and never the password", async () => {
+      const session = await mockAuthProvider.signUp({
+        name: "홍길동",
+        email: "new@example.com",
+        password: "hunter2",
+        accountType: "individual",
+      });
+      expect(session).toMatchObject({ name: "홍길동", email: "new@example.com", provider: "mock" });
+      expect(JSON.stringify(session)).not.toMatch(/hunter2/);
+    });
+
+    it("does not require organizationName for an individual account", async () => {
+      await expect(
+        mockAuthProvider.signUp({
+          name: "홍길동",
+          email: "new@example.com",
+          password: "hunter2",
+          accountType: "individual",
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it("accepts an organization account with an organizationName", async () => {
+      const session = await mockAuthProvider.signUp({
+        name: "홍길동",
+        email: "team@example.com",
+        password: "hunter2",
+        accountType: "organization",
+        organizationName: "KPubData Lab",
+      });
+      expect(session.email).toBe("team@example.com");
+    });
+  });
+
+  describe("signOut", () => {
+    it("resolves without throwing (no server session to revoke in mock mode)", async () => {
+      await expect(mockAuthProvider.signOut()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/features/auth/mockAuthProvider.ts
+++ b/src/features/auth/mockAuthProvider.ts
@@ -1,0 +1,55 @@
+/**
+ * Mock/demo {@link AuthProvider} 구현체 (#263).
+ *
+ * 실제 IdP 연결은 Builder #515 결정 이후로 미룬다 — 이 provider는 Login/Signup UI와
+ * generic AuthProvider 경계를 시연하기 위한 결정적 mock일 뿐, 실제 자격 증명을 검증하지
+ * 않는다. Builder에는 어떤 요청도 보내지 않고(password 원문 전송 금지, #263), 이 provider가
+ * 만든 mock 토큰은 `apiFetch` 인증 헤더 provider에도 연결되지 않는다 — 실제 Builder 호출에
+ * 이 토큰이 실리는 일은 없다(Builder bearer 토큰 연결은 #515 이후 real provider의 몫).
+ *
+ * password는 함수 인자로만 잠깐 존재했다가 버려진다 — store/localStorage/sessionStorage/
+ * 로그 어디에도 저장하지 않는다.
+ */
+import { AuthError, type AuthProvider, type AuthSession, type SignInInput, type SignUpInput } from "./types";
+
+function fabricateMockToken(): string {
+  return `mock-session-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * mock 모드에서 "실패 메시지" UI 경로를 시연하기 위한 결정적 규칙일 뿐이다 — 실제
+ * 자격 증명 검증이 아니며, 이 provider는 password를 어디에도 저장하거나 대조하지 않는다.
+ * (짧은 비밀번호로 로그인을 시도하면 실패 상태를 확인할 수 있다.)
+ */
+function looksLikeDemoValidPassword(password: string): boolean {
+  return password.length >= 4;
+}
+
+export const mockAuthProvider: AuthProvider = {
+  id: "mock",
+
+  async signIn({ email, password }: SignInInput): Promise<AuthSession> {
+    if (!looksLikeDemoValidPassword(password)) {
+      throw new AuthError("이메일 또는 비밀번호가 올바르지 않습니다.");
+    }
+    return {
+      token: fabricateMockToken(),
+      email,
+      name: null,
+      provider: "mock",
+    };
+  },
+
+  async signUp(input: SignUpInput): Promise<AuthSession> {
+    return {
+      token: fabricateMockToken(),
+      email: input.email,
+      name: input.name,
+      provider: "mock",
+    };
+  },
+
+  async signOut(): Promise<void> {
+    // mock 모드에는 폐기할 서버 세션이 없다 — 호출부(useAuthStore.clear())가 메모리 상태를 지운다.
+  },
+};

--- a/src/features/auth/store.test.ts
+++ b/src/features/auth/store.test.ts
@@ -1,0 +1,81 @@
+/**
+ * useAuthStore (#188, #263 generic 세션 확장) 테스트.
+ *
+ * setToken(Google, 하위 호환)과 setSession(mock/generic AuthProvider)이 같은 store를
+ * 공유하면서 서로의 필드를 오염시키지 않는지, 그리고 password가 store 어디에도 남지
+ * 않는지 확인한다.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "./store";
+import type { AuthSession } from "./types";
+
+afterEach(() => {
+  useAuthStore.getState().clear();
+});
+
+describe("useAuthStore", () => {
+  it("starts logged out", () => {
+    const state = useAuthStore.getState();
+    expect(state).toMatchObject({ token: null, email: null, name: null, providerId: null });
+  });
+
+  it("setToken (Google 하위 호환) sets token/email and tags the session as google", () => {
+    useAuthStore.getState().setToken("google-jwt", "user@example.com");
+    expect(useAuthStore.getState()).toMatchObject({
+      token: "google-jwt",
+      email: "user@example.com",
+      name: null,
+      providerId: "google",
+    });
+  });
+
+  it("setToken(null) clears the session and providerId", () => {
+    useAuthStore.getState().setToken("google-jwt", "user@example.com");
+    useAuthStore.getState().setToken(null);
+    expect(useAuthStore.getState()).toMatchObject({ token: null, email: null, providerId: null });
+  });
+
+  it("setSession stores a full generic AuthSession (mock/#263)", () => {
+    const session: AuthSession = {
+      token: "mock-session-abc",
+      email: "person@example.com",
+      name: "홍길동",
+      provider: "mock",
+    };
+    useAuthStore.getState().setSession(session);
+    expect(useAuthStore.getState()).toMatchObject({
+      token: "mock-session-abc",
+      email: "person@example.com",
+      name: "홍길동",
+      providerId: "mock",
+    });
+  });
+
+  it("clear resets every field regardless of which provider logged in", () => {
+    useAuthStore.getState().setSession({
+      token: "mock-session-abc",
+      email: "person@example.com",
+      name: "홍길동",
+      provider: "mock",
+    });
+    useAuthStore.getState().clear();
+    expect(useAuthStore.getState()).toMatchObject({
+      token: null,
+      email: null,
+      name: null,
+      providerId: null,
+    });
+  });
+
+  it("never stores a password field — the state shape only has session data", () => {
+    useAuthStore.getState().setSession({
+      token: "mock-session-abc",
+      email: "person@example.com",
+      name: "홍길동",
+      provider: "mock",
+    });
+    const state = useAuthStore.getState();
+    expect(Object.keys(state)).not.toContain("password");
+    expect(JSON.stringify(state)).not.toMatch(/password/i);
+  });
+});

--- a/src/features/auth/store.ts
+++ b/src/features/auth/store.ts
@@ -1,28 +1,50 @@
 /**
- * 인증 상태 관리 (S3, #188).
+ * 인증 상태 관리 (S3/#188, #263에서 generic 세션으로 확장).
  *
  * 토큰은 메모리(zustand store)에만 보관한다 — persist 미들웨어 사용 금지.
  * localStorage/sessionStorage에 토큰을 쓰면 XSS 한 번으로 탈취된다.
  * 새로고침 시 재로그인(GIS 자동 로그인으로 마찰 완화 예정, S2/#187).
+ *
+ * #263: Google(setToken)과 mock/email 로그인(setSession)이 이 store 하나를 공유해
+ * topbar avatar(#191)/Settings/LoginGate(#190)가 어느 provider로 로그인했는지 신경 쓰지
+ * 않고 동일하게 동작하게 한다. setToken은 기존 GoogleLoginButton 호출부를 그대로 유지하기
+ * 위한 하위 호환 진입점이다(signature 변경 없음).
  */
 import { create } from "zustand";
+import type { AuthProviderId, AuthSession } from "./types";
 
 interface AuthState {
-  /** Builder로 보낼 Bearer 토큰 (Google ID token JWT). null이면 미로그인. */
+  /** Builder로 보낼 Bearer 토큰 (Google ID token JWT 또는 mock 토큰). null이면 미로그인. */
   token: string | null;
   /** 로그인된 사용자 이메일 (UI 표시용, S6/#191). */
   email: string | null;
-  /** 토큰을 설정한다 (GIS 로그인 콜백에서 호출, S2/#187). */
+  /** 표시용 이름. Google 로그인은 이름을 제공하지 않아 null(#263). */
+  name: string | null;
+  /** 이 세션을 만든 provider. 미로그인이면 null(#263). */
+  providerId: AuthProviderId | null;
+  /** 토큰을 설정한다 (GIS 로그인 콜백에서 호출, S2/#187) — provider는 항상 "google"로 기록한다. */
   setToken: (token: string | null, email?: string | null) => void;
-  /** 로그아웃 — 토큰 폐기. */
+  /** generic {@link AuthProvider}(mock/#263)가 반환한 세션을 그대로 저장한다. */
+  setSession: (session: AuthSession) => void;
+  /** 로그아웃 — 세션 전체를 폐기. */
   clear: () => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   token: null,
   email: null,
-  setToken: (token, email = null) => set({ token, email }),
-  clear: () => set({ token: null, email: null }),
+  name: null,
+  providerId: null,
+  setToken: (token, email = null) =>
+    set({ token, email, name: null, providerId: token ? "google" : null }),
+  setSession: (session) =>
+    set({
+      token: session.token,
+      email: session.email,
+      name: session.name,
+      providerId: session.provider,
+    }),
+  clear: () => set({ token: null, email: null, name: null, providerId: null }),
 }));
 
 /**

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Generic 인증 계약 (#263).
+ *
+ * Google GIS(#187)든, Builder #515에서 결정될 email/password OIDC든 이 계약 뒤에서
+ * 갈아끼울 수 있게 만든 provider-agnostic 타입이다. 실제 IdP 연결(JWKS/refresh/Builder
+ * bearer 토큰 정책)은 #515 결정 이후로 미루고, 지금은 mock/demo provider로만 이 계약을
+ * 구현한다.
+ */
+
+/** 어떤 provider가 이 세션을 만들었는지 표시하는 태그. */
+export type AuthProviderId = "google" | "mock";
+
+/**
+ * 로그인 성공 후 Studio가 들고 있는 세션 정보.
+ *
+ * password는 절대 이 shape에 포함하지 않는다 — 어떤 provider도 세션에 원문 비밀번호를
+ * 담아서는 안 된다(#263 보안 요구사항: password를 store/localStorage/sessionStorage/
+ * 로그 어디에도 남기지 않음).
+ */
+export interface AuthSession {
+  /** Builder 호출용 Bearer 토큰(또는 mock 모드에서는 그 자리를 채우는 mock 토큰). */
+  token: string;
+  email: string;
+  /** 표시용 이름. Google 로그인은 이름을 제공하지 않으므로 null(#191 topbar avatar와 호환). */
+  name: string | null;
+  provider: AuthProviderId;
+}
+
+export interface SignInInput {
+  email: string;
+  password: string;
+}
+
+export type AccountType = "individual" | "organization";
+
+export interface SignUpInput {
+  name: string;
+  email: string;
+  password: string;
+  accountType: AccountType;
+  /** 팀·기관(accountType === "organization") 선택 시에만 의미 있는 optional 값. */
+  organizationName?: string;
+}
+
+/** 로그인/가입 실패를 다른 예외(네트워크 오류 등)와 구분하기 위한 전용 에러 타입. */
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuthError";
+  }
+}
+
+/**
+ * email/password(또는 향후 다른 OIDC) 인증을 수행하는 provider의 generic 계약.
+ *
+ * Google GIS는 이 인터페이스를 구현하지 않는다 — GIS SDK는 위젯을 렌더링하고 콜백으로
+ * credential을 돌려주는 방식이라(`gis.ts`/`GoogleLoginButton.tsx` 참고)
+ * `signIn(email, password)` 같은 직접 호출 형태와 맞지 않는다. 대신 Google도 결과적으로
+ * 같은 {@link AuthSession} shape을 세션 store(`useAuthStore`)에 넣으므로, 두 로그인
+ * 방식은 세션 모델 층에서 하나로 합쳐진다 — topbar avatar/Settings/LoginGate는 어느
+ * provider로 로그인했는지 신경 쓰지 않는다.
+ *
+ * Builder #515에서 실제 IdP가 결정되면, 이 인터페이스를 구현하는 real provider가
+ * mock provider 자리를 그대로 대체한다.
+ */
+export interface AuthProvider {
+  readonly id: AuthProviderId;
+  signIn(input: SignInInput): Promise<AuthSession>;
+  signUp(input: SignUpInput): Promise<AuthSession>;
+  signOut(): Promise<void>;
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,92 @@
+/**
+ * 로그인 화면 (/login, #263).
+ *
+ * 실제 IdP 연결은 Builder #515 결정 이후로 미루고, 지금은 mock/demo AuthProvider로
+ * 이메일/비밀번호 로그인 UX와 generic AuthProvider 경계를 시연한다. 기존 Google 로그인
+ * 플로우(#187, GoogleLoginButton/gis.ts)는 건드리지 않는다 — 이 화면은 별도의
+ * mockAuthProvider를 통해 같은 세션 store(useAuthStore)에 로그인한다.
+ */
+import { useState, type FormEvent } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { mockAuthProvider } from "@/features/auth/mockAuthProvider";
+import { useAuthStore } from "@/features/auth/store";
+import { AuthError } from "@/features/auth/types";
+import { Button, Card, ErrorMessage, FormField, TextInput } from "@/shared/ui";
+
+export function LoginPage() {
+  const navigate = useNavigate();
+  const setSession = useAuthStore((state) => state.setSession);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      const session = await mockAuthProvider.signIn({ email, password });
+      setSession(session);
+      navigate("/", { replace: true });
+    } catch (cause) {
+      setError(
+        cause instanceof AuthError ? cause.message : "로그인에 실패했습니다. 잠시 후 다시 시도해주세요.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-5 py-12">
+      <Card className="w-full max-w-md">
+        <h1 className="text-2xl font-semibold tracking-tight">로그인</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          KPubData Studio에 로그인하세요. (mock/demo — 실제 계정 인증은 아직 연결되지 않았습니다.)
+        </p>
+
+        <form className="mt-6 flex flex-col gap-4" onSubmit={handleSubmit}>
+          <FormField id="login-email" label="이메일" required>
+            {(field) => (
+              <TextInput
+                {...field}
+                type="email"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            )}
+          </FormField>
+
+          <FormField id="login-password" label="비밀번호" required>
+            {(field) => (
+              <TextInput
+                {...field}
+                type="password"
+                autoComplete="current-password"
+                required
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            )}
+          </FormField>
+
+          <ErrorMessage>{error}</ErrorMessage>
+
+          <Button type="submit" loading={isSubmitting} className="mt-2">
+            로그인
+          </Button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          계정이 없으신가요?{" "}
+          <Link to="/signup" className="font-medium text-accent-subtle-foreground underline">
+            계정 만들기
+          </Link>
+        </p>
+      </Card>
+    </main>
+  );
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@
  * `/version`을 호출해 계약 버전 호환성을 점검한다(#29).
  */
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { API_BASE } from "@/shared/config/env";
 import {
   API_CONTRACT_VERSION,
@@ -139,9 +140,17 @@ export function SettingsPage() {
                 </button>
               </div>
             ) : (
-              <p className="text-muted-foreground">
-                로그인되지 않았습니다. 실연동 모드에서는 Builder 호출을 위해 Google 로그인이 필요합니다.
-              </p>
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-muted-foreground">
+                  로그인되지 않았습니다. 실연동 모드에서는 Builder 호출을 위해 로그인이 필요합니다.
+                </p>
+                <Link
+                  to="/login"
+                  className="shrink-0 rounded-lg border border-border px-3 py-1 text-xs font-medium text-accent-subtle-foreground hover:bg-muted"
+                >
+                  로그인
+                </Link>
+              </div>
             )}
           </div>
         </Card>

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,0 +1,168 @@
+/**
+ * 계정 만들기 화면 (/signup, #263).
+ *
+ * 실제 IdP 연결은 Builder #515 결정 이후로 미루고, 지금은 mock/demo AuthProvider로
+ * 회원가입 UX와 generic AuthProvider 경계를 시연한다. 가입 성공 시 곧바로 로그인 세션을
+ * 만들지 않고 email verification 안내만 보여준다 — 실제 인증 메일 발송/검증(자체 mail
+ * server)은 이슈 스코프 밖이며 Builder #515 이후 real IdP가 담당한다.
+ */
+import { useState, type FormEvent } from "react";
+import { Link } from "react-router-dom";
+import { mockAuthProvider } from "@/features/auth/mockAuthProvider";
+import type { AccountType } from "@/features/auth/types";
+import { Button, Card, ErrorMessage, FormField, TextInput } from "@/shared/ui";
+
+export function SignupPage() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [accountType, setAccountType] = useState<AccountType>("individual");
+  const [organizationName, setOrganizationName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [createdEmail, setCreatedEmail] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      const session = await mockAuthProvider.signUp({
+        name,
+        email,
+        password,
+        accountType,
+        organizationName:
+          accountType === "organization" && organizationName ? organizationName : undefined,
+      });
+      // 계정은 생성됐지만 실제 email verification 전까지는 로그인 세션을 만들지 않는다.
+      setCreatedEmail(session.email);
+    } catch (cause) {
+      setError(
+        cause instanceof Error ? cause.message : "계정을 만들지 못했습니다. 잠시 후 다시 시도해주세요.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (createdEmail) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-background px-5 py-12">
+        <Card className="w-full max-w-md text-center">
+          <h1 className="text-2xl font-semibold tracking-tight">이메일을 확인해주세요</h1>
+          <p className="mt-3 text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{createdEmail}</span>로 인증 링크를
+            보냈습니다. (mock/demo 모드에서는 실제 이메일이 발송되지 않습니다.)
+          </p>
+          <Link
+            to="/login"
+            className="mt-6 inline-block font-medium text-accent-subtle-foreground underline"
+          >
+            로그인하러 가기
+          </Link>
+        </Card>
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-5 py-12">
+      <Card className="w-full max-w-md">
+        <h1 className="text-2xl font-semibold tracking-tight">계정 만들기</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          KPubData Studio 계정을 만드세요. (mock/demo — 실제 계정 인증은 아직 연결되지 않았습니다.)
+        </p>
+
+        <form className="mt-6 flex flex-col gap-4" onSubmit={handleSubmit}>
+          <FormField id="signup-name" label="이름" required>
+            {(field) => (
+              <TextInput
+                {...field}
+                autoComplete="name"
+                required
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
+            )}
+          </FormField>
+
+          <FormField id="signup-email" label="이메일" required>
+            {(field) => (
+              <TextInput
+                {...field}
+                type="email"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            )}
+          </FormField>
+
+          <FormField id="signup-password" label="비밀번호" required>
+            {(field) => (
+              <TextInput
+                {...field}
+                type="password"
+                autoComplete="new-password"
+                required
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            )}
+          </FormField>
+
+          <fieldset className="flex flex-col gap-2">
+            <legend className="text-sm font-medium text-foreground">계정 유형</legend>
+            <label className="flex items-center gap-2 text-sm text-foreground">
+              <input
+                type="radio"
+                name="accountType"
+                value="individual"
+                checked={accountType === "individual"}
+                onChange={() => setAccountType("individual")}
+              />
+              개인
+            </label>
+            <label className="flex items-center gap-2 text-sm text-foreground">
+              <input
+                type="radio"
+                name="accountType"
+                value="organization"
+                checked={accountType === "organization"}
+                onChange={() => setAccountType("organization")}
+              />
+              팀 · 기관
+            </label>
+          </fieldset>
+
+          {accountType === "organization" ? (
+            <FormField id="signup-org" label="기관/팀명" help="선택 입력입니다.">
+              {(field) => (
+                <TextInput
+                  {...field}
+                  value={organizationName}
+                  onChange={(event) => setOrganizationName(event.target.value)}
+                />
+              )}
+            </FormField>
+          ) : null}
+
+          <ErrorMessage>{error}</ErrorMessage>
+
+          <Button type="submit" loading={isSubmitting} className="mt-2">
+            계정 만들기
+          </Button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          이미 계정이 있으신가요?{" "}
+          <Link to="/login" className="font-medium text-accent-subtle-foreground underline">
+            로그인
+          </Link>
+        </p>
+      </Card>
+    </main>
+  );
+}


### PR DESCRIPTION
## 개요

Closes #263

`kpubdata_ui_prototype_v1.html`의 Login/Signup UX를 구현하되, 실제 email/password IdP 연결은 Builder #515에서 IdP가 결정된 뒤로 미룹니다. 대신 provider-agnostic한 `AuthProvider`/`AuthSession` 계약을 정의하고, 그 뒤에 mock/demo provider를 하나 꽂아 UI와 경계를 시연합니다.

## 이번 PR에서 구현한 것

### Login / Signup 화면 (`/login`, `/signup`)
- Login: 이메일, 비밀번호, 로그인 버튼, "계정 만들기" 링크, 실패 메시지(role="alert")
- Signup: 이름, 이메일, 비밀번호, 개인/팀·기관 선택, 기관/팀명(선택), 계정 만들기 버튼, 로그인 링크
- Signup 성공 시 바로 로그인시키지 않고 "이메일을 확인해주세요" 안내로 전환 — mock/demo 모드에서는 실제 메일이 발송되지 않는다고 명시
- 두 화면 모두 App Shell(사이드바/헤더) 밖의 독립 라우트로 배치(`src/app/router.tsx`, `Layout`의 형제 라우트)

### Generic `AuthProvider` / `AuthSession` (`src/features/auth/types.ts`)
- `AuthSession { token, email, name, provider }` — 로그인 성공 후 공통으로 쓰는 세션 shape
- `AuthProvider { id, signIn, signUp, signOut }` — email/password(또는 향후 다른 OIDC)용 provider 계약
- Google GIS는 이 인터페이스를 구현하지 않습니다 — GIS SDK는 위젯을 렌더링하고 콜백으로 credential을 돌려주는 방식이라 `signIn(email, password)` 같은 직접 호출과 맞지 않습니다. 대신 Google도 결과적으로 같은 `AuthSession` shape을 세션 store에 넣으므로, 두 로그인 방식은 세션 모델 층에서 하나로 합쳐집니다.

### Mock/demo provider (`src/features/auth/mockAuthProvider.ts`)
- Builder에 어떤 요청도 보내지 않음
- password는 함수 인자로만 잠깐 존재했다가 버려짐 — 어디에도 저장/대조하지 않음
- 반환하는 토큰은 로컬에서 즉석 생성한 mock 토큰이며, `apiFetch`의 인증 헤더 provider에는 연결되어 있지 않습니다(즉 이 토큰이 실제 Builder 호출에 실리는 일은 없습니다) — Builder bearer 토큰 연결은 명시적으로 #515 이후로 미룹니다
- 짧은 비밀번호로 로그인하면 결정적으로 실패 상태(`AuthError`)를 재현할 수 있게 해서 Login 화면의 "실패 메시지" 요구사항을 시연

### 세션 store 확장 (`src/features/auth/store.ts`)
- 기존 `useAuthStore`를 **교체하지 않고 확장**했습니다: `name`, `providerId` 필드와 `setSession()` 메서드를 추가
- 기존 `setToken(token, email?)` 시그니처와 동작은 그대로 유지 — `GoogleLoginButton.tsx`는 한 글자도 건드리지 않았습니다
- 결과적으로 Google(`setToken`)과 mock(`setSession`)이 같은 store를 공유해, topbar avatar/Settings/`LoginGate`가 어느 provider로 로그인했는지 신경 쓰지 않고 동일하게 동작합니다

### 기존 코드와의 연결 (최소한만 추가)
- `LoginGate.tsx`, `SettingsPage.tsx`: 로그인 안내 문구에 `/login`으로 가는 링크 한 줄씩만 추가했습니다(그 외 로직/조건은 그대로) — 새 화면이 실제로 도달 가능하도록 하기 위한 최소 변경입니다
- `__tests__/settingsVersionCheck.test.tsx`: 이 변경으로 `SettingsPage`가 이제 `<Link>`를 렌더링해 Router 컨텍스트가 필요해졌습니다 — 기존 테스트 2건에 `MemoryRouter` 래핑을 추가해 통과시켰습니다(다른 로직 변경 없음)

## 보안 요구사항 준수 확인
- password는 Zustand store/localStorage/sessionStorage/로그 어디에도 저장하지 않습니다 — 테스트(`mockAuthProvider.test.ts`, `LoginPage.test.tsx`, `SignupPage.test.tsx`)에서 반환된 세션/store/DOM에 원문 비밀번호가 섞이지 않는지 직접 검증합니다
- Builder로 password 원문을 전송하지 않습니다 — mock provider는 Builder API를 아예 호출하지 않습니다
- 토큰은 URL이나 localStorage에 저장하지 않습니다 — 기존과 동일하게 메모리 전용 zustand store만 사용합니다(persist 미들웨어 없음)
- 자체 password hashing DB나 reset mail server는 만들지 않았습니다 — mock provider는 어떤 자격 증명도 저장/대조하지 않고, 매 signIn마다 새 토큰을 즉석 발급할 뿐입니다

## #515 이후로 미룬 것 (이슈에 명시된 대로)
- 실제 IdP adapter 선택 및 연결
- signIn/signUp/getSession/refresh 정책, JWKS, issuer/audience 계약
- 이 mock provider의 토큰을 Builder bearer 토큰으로 연결하는 것 — 지금은 의도적으로 연결하지 않았습니다
- 실제 email verification 발송/검증
- token expiry/401 처리 정책(기존 `setAuthErrorCallback`은 Google 토큰 흐름에만 연결되어 있고 그대로 둡니다)

## 참고: 조사 중 발견한 기존 이슈 (이번 PR 스코프 밖)
`LoginGate`와 `initAuth()`가 정의는 되어 있지만 실제로 `router.tsx`/`Layout.tsx`/`main.tsx` 어디에도 연결되어 있지 않다는 것을 확인했습니다(#190/#187 당시 마무리가 안 된 것으로 보입니다) — 즉 현재는 실연동 모드에서도 앱 콘텐츠가 실제로 게이팅되지 않고, `apiFetch`에도 토큰이 주입되지 않습니다. 이번 PR은 Login/Signup UI와 generic AuthProvider 경계만 다루는 스코프라 이 배선 문제는 건드리지 않았습니다 — 별도 이슈로 분리했습니다: #290

## 테스트
- `npm run typecheck` — PASS
- `npm run lint` — PASS (0 errors, 0 warnings)
- `npm test` — PASS (전체 605 tests, 신규 21건 포함)
- `npm run build` — PASS
- 개발 서버(mock 모드 + `VITE_USE_REAL_BUILDER=true` 모드)에서 Playwright로 직접 로그인 실패/성공, 회원가입+인증 안내, topbar avatar/Settings 카드 업데이트를 확인 — 콘솔 에러 없음

