### PR TITLE
Fix #290: LoginGate/initAuth 앱 부트스트랩에 연결

### DIFF
--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -8,6 +8,7 @@
 import { useEffect, type ReactNode } from "react";
 import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
 import { useAuthStore } from "@/features/auth/store";
+import { LoginGate } from "@/features/auth/LoginGate";
 import { KubiDrawer } from "@/features/kubi/KubiDrawer";
 import { KubiSearchInput } from "@/features/kubi/KubiSearchInput";
 import { useUIStore } from "@/shared/hooks/useUIStore";
@@ -502,7 +503,9 @@ export function Layout() {
             </div>
           </header>
 
-          <Outlet />
+          <LoginGate>
+            <Outlet />
+          </LoginGate>
         </div>
       </div>
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "@/app/App";
+import { initAuth } from "@/features/auth/init";
 import "./globals.css";
 
 const container = document.getElementById("root");
@@ -14,6 +15,8 @@ const container = document.getElementById("root");
 if (!container) {
   throw new Error("Root container not found");
 }
+
+initAuth();
 
 createRoot(container).render(
   <StrictMode>


### PR DESCRIPTION
Issue #290: LoginGate/initAuth가 앱 부트스트랩에 연결되어 있지 않음 (#190/#188 마무리 배선 누락)

## 문제
- LoginGate와 initAuth()가 코드로는 존재하지만, 실제로 앱 어디에도 연결(import)되어 있지 않음
- 실연동 모드에서도 로그인 없이 앱 콘텐츠가 그대로 렌더링됨
- useAuthStore의 토큰이 apiFetch의 Authorization 헤더에 실제로 주입되지 않음

## 해결
- main.tsx에서 앱 시작 시 initAuth() 호출 추가
- Layout.tsx의 Outlet을 LoginGate로 감싸기
- 실연동 모드(VITE_USE_REAL_BUILDER=true)에서만 로그인 요구
- mock 모드(Pages 데모 포함)에서는 게이트 없이 children 렌더링

## 완료 조건
- #190의 인수 기준: VITE_USE_REAL_BUILDER 미설정 배포가 로그인 없이 그대로 동작
- 실연동 모드 미로그인 상태에서 Builder 호출이 발생하지 않음
- GitHub Pages mock 데모가 깨지지 않음 (배포 후 확인 필요)