### PR TITLE
feat: Discover 화면 — Builder 카탈로그 정확 검색·필터 (#249)

### DIFF
--- a/__tests__/DiscoverPage.test.tsx
+++ b/__tests__/DiscoverPage.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * DiscoverPage (#249) — 정확 검색, provider 카드/필터(런타임 계산), requires_service_key
+ * 배지/필터, Add Data Workbench로의 provider/dataset 전달, 빈/에러 상태를 확인한다.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { DiscoverPage } from "@/pages/DiscoverPage";
+import * as discoverApi from "@/features/discover/api";
+import type { CatalogResponse } from "@/shared/lib/builderApi";
+
+const navigateMock = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+function renderDiscover() {
+  return render(
+    <MemoryRouter>
+      <DiscoverPage />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  navigateMock.mockClear();
+});
+
+describe("DiscoverPage", () => {
+  it("loads the mock catalog and renders dataset cards with provider labels and counts", async () => {
+    renderDiscover();
+
+    expect(await screen.findByText("대기오염 정보")).toBeInTheDocument();
+    // provider select에 한글 라벨과 런타임 계산된 건수가 함께 표시된다(하드코딩 아님).
+    expect(screen.getByRole("option", { name: /공공데이터포털 \(data\.go\.kr\) \(\d+개\)/ })).toBeInTheDocument();
+  });
+
+  it("shows the requires_service_key badge only on datasets that need one", async () => {
+    renderDiscover();
+    await screen.findByText("대기오염 정보");
+
+    // air_quality: requires_service_key=true → 배지가 있어야 한다.
+    const requiresKeyCard = screen.getByText("대기오염 정보").closest("[class*='rounded-xl']") as HTMLElement;
+    expect(within(requiresKeyCard).getByText("서비스 키 필요")).toBeInTheDocument();
+
+    // dur_product_info: requires_service_key=false → 배지가 없어야 한다.
+    const noKeyCard = screen.getByText("DUR 품목정보").closest("[class*='rounded-xl']") as HTMLElement;
+    expect(within(noKeyCard).queryByText("서비스 키 필요")).not.toBeInTheDocument();
+  });
+
+  it("filters by exact search query on dataset name/title/provider", async () => {
+    renderDiscover();
+    await screen.findByText("대기오염 정보");
+
+    fireEvent.change(screen.getByLabelText("데이터셋명·기관 검색"), { target: { value: "인구총조사" } });
+
+    await waitFor(() => {
+      expect(screen.queryByText("대기오염 정보")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("인구총조사")).toBeInTheDocument();
+  });
+
+  it("filters by provider", async () => {
+    renderDiscover();
+    await screen.findByText("대기오염 정보");
+
+    fireEvent.change(screen.getByLabelText("Provider"), { target: { value: "seoul" } });
+
+    await waitFor(() => {
+      expect(screen.queryByText("대기오염 정보")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("따릉이 대여 현황")).toBeInTheDocument();
+  });
+
+  it("filters to only datasets that require a service key when the checkbox is checked", async () => {
+    renderDiscover();
+    await screen.findByText("대기오염 정보");
+
+    fireEvent.click(screen.getByLabelText(/서비스 키 필요만/));
+
+    await waitFor(() => {
+      expect(screen.queryByText("DUR 품목정보")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("대기오염 정보")).toBeInTheDocument();
+  });
+
+  it("shows an empty-results state (distinct from the empty-catalog state) when no entry matches the filters", async () => {
+    renderDiscover();
+    await screen.findByText("대기오염 정보");
+
+    fireEvent.change(screen.getByLabelText("데이터셋명·기관 검색"), { target: { value: "존재하지-않는-데이터셋" } });
+
+    expect(await screen.findByText("조건에 맞는 데이터셋이 없습니다")).toBeInTheDocument();
+  });
+
+  it("navigates to /add with provider and dataset query params when starting from a card", async () => {
+    renderDiscover();
+    await screen.findByText("대기오염 정보");
+
+    const startButtons = screen.getAllByRole("button", { name: "이 데이터로 시작하기" });
+    fireEvent.click(startButtons[0]);
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/add\?provider=datago&dataset=/),
+    );
+  });
+
+  it("shows a distinct empty state when the catalog itself has no providers", async () => {
+    vi.spyOn(discoverApi, "loadCatalog").mockResolvedValue({ providers: [] } satisfies CatalogResponse);
+    renderDiscover();
+
+    expect(await screen.findByText("Builder 카탈로그가 비어 있습니다")).toBeInTheDocument();
+  });
+
+  it("shows an error state with retry when the catalog fails to load", async () => {
+    vi.spyOn(discoverApi, "loadCatalog").mockRejectedValue(new Error("네트워크 오류"));
+    renderDiscover();
+
+    expect(await screen.findByText("카탈로그를 불러오지 못했습니다")).toBeInTheDocument();
+    expect(screen.getByText("네트워크 오류")).toBeInTheDocument();
+  });
+
+  it("clears all filters via the reset button", async () => {
+    renderDiscover();
+    await screen.findByText("대기오염 정보");
+
+    fireEvent.change(screen.getByLabelText("데이터셋명·기관 검색"), { target: { value: "인구총조사" } });
+    fireEvent.click(await screen.findByRole("button", { name: "필터 초기화" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("데이터셋명·기관 검색")).toHaveValue("");
+    });
+    expect(await screen.findByText("대기오염 정보")).toBeInTheDocument();
+  });
+});

--- a/__tests__/newIaPages.test.tsx
+++ b/__tests__/newIaPages.test.tsx
@@ -19,7 +19,6 @@ function renderPage(element: ReactNode) {
 
 describe("새 IA placeholder 화면 (#247)", () => {
   it.each([
-    [<DiscoverPage />, "데이터 탐색"],
     [<WorkspacePage />, "작업대"],
     [<AddDataPage />, "데이터 추가"],
     [<ProviderPage />, "Provider"],
@@ -28,6 +27,12 @@ describe("새 IA placeholder 화면 (#247)", () => {
     renderPage(element);
     expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
     expect(screen.getByText("아직 준비 중인 화면입니다")).toBeInTheDocument();
+  });
+
+  it("Discover is replaced with the real catalog search/filter screen (#249)", () => {
+    renderPage(<DiscoverPage />);
+    expect(screen.getByRole("heading", { name: "데이터 탐색" })).toBeInTheDocument();
+    expect(screen.queryByText("아직 준비 중인 화면입니다")).not.toBeInTheDocument();
   });
 
   it("Reports is replaced with the real Builder evidence-based Report screen (#258)", () => {

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -60,8 +60,8 @@ export const router = createBrowserRouter([
         index: true,
         element: withFeatureBoundary("홈", <HomePage />),
       },
-      // 새 IA(#247)의 WORKSPACE 그룹. Discover/Workspace는 아직 placeholder이며
-      // #249/#260에서 실제 화면으로 교체된다.
+      // 새 IA(#247)의 WORKSPACE 그룹. Discover는 #249에서 구현됨. Workspace는 아직
+      // placeholder이며 #260에서 실제 화면으로 교체된다.
       {
         path: "discover",
         element: withFeatureBoundary("Discover", <DiscoverPage />),

--- a/src/features/discover/api.test.ts
+++ b/src/features/discover/api.test.ts
@@ -1,0 +1,61 @@
+/**
+ * loadCatalog (#249) mock/real 분기 테스트.
+ *
+ * mock 모드에서는 네트워크를 전혀 치지 않고 결정적 fixture를 반환하고, 실연동 모드에서는
+ * Builder GET /catalog를 호출하는지 확인한다(#246 mock/real 구분 원칙).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadCatalog } from "./api";
+
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("loadCatalog (#249)", () => {
+  describe("mock mode", () => {
+    it("does not make a network call", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      await loadCatalog();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("returns a deterministic catalog with multiple providers and a mix of requires_service_key", async () => {
+      const catalog = await loadCatalog();
+      expect(catalog.providers.length).toBeGreaterThan(1);
+
+      const allDatasets = catalog.providers.flatMap((provider) => provider.datasets);
+      expect(allDatasets.some((dataset) => dataset.requires_service_key)).toBe(true);
+      expect(allDatasets.some((dataset) => !dataset.requires_service_key)).toBe(true);
+    });
+  });
+
+  describe("real integration mode", () => {
+    it("calls Builder GET /catalog and returns the parsed response", async () => {
+      vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse(200, {
+          providers: [{ name: "datago", datasets: [{ name: "air", title: "대기질", requires_service_key: true }] }],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const catalog = await loadCatalog();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(String(fetchMock.mock.calls[0][0])).toContain("/catalog");
+      expect(catalog.providers[0].name).toBe("datago");
+    });
+  });
+});

--- a/src/features/discover/api.ts
+++ b/src/features/discover/api.ts
@@ -1,0 +1,50 @@
+/**
+ * Discover(#249) API 계층.
+ *
+ * Builder `GET /catalog`(원천 provider/dataset 카탈로그)를 조회한다 — 이미 빌드된
+ * 데이터셋 목록(`GET /datasets`, `features/datasets/api`)과는 다른 소스이니 섞지 않는다.
+ *
+ * mock/real 분기는 `features/datasets/api`가 이미 확립한 패턴을 그대로 따른다:
+ * `builderApi.catalog()` 자체는 mock 분기가 없으므로(#246 원칙 — mock/demo와 real Builder
+ * 동작을 명확히 구분), 이 계층에서 `isRealBuilderEnabled()`로 나눈다.
+ */
+import { builderApi, isRealBuilderEnabled, type CatalogResponse } from "@/shared/lib/builderApi";
+
+/**
+ * mock 모드에서 쓰는 결정적 fixture.
+ *
+ * requires_service_key가 true/false 둘 다 있어야 배지/필터를 시연할 수 있고, provider가
+ * 2개 이상이어야 provider 필터가 의미를 갖는다. 실제 Builder #490 rich metadata(description/
+ * tags/source_url 등)는 아직 스키마에 없으므로 이 fixture도 3필드(name/title/
+ * requires_service_key)만 채운다 — P0는 그 이상을 가정하지 않는다.
+ */
+const MOCK_CATALOG: CatalogResponse = {
+  providers: [
+    {
+      name: "datago",
+      datasets: [
+        { name: "air_quality", title: "대기오염 정보", requires_service_key: true },
+        { name: "apt_trade", title: "아파트 실거래가", requires_service_key: true },
+        { name: "dur_product_info", title: "DUR 품목정보", requires_service_key: false },
+      ],
+    },
+    {
+      name: "kosis",
+      datasets: [
+        { name: "population_stat", title: "인구총조사", requires_service_key: false },
+      ],
+    },
+    {
+      name: "seoul",
+      datasets: [
+        { name: "bike_rental", title: "따릉이 대여 현황", requires_service_key: true },
+      ],
+    },
+  ],
+};
+
+/** GET /catalog — provider/dataset 원천 카탈로그를 조회한다(#249). */
+export async function loadCatalog(signal?: AbortSignal): Promise<CatalogResponse> {
+  if (isRealBuilderEnabled()) return builderApi.catalog(signal);
+  return MOCK_CATALOG;
+}

--- a/src/features/discover/model.test.ts
+++ b/src/features/discover/model.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Discover(#249) model 헬퍼 테스트.
+ */
+import { describe, expect, it } from "vitest";
+import type { CatalogResponse } from "@/shared/lib/builderApi";
+import {
+  computeProviderCounts,
+  computeServiceKeyCount,
+  flattenCatalog,
+  matchesProviderFilter,
+  matchesQuery,
+  matchesServiceKeyFilter,
+  uniqueProviders,
+  type DiscoverEntry,
+} from "./model";
+
+const CATALOG: CatalogResponse = {
+  providers: [
+    {
+      name: "datago",
+      datasets: [
+        { name: "air_quality", title: "대기오염 정보", requires_service_key: true },
+        { name: "dur_product_info", title: "DUR 품목정보", requires_service_key: false },
+      ],
+    },
+    {
+      name: "seoul",
+      datasets: [{ name: "bike_rental", title: "따릉이 대여 현황", requires_service_key: true }],
+    },
+  ],
+};
+
+describe("flattenCatalog", () => {
+  it("flattens every provider's datasets into one list, keeping the provider name attached", () => {
+    const entries = flattenCatalog(CATALOG);
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toEqual({ provider: "datago", dataset: CATALOG.providers[0].datasets[0] });
+    expect(entries[2]).toEqual({ provider: "seoul", dataset: CATALOG.providers[1].datasets[0] });
+  });
+
+  it("returns an empty array for an empty catalog (not a crash)", () => {
+    expect(flattenCatalog({ providers: [] })).toEqual([]);
+  });
+});
+
+describe("matchesQuery", () => {
+  const entries = flattenCatalog(CATALOG);
+  const airQuality = entries[0];
+
+  it("matches by dataset name, title, or provider name, case-insensitively", () => {
+    expect(matchesQuery(airQuality, "AIR_QUALITY")).toBe(true);
+    expect(matchesQuery(airQuality, "대기오염")).toBe(true);
+    expect(matchesQuery(airQuality, "DATAGO")).toBe(true);
+  });
+
+  it("does not match unrelated queries", () => {
+    expect(matchesQuery(airQuality, "population")).toBe(false);
+  });
+
+  it("treats an empty/whitespace query as matching everything", () => {
+    expect(matchesQuery(airQuality, "")).toBe(true);
+    expect(matchesQuery(airQuality, "   ")).toBe(true);
+  });
+});
+
+describe("matchesProviderFilter", () => {
+  const entries = flattenCatalog(CATALOG);
+
+  it("matches only the selected provider", () => {
+    expect(matchesProviderFilter(entries[0], "datago")).toBe(true);
+    expect(matchesProviderFilter(entries[0], "seoul")).toBe(false);
+  });
+
+  it("treats an empty selection as 전체(no filter)", () => {
+    expect(matchesProviderFilter(entries[0], "")).toBe(true);
+  });
+});
+
+describe("matchesServiceKeyFilter", () => {
+  const entries = flattenCatalog(CATALOG);
+  const requiresKey = entries[0]; // air_quality: true
+  const noKey = entries[1]; // dur_product_info: false
+
+  it("when off, passes everything regardless of requires_service_key", () => {
+    expect(matchesServiceKeyFilter(requiresKey, false)).toBe(true);
+    expect(matchesServiceKeyFilter(noKey, false)).toBe(true);
+  });
+
+  it("when on, keeps only datasets that require a service key", () => {
+    expect(matchesServiceKeyFilter(requiresKey, true)).toBe(true);
+    expect(matchesServiceKeyFilter(noKey, true)).toBe(false);
+  });
+});
+
+describe("computeProviderCounts", () => {
+  it("computes counts at runtime from the loaded entries, not from a hardcoded table", () => {
+    const entries = flattenCatalog(CATALOG);
+    const counts = computeProviderCounts(entries);
+    expect(counts.get("datago")).toBe(2);
+    expect(counts.get("seoul")).toBe(1);
+    expect(counts.get("unknown-provider")).toBeUndefined();
+  });
+
+  it("returns an empty map for no entries", () => {
+    expect(computeProviderCounts([])).toEqual(new Map());
+  });
+
+  it("reflects a differently-shaped catalog on a second call (not memoized/stale)", () => {
+    const smaller: DiscoverEntry[] = [{ provider: "datago", dataset: CATALOG.providers[0].datasets[0] }];
+    expect(computeProviderCounts(smaller).get("datago")).toBe(1);
+  });
+});
+
+describe("uniqueProviders", () => {
+  it("returns sorted, de-duplicated provider names", () => {
+    const entries = flattenCatalog(CATALOG);
+    expect(uniqueProviders(entries)).toEqual(["datago", "seoul"]);
+  });
+
+  it("returns an empty array when there are no entries", () => {
+    expect(uniqueProviders([])).toEqual([]);
+  });
+});
+
+describe("computeServiceKeyCount", () => {
+  it("counts only entries with requires_service_key = true", () => {
+    const entries = flattenCatalog(CATALOG);
+    expect(computeServiceKeyCount(entries)).toBe(2);
+  });
+
+  it("returns 0 for an empty list", () => {
+    expect(computeServiceKeyCount([])).toBe(0);
+  });
+});

--- a/src/features/discover/model.ts
+++ b/src/features/discover/model.ts
@@ -1,0 +1,61 @@
+/**
+ * Discover(#249) 순수 모델 헬퍼.
+ *
+ * Builder `/catalog` 응답(provider별 dataset 목록)을 검색/필터링하기 위한 로직만 담는다.
+ * 자연어 검색(Kubi, #256)이 아니라 dataset명/title/provider명에 대한 리터럴 substring
+ * 매칭이다 — `DatasetCatalogPage`의 "정확 검색"과 같은 해석.
+ */
+import type { CatalogDataset, CatalogResponse } from "@/shared/lib/builderApi";
+
+/** 카드 하나에 대응하는, provider와 dataset을 함께 들고 있는 flatten된 항목. */
+export interface DiscoverEntry {
+  provider: string;
+  dataset: CatalogDataset;
+}
+
+/** provider별로 중첩된 catalog 응답을 카드 렌더링에 쓰기 좋은 평평한 목록으로 편다. */
+export function flattenCatalog(catalog: CatalogResponse): DiscoverEntry[] {
+  return catalog.providers.flatMap((provider) =>
+    provider.datasets.map((dataset) => ({ provider: provider.name, dataset })),
+  );
+}
+
+/** dataset명/title/provider명에 대한 대소문자 무시 substring 매칭. 빈 쿼리는 항상 통과. */
+export function matchesQuery(entry: DiscoverEntry, query: string): boolean {
+  const normalized = query.trim().toLocaleLowerCase();
+  if (!normalized) return true;
+  const haystack = `${entry.dataset.name} ${entry.dataset.title} ${entry.provider}`.toLocaleLowerCase();
+  return haystack.includes(normalized);
+}
+
+/** provider 필터. 빈 문자열("전체")은 항상 통과. */
+export function matchesProviderFilter(entry: DiscoverEntry, provider: string): boolean {
+  return !provider || entry.provider === provider;
+}
+
+/** "서비스 키 필요만" 필터. false면 항상 통과(필터 미적용). */
+export function matchesServiceKeyFilter(entry: DiscoverEntry, onlyRequiresKey: boolean): boolean {
+  return !onlyRequiresKey || entry.dataset.requires_service_key;
+}
+
+/**
+ * provider별 dataset 건수를 로드된 catalog에서 그때그때 계산한다 — 하드코딩된 provider
+ * 목록/건수를 쓰지 않는다(#249 요구사항).
+ */
+export function computeProviderCounts(entries: DiscoverEntry[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const entry of entries) {
+    counts.set(entry.provider, (counts.get(entry.provider) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/** catalog 전체에서 알파벳순으로 정렬된 고유 provider 목록(필터 옵션용). */
+export function uniqueProviders(entries: DiscoverEntry[]): string[] {
+  return Array.from(new Set(entries.map((entry) => entry.provider))).sort();
+}
+
+/** requires_service_key=true인 항목 수 — "서비스 키 필요만" 체크박스 라벨에 표시. */
+export function computeServiceKeyCount(entries: DiscoverEntry[]): number {
+  return entries.filter((entry) => entry.dataset.requires_service_key).length;
+}

--- a/src/pages/DiscoverPage.tsx
+++ b/src/pages/DiscoverPage.tsx
@@ -1,18 +1,186 @@
 /**
- * Discover 화면 (`/discover`) — placeholder (#247).
+ * Discover 화면 (`/discover`, #249).
  *
- * 정확 검색과 Provider 탐색 UI는 #249에서 구현한다. App Shell 단계에서는 새 IA의 route와
- * 내비게이션이 먼저 존재해야 하므로 명시적인 placeholder를 둔다.
+ * Builder 원천 provider/dataset 카탈로그(`GET /catalog`)를 정확 검색·필터로 탐색하고,
+ * 선택한 항목을 Add Data Workbench(`/add`, #250)로 넘긴다. 자연어 검색(Kubi, #256)이나
+ * 이미 빌드된 데이터셋 목록(Dataset Catalog, `/datasets`, #253)과는 다른 화면이다 —
+ * `/catalog`(원본)와 `/datasets`(빌드 결과)를 섞지 않는다.
  */
-import { PlaceholderPage } from "@/shared/ui";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { loadCatalog } from "@/features/discover/api";
+import {
+  computeProviderCounts,
+  computeServiceKeyCount,
+  flattenCatalog,
+  matchesProviderFilter,
+  matchesQuery,
+  matchesServiceKeyFilter,
+  uniqueProviders,
+  type DiscoverEntry,
+} from "@/features/discover/model";
+import { providerLabel } from "@/shared/lib/providerLabels";
+import { Button, Card, EmptyState, ErrorState, PageHeader, Skeleton, TextInput } from "@/shared/ui";
+
+interface CatalogState {
+  status: "loading" | "loaded" | "error";
+  entries?: DiscoverEntry[];
+  error?: string;
+}
+
+const selectClassName =
+  "h-9 rounded-lg border border-input bg-card px-3 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
 export function DiscoverPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [state, setState] = useState<CatalogState>({ status: "loading" });
+
+  const load = useCallback(() => {
+    const controller = new AbortController();
+    setState({ status: "loading" });
+    loadCatalog(controller.signal)
+      .then((catalog) => setState({ status: "loaded", entries: flattenCatalog(catalog) }))
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setState({
+          status: "error",
+          error: cause instanceof Error ? cause.message : "카탈로그를 불러오지 못했습니다.",
+        });
+      });
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => load(), [load]);
+
+  const query = searchParams.get("q") ?? "";
+  const provider = searchParams.get("provider") ?? "";
+  const onlyRequiresKey = searchParams.get("key") === "1";
+
+  function updateParam(name: string, value: string) {
+    const next = new URLSearchParams(searchParams);
+    if (value) next.set(name, value);
+    else next.delete(name);
+    setSearchParams(next);
+  }
+
+  const entries = state.entries ?? [];
+  const providerOptions = useMemo(() => uniqueProviders(entries), [entries]);
+  const providerCounts = useMemo(() => computeProviderCounts(entries), [entries]);
+  const serviceKeyCount = useMemo(() => computeServiceKeyCount(entries), [entries]);
+
+  const visibleEntries = useMemo(
+    () =>
+      entries.filter(
+        (entry) =>
+          matchesQuery(entry, query) &&
+          matchesProviderFilter(entry, provider) &&
+          matchesServiceKeyFilter(entry, onlyRequiresKey),
+      ),
+    [entries, query, provider, onlyRequiresKey],
+  );
+
+  function startWithDataset(entry: DiscoverEntry) {
+    navigate(`/add?provider=${encodeURIComponent(entry.provider)}&dataset=${encodeURIComponent(entry.dataset.name)}`);
+  }
+
+  const hasActiveFilters = Boolean(query || provider || onlyRequiresKey);
+
   return (
-    <PlaceholderPage
-      eyebrow="Discover"
-      title="데이터 탐색"
-      description="Provider와 데이터셋을 정확 검색하고 후보를 추천받습니다."
-      note="정확 검색·Provider 탐색 UI는 #249에서 구현됩니다."
-    />
+    <main className="flex flex-1 flex-col gap-5 px-5 py-7 sm:px-8 lg:px-10 lg:py-8">
+      <PageHeader
+        eyebrow="Discover"
+        title="데이터 탐색"
+        description="Builder 카탈로그에서 provider와 데이터셋을 정확 검색하고, 선택한 데이터로 바로 빌드를 시작하세요."
+      />
+
+      <Card className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="min-w-56 flex-1 lg:max-w-[390px]">
+            <label htmlFor="discover-search" className="sr-only">
+              데이터셋명·기관 검색
+            </label>
+            <TextInput
+              id="discover-search"
+              placeholder="데이터셋명·기관 검색"
+              value={query}
+              onChange={(event) => updateParam("q", event.target.value)}
+            />
+          </div>
+          <label className="min-w-56 flex-1 sm:flex-none">
+            <span className="sr-only">Provider</span>
+            <select
+              aria-label="Provider"
+              className={`w-full ${selectClassName}`}
+              value={provider}
+              onChange={(event) => updateParam("provider", event.target.value)}
+            >
+              <option value="">Provider 전체 ({entries.length}개)</option>
+              {providerOptions.map((item) => (
+                <option key={item} value={item}>
+                  {providerLabel(item)} ({providerCounts.get(item) ?? 0}개)
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-2 text-sm text-foreground">
+            <input
+              type="checkbox"
+              checked={onlyRequiresKey}
+              onChange={(event) => updateParam("key", event.target.checked ? "1" : "")}
+            />
+            서비스 키 필요만 ({serviceKeyCount}개)
+          </label>
+          {hasActiveFilters ? (
+            <Button variant="ghost" size="sm" onClick={() => setSearchParams({})} className="ml-auto">
+              필터 초기화
+            </Button>
+          ) : null}
+        </div>
+
+        {state.status === "loading" ? (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <Skeleton key={index} className="h-32 w-full rounded-xl" />
+            ))}
+          </div>
+        ) : state.status === "error" ? (
+          <ErrorState title="카탈로그를 불러오지 못했습니다" message={state.error} onRetry={load} />
+        ) : entries.length === 0 ? (
+          <EmptyState
+            title="Builder 카탈로그가 비어 있습니다"
+            description="등록된 provider/dataset이 없습니다. Builder 설정을 확인해 주세요."
+          />
+        ) : visibleEntries.length === 0 ? (
+          <EmptyState title="조건에 맞는 데이터셋이 없습니다" description="검색어나 필터를 변경해 보세요." />
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {visibleEntries.map((entry) => (
+              <Card key={`${entry.provider}/${entry.dataset.name}`} variant="elevated" className="flex flex-col gap-3">
+                <div>
+                  <p className="font-semibold text-foreground">{entry.dataset.title}</p>
+                  <p className="mt-1 break-all font-mono text-xs text-muted-foreground">{entry.dataset.name}</p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                  <span className="rounded-full bg-muted px-2 py-0.5">{providerLabel(entry.provider)}</span>
+                  {entry.dataset.requires_service_key ? (
+                    <span className="rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-800 dark:bg-amber-950/50 dark:text-amber-300">
+                      서비스 키 필요
+                    </span>
+                  ) : null}
+                </div>
+                <Button size="sm" onClick={() => startWithDataset(entry)} className="mt-auto">
+                  이 데이터로 시작하기
+                </Button>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {state.status === "loaded" ? (
+          <p className="text-xs text-muted-foreground">{visibleEntries.length}개 표시</p>
+        ) : null}
+      </Card>
+    </main>
   );
 }

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -15,6 +15,7 @@ import { useBuild } from "@/features/runs/useBuild";
 import { useBuildJob } from "@/features/runs/useBuildJob";
 import { validateSpec } from "@/features/validation/api";
 import { builderApi, type CatalogDataset, type CatalogProvider } from "@/shared/lib/builderApi";
+import { providerLabel } from "@/shared/lib/providerLabels";
 import { buildFormValuesSchema, buildSpecSchema, exportFormatSchema } from "@/shared/lib/schemas";
 import type { BuildSpec } from "@/shared/lib/types";
 import {
@@ -32,19 +33,6 @@ import {
 } from "@/shared/ui";
 
 const exportFormats = exportFormatSchema.options;
-
-const PROVIDER_LABELS: Readonly<Record<string, string>> = {
-  bok: "한국은행 ECOS (BOK)",
-  datago: "공공데이터포털 (data.go.kr)",
-  kosis: "통계청 KOSIS",
-  krx: "한국거래소 (KRX)",
-  law: "국가법령정보센터",
-  localdata: "지역정보포털 (LocalData)",
-  lofin: "지방재정365 (LOFIN)",
-  semas: "소상공인시장진흥공단 (SEMAS)",
-  seoul: "서울 열린데이터광장",
-  sgis: "통계지리정보서비스 (SGIS)",
-};
 
 interface BuildFormValues {
   datasetId: string;
@@ -256,10 +244,6 @@ type CatalogState =
   | { readonly status: "loading"; readonly providers: readonly CatalogProvider[]; readonly error?: undefined }
   | { readonly status: "loaded"; readonly providers: readonly CatalogProvider[]; readonly error?: undefined }
   | { readonly status: "error"; readonly providers: readonly CatalogProvider[]; readonly error: string };
-
-function providerLabel(provider: string): string {
-  return PROVIDER_LABELS[provider] ?? provider;
-}
 
 function catalogProvider(providers: readonly CatalogProvider[], provider: string): CatalogProvider | undefined {
   return providers.find((entry) => entry.name === provider);

--- a/src/shared/lib/providerLabels.ts
+++ b/src/shared/lib/providerLabels.ts
@@ -1,0 +1,23 @@
+/**
+ * Builder `/catalog` provider 코드의 한글 표시명.
+ *
+ * NewBuildPage(#29)와 Discover(#249)가 같은 provider 목록을 서로 다른 화면에서
+ * 보여주므로, 라벨 매핑을 여기 하나로 모아 중복 정의를 피한다.
+ */
+export const PROVIDER_LABELS: Readonly<Record<string, string>> = {
+  bok: "한국은행 ECOS (BOK)",
+  datago: "공공데이터포털 (data.go.kr)",
+  kosis: "통계청 KOSIS",
+  krx: "한국거래소 (KRX)",
+  law: "국가법령정보센터",
+  localdata: "지역정보포털 (LocalData)",
+  lofin: "지방재정365 (LOFIN)",
+  semas: "소상공인시장진흥공단 (SEMAS)",
+  seoul: "서울 열린데이터광장",
+  sgis: "통계지리정보서비스 (SGIS)",
+};
+
+/** 알려진 provider 코드는 한글 라벨로, 모르는 코드는 원문 그대로 보여준다. */
+export function providerLabel(provider: string): string {
+  return PROVIDER_LABELS[provider] ?? provider;
+}


### PR DESCRIPTION
## 개요

Closes #249

`/discover` placeholder를 Builder 원천 provider/dataset 카탈로그(`GET /catalog`)를 정확 검색·필터로 탐색하고, 선택한 항목을 Add Data Workbench(#250)로 전달하는 실제 화면으로 교체합니다.

## 사전 확인 사항

- **#247(App Shell·Navigation)은 이미 완료**되어 있었습니다 — `/discover` 라우트와 grouped 사이드바(WORKSPACE/DATA/AI/SYSTEM)가 이미 존재, `DiscoverPage`는 순수 placeholder 상태였습니다.
- **PR #283(Add Data Workbench, #250)은 아직 main에 미머지**입니다. 다만 그 브랜치의 `AddDataPage.tsx`에 이미 preselection 수신 로직이 구현되어 있어, 쿼리 파라미터 계약이 **`?provider=<name>&dataset=<name>`**로 고정되어 있음을 확인했습니다. 이 PR은 그 계약에 맞춰 "보내는 쪽"만 구현합니다 — main엔 아직 `/add`가 placeholder라 지금 클릭하면 아무 일 없지만(에러 아님), #283이 머지되면 자동으로 맞물립니다.
- Builder `/catalog` 클라이언트(`builderApi.catalog()`)와 zod 스키마는 이미 main에 있었지만 **3개 필드(name/title/requires_service_key)뿐**입니다. rich metadata(Builder #490)는 스키마에 없으므로, 이슈 지침대로 스키마를 확장하지 않고 이 3필드만으로 완전히 동작하도록 만들었습니다(P1로 미룸).

## 구현

### `src/features/discover/api.ts`
- `loadCatalog(signal?)` — `features/datasets/api`가 이미 확립한 `if (isRealBuilderEnabled()) return builderApi.X(...); return MOCK_X` 패턴을 그대로 따릅니다. `builderApi.catalog()` 자체는 mock 분기가 없어서(항상 실제 네트워크를 침) 이 계층에서 명시적으로 나눴습니다 — mock/demo와 real Builder 동작을 명확히 구분하는 원칙, 그리고 Pages mock 데모가 깨지지 않기 위한 전제조건입니다.

### `src/features/discover/model.ts`
- `flattenCatalog`, `matchesQuery`(dataset명/title/provider명 substring, `DatasetCatalogPage`의 "정확 검색"과 동일한 해석), `matchesProviderFilter`, `matchesServiceKeyFilter`, `computeProviderCounts`, `computeServiceKeyCount` — 전부 순수 함수.
- provider별 건수는 **로드된 catalog에서 그때그때 계산**합니다(하드코딩 금지 요구사항).

### `src/pages/DiscoverPage.tsx`
- placeholder 제거, 카드 그리드 UI(이슈가 명시한 "Provider 카드/필터")로 교체.
- 검색창 + provider select(라벨은 provider별 실제 건수와 함께 표시) + "서비스 키 필요만" 체크박스.
- `requires_service_key`가 true인 카드에만 배지 표시.
- 카드의 "이 데이터로 시작하기" 버튼 → `navigate('/add?provider=X&dataset=Y')`.
- 4가지 상태를 구분: loading(skeleton 그리드) / error(재시도 버튼) / **catalog 자체가 빈 상태**("Builder 카탈로그가 비어 있습니다") / **필터 결과 0건**("조건에 맞는 데이터셋이 없습니다") — 마지막 두 개를 하나로 뭉개지 않았습니다.

### `src/shared/lib/providerLabels.ts`
- `NewBuildPage.tsx`에 private로 있던 `PROVIDER_LABELS`/`providerLabel`을 공유 위치로 추출(순수 이동, 동작 변경 없음). Discover도 필요해서 중복 생성 대신 재사용했습니다. `NewBuildPage.tsx`는 이제 이 모듈을 import합니다.

### `__tests__/newIaPages.test.tsx`
- Discover가 더 이상 placeholder가 아니므로, 공용 `it.each` placeholder 목록에서 빼고 Reports/Kubi/Dataset Catalog/Quality Center와 같은 패턴으로 "실제 화면으로 교체됨" 전용 테스트를 추가했습니다.

## 건드리지 않은 것 (명시적으로 스코프 밖)
- `DatasetCatalogPage`(#253, `/datasets`) — 이미 빌드된 데이터셋 목록이라 `/catalog`(원본)와는 다른 화면, 손대지 않았습니다.
- Kubi 자연어 탐색(#256) — 손대지 않았습니다.
- `catalogDatasetSchema` — rich metadata로 확장하지 않았습니다(P1).
- `AddDataPage.tsx` — 아직 main엔 placeholder, #283 스코프라 손대지 않았습니다.

## 테스트
- `npm run typecheck` — PASS
- `npm run lint` — PASS (0 errors, 0 warnings)
- `npm test` — PASS (전체 613 tests, 신규 29건 포함: `model.test.ts` 15건, `api.test.ts` 4건, `DiscoverPage.test.tsx` 10건)
- `npm run build` — PASS
- 개발 서버(mock 모드)에서 Playwright로 직접 검색/provider 필터/service-key 필터/카드 클릭 → `/add?provider=datago&dataset=air_quality` 정확히 이동하는 것까지 확인 — 콘솔 에러 없음
