### PR TITLE
fix(monitoring): Builder #516 실제 wire 계약 정합 — /monitoring/summary + /monitoring/builds (#302)

### DIFF
--- a/__tests__/MonitoringPage.test.tsx
+++ b/__tests__/MonitoringPage.test.tsx
@@ -1,20 +1,37 @@
 /**
- * Monitoring 화면 테스트 (#264).
+ * Monitoring 화면 테스트 (#264, #302).
  *
- * - system/builds/recent-runs tabs 렌더링
- * - loading/error/empty states 처리
- * - 자동/수동 새로고침 기능
- * - 데이터 연동 테스트
+ * - system/builds/recent-runs 탭 렌더링
+ * - 실제 Builder 계약(/monitoring/summary + /monitoring/builds) 기준 데이터 표시
+ * - 401은 권한 없음 상태로 구분(실API 응답 기준, #302)
+ * - 실연동 실패 시 mock 폴백 없음(정상 오인 방지, #302)
+ * - unavailable/null을 0/정상으로 표시하지 않음(#302 회귀 테스트)
+ * - recent run → Builds 상세 네비게이션(#302)
  */
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { MonitoringPage } from "@/pages/MonitoringPage";
 import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
-import type { MonitoringResponse } from "@/shared/lib/builderApi.schema";
+import type {
+  MonitoringSummaryResponse,
+  MonitoringBuildsResponse,
+} from "@/shared/lib/builderApi.schema";
 
-// 이 저장소는 @testing-library/user-event 의존성을 쓰지 않는다(fireEvent 컨벤션).
-// 테스트 본문의 `await user.click(...)` 표현을 그대로 유지하기 위한 얇은 어댑터다.
+vi.mock("@/shared/lib/builderApi", async () => {
+  const actual = await vi.importActual<typeof import("@/shared/lib/builderApi")>(
+    "@/shared/lib/builderApi",
+  );
+  return {
+    ...actual,
+    isRealBuilderEnabled: vi.fn(() => false),
+    builderApi: {
+      getMonitoringSummary: vi.fn(),
+      getMonitoringBuilds: vi.fn(),
+    },
+  };
+});
+
 function setupUserEvent() {
   return {
     user: {
@@ -25,12 +42,41 @@ function setupUserEvent() {
   };
 }
 
-vi.mock("@/shared/lib/builderApi", () => ({
-  isRealBuilderEnabled: vi.fn(() => false),
-  builderApi: {
-    getMonitoring: vi.fn(),
-  },
-}));
+function summaryFixture(
+  overrides: Partial<MonitoringSummaryResponse> = {},
+): MonitoringSummaryResponse {
+  return {
+    generated_at: "2026-08-20T00:00:00+00:00",
+    status: "healthy",
+    api: { availability: "available", sample_count: 10, p95_latency_ms: 200 },
+    queue: { availability: "available", waiting: 3, running: 2, total: 5 },
+    workers: { availability: "available", active: 2, capacity: 4, utilization: 0.5 },
+    artifact_store: { availability: "available", last_write_at: "2026-08-20T00:00:00+00:00" },
+    ...overrides,
+  };
+}
+
+function buildsFixture(
+  overrides: Partial<MonitoringBuildsResponse> = {},
+): MonitoringBuildsResponse {
+  return {
+    window: "24h",
+    bucket: "hour",
+    availability: "available",
+    excluded_count: 0,
+    buckets: [],
+    recent_runs: [],
+    ...overrides,
+  };
+}
+
+function renderMonitoring() {
+  return render(
+    <MemoryRouter initialEntries={["/monitoring"]}>
+      <MonitoringPage />
+    </MemoryRouter>,
+  );
+}
 
 describe("MonitoringPage", () => {
   beforeEach(() => {
@@ -39,28 +85,17 @@ describe("MonitoringPage", () => {
   });
 
   it("기본 제목과 설명을 렌더링한다", async () => {
-    render(
-      <MemoryRouter>
-        <MonitoringPage />
-      </MemoryRouter>,
-    );
+    renderMonitoring();
 
     await waitFor(() => {
       expect(
         screen.getByRole("heading", { name: /시스템 모니터링/ }),
       ).toBeInTheDocument();
-      expect(
-        screen.getByText(/실행 이력과 시스템 리소스 상태를 실시간으로 확인합니다/),
-      ).toBeInTheDocument();
     });
   });
 
   it("system/builds/recent-runs 탭을 렌더링한다", async () => {
-    render(
-      <MemoryRouter>
-        <MonitoringPage />
-      </MemoryRouter>,
-    );
+    renderMonitoring();
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "System Resources" })).toBeInTheDocument();
@@ -71,207 +106,148 @@ describe("MonitoringPage", () => {
 
   it("탭 전환이 정상적으로 작동한다", async () => {
     const { user } = setupUserEvent();
-
-    render(
-      <MemoryRouter>
-        <MonitoringPage />
-      </MemoryRouter>,
-    );
+    renderMonitoring();
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "System Resources" }).className).toContain(
-        "border-b-2"
+        "border-b-2",
       );
     });
 
     await user.click(screen.getByRole("button", { name: "Build Statistics" }));
 
     expect(screen.getByRole("button", { name: "Build Statistics" }).className).toContain(
-      "border-b-2"
+      "border-b-2",
     );
-    expect(screen.getByRole("button", { name: "System Resources" }).className).not.toContain(
-      "border-b-2"
-    );
+    expect(
+      screen.getByRole("button", { name: "System Resources" }).className,
+    ).not.toContain("border-b-2");
   });
 
-  it("loading 상태를 올바르게 표시한다", async () => {
+  it("실연동 모드에서 실제 Builder 엔드포인트 2개를 병렬 호출한다 (#302)", async () => {
     vi.mocked(isRealBuilderEnabled).mockReturnValue(true);
-    vi.mocked(builderApi.getMonitoring).mockImplementation(
-      () => new Promise(() => {})
-    );
+    vi.mocked(builderApi.getMonitoringSummary).mockResolvedValue(summaryFixture());
+    vi.mocked(builderApi.getMonitoringBuilds).mockResolvedValue(buildsFixture());
 
-    render(
-      <MemoryRouter>
-        <MonitoringPage />
-      </MemoryRouter>,
-    );
-
-    expect(screen.getAllByText("데이터 로드 중...")).toHaveLength(1);
-    // Skeleton은 aria-hidden이라 role로 잡히지 않는다 — 시각적 skeleton 블록 수로 확인한다.
-    expect(document.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
-  });
-
-  it("데이터 로드 후 system 리소스를 올바르게 표시한다", async () => {
-    const mockResponse: MonitoringResponse = {
-      system: {
-        health: {
-          status: "healthy",
-          p95_latency: 245,
-        },
-        queue: {
-          queued: 3,
-          running: 2,
-          total: 5,
-        },
-        workers: {
-          active: 2,
-          capacity: 4,
-          utilization: 0.5,
-        },
-        artifact_store: {
-          status: "ok",
-          last_write: new Date().toISOString(),
-        },
-      },
-      builds: {
-        stats: [
-          { time: "00:00", success: 12, failed: 1, cancelled: 0 },
-          { time: "04:00", success: 8, failed: 0, cancelled: 1 },
-        ],
-        total_success: 20,
-        total_failed: 1,
-        total_cancelled: 1,
-        recent_runs: [],
-      },
-    };
-
-    vi.mocked(builderApi.getMonitoring).mockResolvedValue(mockResponse);
-
-    render(
-      <MemoryRouter>
-        <MonitoringPage />
-      </MemoryRouter>,
-    );
+    renderMonitoring();
 
     await waitFor(() => {
-      expect(screen.getByText("Builder API")).toBeInTheDocument();
+      expect(builderApi.getMonitoringSummary).toHaveBeenCalled();
+      expect(builderApi.getMonitoringBuilds).toHaveBeenCalled();
+    });
+  });
+
+  it("401 응답은 권한 없음 상태로 구분한다 — 실API 응답 기준 (#302)", async () => {
+    vi.mocked(isRealBuilderEnabled).mockReturnValue(true);
+    const { ApiError } = await vi.importActual<typeof import("@/shared/lib/builderApi")>(
+      "@/shared/lib/builderApi",
+    );
+    vi.mocked(builderApi.getMonitoringSummary).mockRejectedValue(
+      new ApiError(401, "인증이 필요합니다"),
+    );
+    vi.mocked(builderApi.getMonitoringBuilds).mockResolvedValue(buildsFixture());
+
+    renderMonitoring();
+
+    await waitFor(() => {
+      expect(screen.getByText("권한이 없습니다")).toBeInTheDocument();
+    });
+    expect(builderApi.getMonitoringBuilds).toHaveBeenCalled();
+  });
+
+  it("실연동 실패 시 mock 데이터로 대체하지 않는다 (#302)", async () => {
+    vi.mocked(isRealBuilderEnabled).mockReturnValue(true);
+    vi.mocked(builderApi.getMonitoringSummary).mockRejectedValue(new Error("network down"));
+    vi.mocked(builderApi.getMonitoringBuilds).mockRejectedValue(new Error("network down"));
+
+    renderMonitoring();
+
+    await waitFor(() => {
+      expect(screen.getByText("데이터를 가져올 수 없습니다")).toBeInTheDocument();
+    });
+    // mock fixture의 run id가 실연동 실패 화면에 나타나면 정상 오인이다.
+    expect(screen.queryByText("run-001")).not.toBeInTheDocument();
+  });
+
+  it("api가 unavailable이면 정상으로 표시하지 않는다 (#302 회귀)", async () => {
+    vi.mocked(isRealBuilderEnabled).mockReturnValue(true);
+    vi.mocked(builderApi.getMonitoringSummary).mockResolvedValue(
+      summaryFixture({
+        status: "degraded",
+        api: { availability: "unavailable", sample_count: null, p95_latency_ms: null },
+      }),
+    );
+    vi.mocked(builderApi.getMonitoringBuilds).mockResolvedValue(buildsFixture());
+
+    renderMonitoring();
+
+    await waitFor(() => {
+      expect(screen.getByText("사용 불가")).toBeInTheDocument();
+    });
+    // Builder API 카드의 배지가 정상이어선 안 된다(Artifact Store의 정상 배지와 구분).
+    const apiCard = screen.getByText("Builder API").closest("div")?.parentElement?.parentElement;
+    expect(apiCard).not.toBeNull();
+    expect(apiCard?.textContent).not.toContain("정상");
+    expect(screen.getByText(/측정 불가/)).toBeInTheDocument();
+  });
+
+  it("queue 측정값이 null이면 0이 아니라 — 로 표시한다 (#302 회귀)", async () => {
+    vi.mocked(isRealBuilderEnabled).mockReturnValue(true);
+    vi.mocked(builderApi.getMonitoringSummary).mockResolvedValue(
+      summaryFixture({
+        queue: { availability: "unavailable", waiting: null, running: null, total: null },
+      }),
+    );
+    vi.mocked(builderApi.getMonitoringBuilds).mockResolvedValue(buildsFixture());
+
+    renderMonitoring();
+
+    await waitFor(() => {
       expect(screen.getByText("Queue")).toBeInTheDocument();
-      expect(screen.getByText("Workers")).toBeInTheDocument();
-      expect(screen.getByText("Artifact Store")).toBeInTheDocument();
     });
+    // 대기/실행/전체가 전부 —(측정 불가)이고 0으로 표시되지 않는다.
+    const queueSection = screen.getByText("대기 중").closest("div")?.parentElement;
+    expect(queueSection).not.toBeNull();
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(3);
   });
 
-  it("자동 새로고침 토글 기능이 작동한다", async () => {
-    const { user } = setupUserEvent();
-
-    render(
-      <MemoryRouter>
-        <MonitoringPage />
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /자동 새로고침 ON/ })).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole("button", { name: /자동 새로고침 ON/ }));
-
-    expect(screen.getByRole("button", { name: /자동 새로고침 OFF/ })).toBeInTheDocument();
-  });
-
-  it("수동 새로고침 버튼이 작동한다", async () => {
+  it("partial 집계는 제외 건수와 함께 안내한다 (#302)", async () => {
     vi.mocked(isRealBuilderEnabled).mockReturnValue(true);
-    const mockResponse: MonitoringResponse = {
-      system: {
-        health: {
-          status: "healthy",
-          p95_latency: 200,
-        },
-        queue: null,
-        workers: null,
-        artifact_store: {
-          status: "ok",
-          last_write: new Date().toISOString(),
-        },
-      },
-      builds: {
-        stats: [],
-        total_success: 0,
-        total_failed: 0,
-        total_cancelled: 0,
-        recent_runs: [],
-      },
-    };
-
-    vi.mocked(builderApi.getMonitoring).mockResolvedValue(mockResponse);
+    vi.mocked(builderApi.getMonitoringSummary).mockResolvedValue(summaryFixture());
+    vi.mocked(builderApi.getMonitoringBuilds).mockResolvedValue(
+      buildsFixture({
+        availability: "partial",
+        excluded_count: 2,
+        buckets: [
+          {
+            bucket_start: "2026-08-20T01:00:00+00:00",
+            bucket_end: "2026-08-20T02:00:00+00:00",
+            total: 3,
+            success: 3,
+            failed: 0,
+            cancelled: 0,
+          },
+        ],
+      }),
+    );
 
     const { user } = setupUserEvent();
+    renderMonitoring();
 
-    render(
-      <MemoryRouter>
-        <MonitoringPage />
-      </MemoryRouter>,
-    );
+    await user.click(await screen.findByRole("button", { name: "Build Statistics" }));
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "새로고침" })).toBeInTheDocument();
-    });
-
-    const refreshButton = screen.getByRole("button", { name: "새로고침" });
-
-    await user.click(refreshButton);
-
-    expect(vi.mocked(builderApi.getMonitoring)).toHaveBeenCalled();
-  });
-
-  it("API 에러 시 error state를 올바르게 표시한다", async () => {
-    vi.mocked(isRealBuilderEnabled).mockReturnValue(true);
-    vi.mocked(builderApi.getMonitoring).mockRejectedValue(new Error("API Error"));
-
-    render(
-      <MemoryRouter>
-        <MonitoringPage />
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText(/데이터를 가져올 수 없습니다/)).toBeInTheDocument();
+      expect(screen.getByText(/제외 2건/)).toBeInTheDocument();
     });
   });
 
-  it("빈 데이터일 때 empty state를 올바르게 표시한다", async () => {
+  it("빈 데이터일 때 empty state를 표시한다", async () => {
     vi.mocked(isRealBuilderEnabled).mockReturnValue(true);
-    const mockResponse: MonitoringResponse = {
-      system: {
-        health: {
-          status: "healthy",
-          p95_latency: 100,
-        },
-        queue: null,
-        workers: null,
-        artifact_store: {
-          status: "ok",
-          last_write: null,
-        },
-      },
-      builds: {
-        stats: [],
-        total_success: 0,
-        total_failed: 0,
-        total_cancelled: 0,
-        recent_runs: [],
-      },
-    };
-
-    vi.mocked(builderApi.getMonitoring).mockResolvedValue(mockResponse);
+    vi.mocked(builderApi.getMonitoringSummary).mockResolvedValue(summaryFixture());
+    vi.mocked(builderApi.getMonitoringBuilds).mockResolvedValue(buildsFixture());
 
     const { user } = setupUserEvent();
-
-    render(
-      <MemoryRouter>
-        <MonitoringPage />
-      </MemoryRouter>,
-    );
+    renderMonitoring();
 
     await user.click(await screen.findByRole("button", { name: "Build Statistics" }));
 
@@ -280,110 +256,82 @@ describe("MonitoringPage", () => {
     });
   });
 
-  it("recent runs 탭에서 데이터를 올바르게 표시한다", async () => {
+  it("recent runs 탭에서 run_id·상태·소요시간을 표시한다", async () => {
     vi.mocked(isRealBuilderEnabled).mockReturnValue(true);
-    const mockResponse: MonitoringResponse = {
-      system: {
-        health: {
-          status: "healthy",
-          p95_latency: 150,
-        },
-        queue: null,
-        workers: null,
-        artifact_store: {
-          status: "ok",
-          last_write: new Date().toISOString(),
-        },
-      },
-      builds: {
-        stats: [],
-        total_success: 2,
-        total_failed: 1,
-        total_cancelled: 0,
+    vi.mocked(builderApi.getMonitoringSummary).mockResolvedValue(summaryFixture());
+    vi.mocked(builderApi.getMonitoringBuilds).mockResolvedValue(
+      buildsFixture({
         recent_runs: [
           {
-            id: "run-001",
-            title: "테스트 빌드",
-            status: "succeeded",
-            started_at: new Date(Date.now() - 3600000).toISOString(),
-            finished_at: new Date(Date.now() - 1800000).toISOString(),
-            duration: 1800,
+            run_id: "run-abc",
+            status: "ok",
+            started_at: "2026-08-20T00:00:00+00:00",
+            finished_at: "2026-08-20T00:30:00+00:00",
           },
         ],
-      },
-    };
-
-    vi.mocked(builderApi.getMonitoring).mockResolvedValue(mockResponse);
-
-    const { user } = setupUserEvent();
-
-    render(
-      <MemoryRouter>
-        <MonitoringPage />
-      </MemoryRouter>,
+      }),
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Recent Runs" })).toBeInTheDocument();
-    });
+    const { user } = setupUserEvent();
+    renderMonitoring();
 
-    await user.click(screen.getByRole("button", { name: "Recent Runs" }));
+    await user.click(await screen.findByRole("button", { name: "Recent Runs" }));
 
-    expect(screen.getByText("테스트 빌드")).toBeInTheDocument();
+    expect(await screen.findByText("run-abc")).toBeInTheDocument();
+    // BuildIndex 내부 값 ok는 성공으로 표시한다.
     expect(screen.getByText("성공")).toBeInTheDocument();
     expect(screen.getByText(/1800초/)).toBeInTheDocument();
   });
 
-  it("실연동 모드에서는 builderApi를 호출한다", async () => {
+  it("recent run의 보기 링크가 Builds 상세로 이동한다 (#302 네비게이션)", async () => {
     vi.mocked(isRealBuilderEnabled).mockReturnValue(true);
+    vi.mocked(builderApi.getMonitoringSummary).mockResolvedValue(summaryFixture());
+    vi.mocked(builderApi.getMonitoringBuilds).mockResolvedValue(
+      buildsFixture({
+        recent_runs: [
+          {
+            run_id: "run-nav",
+            status: "ok",
+            started_at: "2026-08-20T00:00:00+00:00",
+            finished_at: "2026-08-20T00:10:00+00:00",
+          },
+        ],
+      }),
+    );
 
-    const mockResponse: MonitoringResponse = {
-      system: {
-        health: {
-          status: "healthy",
-          p95_latency: 120,
-        },
-        queue: null,
-        workers: null,
-        artifact_store: {
-          status: "ok",
-          last_write: null,
-        },
-      },
-      builds: {
-        stats: [],
-        total_success: 0,
-        total_failed: 0,
-        total_cancelled: 0,
-        recent_runs: [],
-      },
-    };
+    const locationRef: { current: { pathname: string } | null } = { current: null };
+    function LocationProbe() {
+      locationRef.current = useLocation();
+      return null;
+    }
 
-    vi.mocked(builderApi.getMonitoring).mockResolvedValue(mockResponse);
-
+    const { user } = setupUserEvent();
     render(
-      <MemoryRouter>
-        <MonitoringPage />
+      <MemoryRouter initialEntries={["/monitoring"]}>
+        <Routes>
+          <Route path="/monitoring" element={<MonitoringPage />} />
+          <Route path="/builds/:buildId" element={<LocationProbe />} />
+        </Routes>
       </MemoryRouter>,
     );
 
+    await user.click(await screen.findByRole("button", { name: "Recent Runs" }));
+    const viewLink = await screen.findByRole("link", { name: "보기" });
+    await user.click(viewLink);
+
     await waitFor(() => {
-      expect(vi.mocked(builderApi.getMonitoring)).toHaveBeenCalled();
+      expect(locationRef.current).not.toBeNull();
     });
+    expect(locationRef.current?.pathname).toBe("/builds/run-nav");
   });
 
-  it("mock 모드에서는 mock 데이터를 사용한다", async () => {
-    vi.mocked(isRealBuilderEnabled).mockReturnValue(false);
-
-    render(
-      <MemoryRouter>
-        <MonitoringPage />
-      </MemoryRouter>,
-    );
+  it("mock 모드에서는 네트워크를 호출하지 않는다", async () => {
+    renderMonitoring();
 
     await waitFor(() => {
-      expect(vi.mocked(builderApi.getMonitoring)).not.toHaveBeenCalled();
-      expect(screen.getByText("Builder API")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /시스템 모니터링/ })).toBeInTheDocument();
     });
+    expect(builderApi.getMonitoringSummary).not.toHaveBeenCalled();
+    expect(builderApi.getMonitoringBuilds).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -37,7 +37,8 @@ const EXPECTED_OPERATIONS = [
   "query",
   "getBuildSpecSnapshot",
   "getBuildEvents",
-  "getMonitoring",
+  "getMonitoringSummary",
+  "getMonitoringBuilds",
   "testProviderConnection",
   "uploadFile",
 ] as const;

--- a/src/pages/MonitoringPage.tsx
+++ b/src/pages/MonitoringPage.tsx
@@ -1,24 +1,12 @@
 /**
- * Monitoring 화면 (`/monitoring`) — 시스템 리소스·Build 통계 모니터링 (#264).
+ * Monitoring 화면 (`/monitoring`) — 시스템 리소스·Build 통계 모니터링 (#264, #302).
  *
- * Issue #264: 시스템 리소스와 Build 통계를 실제 Builder monitoring API로 확인한다.
- *
- * P0 범위:
- * - system/build/recent-runs tabs
- * - 시스템 리소스: Builder API Healthy/Degraded + p95 latency, Queue, Workers, Artifact Store
- * - Build 통계: 시간대별 Build 수, success/fail/cancelled
- * - Recent Runs: 최근 빌드 실행 이력
- * - unavailable을 0/정상으로 표시하지 않음
- * - loading/error/partial-data
- * - polling lifecycle/page hidden 완화
- * - unauthorized/monitoring-disabled 처리
- * - 자동 새로고침 토글
- *
- * P1 고도화:
- * - Page Visibility API로 숨김 상태에서 polling 최적화
- * - 더 나은 차트 시각화
- * - 로딩/에러 상태 애니메이션 개선
- * - 토스트 알림으로 상태 변경 알림
+ * Builder #516 실제 계약에 정합한다(#302):
+ * - GET /monitoring/summary (시스템) + GET /monitoring/builds?window=24h&bucket=hour (통계)
+ * - availability 어휘: available/partial/unavailable — null/측정불가를 0/정상으로
+ *   표시하지 않는다(#516 원칙).
+ * - 실연동 모드에서 오류가 나면 mock으로 대체하지 않는다(정상 오인 방지, #302).
+ * - 401/403은 "권한 없음" 상태로 구분한다(ApiError.status 기반).
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -28,75 +16,79 @@ import {
   PageHeader,
   Button,
   LinkButton,
-  type StatusValue,
 } from "@/shared/ui";
-import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
+import { ApiError, builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
 import type {
-  MonitoringResponse,
-  SystemHealth,
-  QueueStats,
-  WorkerStats,
-  ArtifactStoreStats,
-  BuildStats,
-  RecentRun,
+  MonitoringApiStatus,
+  MonitoringArtifactStoreStats,
+  MonitoringBucket,
+  MonitoringQueueStats,
+  MonitoringRecentRun,
+  MonitoringWorkerStats,
+  MonitoringSummaryResponse,
+  MonitoringBuildsResponse,
 } from "@/shared/lib/builderApi.schema";
 
 type TabType = "system" | "builds" | "recent-runs";
 
 type LoadingState = "idle" | "loading" | "success" | "error";
 
+interface MonitoringData {
+  summary: MonitoringSummaryResponse;
+  builds: MonitoringBuildsResponse;
+}
+
 export function MonitoringPage() {
   const [activeTab, setActiveTab] = useState<TabType>("system");
   const [loading, setLoading] = useState<LoadingState>("idle");
-  const [error, setError] = useState<string | null>(null);
-  const [data, setData] = useState<MonitoringResponse | null>(null);
+  const [unauthorized, setUnauthorized] = useState(false);
+  const [data, setData] = useState<MonitoringData | null>(null);
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(null);
   const [isPageVisible, setIsPageVisible] = useState(true);
 
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
-  const previousHealthRef = useRef<string | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const previousStatusRef = useRef<string | null>(null);
 
   const fetchMonitoringData = useCallback(async () => {
     if (!isPageVisible) return;
 
     setLoading("loading");
-    setError(null);
+
+    if (!isRealBuilderEnabled()) {
+      const mock = getMockData();
+      setData(mock);
+      setLoading("success");
+      setLastRefreshTime(new Date());
+      return;
+    }
 
     try {
-      let result: MonitoringResponse;
-
-      if (isRealBuilderEnabled()) {
-        result = await builderApi.getMonitoring();
-      } else {
-        result = getMockData();
-      }
-
-      setData(result);
+      const [summary, builds] = await Promise.all([
+        builderApi.getMonitoringSummary(),
+        builderApi.getMonitoringBuilds(),
+      ]);
+      setData({ summary, builds });
       setLoading("success");
       setLastRefreshTime(new Date());
 
-      const currentHealth = result.system.health.status;
-      if (previousHealthRef.current && previousHealthRef.current !== currentHealth) {
-        if (currentHealth === "degraded") {
-          console.warn("Builder API 성능 저하 감지됨");
-        } else if (currentHealth === "unavailable") {
-          console.error("Builder API 사용 불가 상태 감지됨");
+      if (
+        previousStatusRef.current &&
+        previousStatusRef.current !== summary.status
+      ) {
+        if (summary.status === "degraded") {
+          console.warn("Builder 시스템 상태 저하 감지됨");
         }
       }
-      previousHealthRef.current = currentHealth;
-
+      previousStatusRef.current = summary.status;
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : "Unknown error";
-      setError(errorMessage);
-      setLoading("error");
-
-      if (errorMessage === "unauthorized" || errorMessage === "monitoring-disabled") {
+      // 401/403은 인증/인가 문제로 구분해 안내한다 — 실API 응답 기준(#302).
+      if (err instanceof ApiError && (err.status === 401 || err.status === 403)) {
+        setUnauthorized(true);
+        setLoading("error");
         return;
       }
-
-      setData(getMockData());
-      setLastRefreshTime(new Date());
+      setLoading("error");
     }
   }, [isPageVisible]);
 
@@ -108,67 +100,37 @@ export function MonitoringPage() {
     }
 
     return () => {
-      if (intervalRef.current) {
+      if (intervalRef.current !== null) {
         clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
     };
   }, [fetchMonitoringData, autoRefresh, isPageVisible]);
 
-  // Page Visibility API로 숨김 상태 감지
   useEffect(() => {
-    const handleVisibilityChange = () => {
-      setIsPageVisible(!document.hidden);
-    };
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
+    const onVisibilityChange = () => setIsPageVisible(document.visibilityState === "visible");
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
   }, []);
+
+  const toggleAutoRefresh = () => setAutoRefresh((prev) => !prev);
 
   const handleTabChange = (tab: TabType) => {
     setActiveTab(tab);
   };
 
-  const toggleAutoRefresh = () => {
-    setAutoRefresh((prev) => !prev);
-  };
-
-  const handleManualRefresh = () => {
-    fetchMonitoringData();
-  };
-
-  if (error === "unauthorized") {
+  if (unauthorized) {
     return (
       <main className="flex flex-1 flex-col gap-8 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
         <PageHeader
           eyebrow="Monitoring"
-          title="모니터링"
-          description="실행 이력과 시스템 상태를 모니터링합니다."
+          title="시스템 모니터링"
+          description="실행 이력과 시스템 리소스 상태를 실시간으로 확인합니다."
         />
         <Card variant="error">
           <p className="font-semibold">권한이 없습니다</p>
           <p className="mt-2 text-sm text-muted-foreground">
-            모니터링 데이터를 보려면 로그인이 필요합니다.
-          </p>
-        </Card>
-      </main>
-    );
-  }
-
-  if (error === "monitoring-disabled") {
-    return (
-      <main className="flex flex-1 flex-col gap-8 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
-        <PageHeader
-          eyebrow="Monitoring"
-          title="모니터링"
-          description="실행 이력과 시스템 상태를 모니터링합니다."
-        />
-        <Card>
-          <p className="font-semibold">모니터링이 비활성화되어 있습니다</p>
-          <p className="mt-2 text-sm text-muted-foreground">
-            관리자에게 문의하여 모니터링을 활성화해 주세요.
+            모니터링 데이터를 조회하려면 로그인이 필요합니다.
           </p>
         </Card>
       </main>
@@ -199,9 +161,8 @@ export function MonitoringPage() {
             <Button
               variant="secondary"
               size="sm"
-              onClick={handleManualRefresh}
+              onClick={() => fetchMonitoringData()}
               type="button"
-              disabled={loading === "loading"}
             >
               새로고침
             </Button>
@@ -209,7 +170,16 @@ export function MonitoringPage() {
         }
       />
 
-      <div className="flex gap-2 border-b border-border">
+      {data?.summary.status === "degraded" && (
+        <Card variant="error">
+          <p className="font-semibold">시스템 상태 저하</p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            일부 하위 시스템이 partial/unavailable 상태입니다. 각 카드의 상태 배지를 확인하세요.
+          </p>
+        </Card>
+      )}
+
+      <div className="flex gap-1 border-b border-border">
         <button
           className={`px-4 py-2 text-sm font-medium transition-colors ${
             activeTab === "system"
@@ -246,11 +216,11 @@ export function MonitoringPage() {
       </div>
 
       {activeTab === "system" ? (
-        <SystemResourcesTab loading={loading} data={data?.system} />
+        <SystemResourcesTab loading={loading} summary={data?.summary} />
       ) : activeTab === "builds" ? (
-        <BuildStatisticsTab loading={loading} data={data?.builds} />
+        <BuildStatisticsTab loading={loading} builds={data?.builds} />
       ) : (
-        <RecentRunsTab loading={loading} data={data?.builds?.recent_runs} />
+        <RecentRunsTab loading={loading} runs={data?.builds?.recent_runs} />
       )}
     </main>
   );
@@ -258,10 +228,10 @@ export function MonitoringPage() {
 
 function SystemResourcesTab({
   loading,
-  data,
+  summary,
 }: {
   loading: LoadingState;
-  data: MonitoringResponse["system"] | undefined;
+  summary: MonitoringSummaryResponse | undefined;
 }) {
   if (loading === "error") {
     return (
@@ -274,30 +244,30 @@ function SystemResourcesTab({
     );
   }
 
-  if (loading === "loading" || !data) {
+  if (loading === "loading" || !summary) {
     return <SystemResourcesSkeleton />;
   }
 
   return (
     <div className="space-y-6">
-      <SystemHealthCard health={data.health} />
+      <SystemHealthCard status={summary.status} api={summary.api} />
 
       <div className="grid gap-6 lg:grid-cols-2">
-        <QueueStatsCard stats={data.queue} />
-        <WorkerStatsCard stats={data.workers} />
+        <QueueStatsCard stats={summary.queue} />
+        <WorkerStatsCard stats={summary.workers} />
       </div>
 
-      <ArtifactStoreCard stats={data.artifact_store} />
+      <ArtifactStoreCard stats={summary.artifact_store} />
     </div>
   );
 }
 
 function BuildStatisticsTab({
   loading,
-  data,
+  builds,
 }: {
   loading: LoadingState;
-  data: MonitoringResponse["builds"] | undefined;
+  builds: MonitoringBuildsResponse | undefined;
 }) {
   if (loading === "error") {
     return (
@@ -310,13 +280,22 @@ function BuildStatisticsTab({
     );
   }
 
-  if (loading === "loading" || !data) {
+  if (loading === "loading" || !builds) {
     return <BuildStatisticsSkeleton />;
   }
 
-  const totalBuilds = data.total_success + data.total_failed + data.total_cancelled;
+  // builder는 총계를 내려주지 않는다(#516) — bucket 합으로 화면에서 계산한다.
+  const totals = builds.buckets.reduce(
+    (acc, bucket) => ({
+      success: acc.success + bucket.success,
+      failed: acc.failed + bucket.failed,
+      cancelled: acc.cancelled + bucket.cancelled,
+    }),
+    { success: 0, failed: 0, cancelled: 0 },
+  );
+  const totalBuilds = totals.success + totals.failed + totals.cancelled;
 
-  if (totalBuilds === 0) {
+  if (totalBuilds === 0 && builds.recent_runs.length === 0) {
     return (
       <Card>
         <EmptyState
@@ -333,35 +312,57 @@ function BuildStatisticsTab({
         <Card className="flex items-center justify-between">
           <span className="text-sm text-muted-foreground">성공</span>
           <span className="text-2xl font-semibold text-emerald-600 dark:text-emerald-400">
-            {data.total_success}
+            {totals.success}
           </span>
         </Card>
         <Card className="flex items-center justify-between">
           <span className="text-sm text-muted-foreground">실패</span>
           <span className="text-2xl font-semibold text-red-600 dark:text-red-400">
-            {data.total_failed}
+            {totals.failed}
           </span>
         </Card>
         <Card className="flex items-center justify-between">
           <span className="text-sm text-muted-foreground">취소</span>
           <span className="text-2xl font-semibold text-muted-foreground">
-            {data.total_cancelled}
+            {totals.cancelled}
           </span>
         </Card>
       </div>
 
-      <BuildChart stats={data.stats} />
+      {builds.availability === "partial" && (
+        <Card variant="error">
+          <p className="text-sm text-muted-foreground">
+            일부 run이 권한 제한으로 집계에서 제외되었습니다 (제외 {builds.excluded_count}건).
+          </p>
+        </Card>
+      )}
+
+      <BuildChart buckets={builds.buckets} />
     </div>
   );
 }
 
-function SystemHealthCard({ health }: { health: SystemHealth }) {
+function SystemHealthCard({
+  status,
+  api,
+}: {
+  status: MonitoringSummaryResponse["status"];
+  api: MonitoringApiStatus;
+}) {
+  // aggregate는 healthy/degraded 2값이고, api 자체 측정 불가는 availability가 알려준다.
   const statusLabel =
-    health.status === "healthy"
-      ? "정상"
-      : health.status === "degraded"
+    api.availability === "unavailable"
+      ? "사용 불가"
+      : status === "degraded"
       ? "성능 저하"
-      : "사용 불가";
+      : "정상";
+
+  const statusColor =
+    api.availability === "unavailable"
+      ? "bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300"
+      : status === "degraded"
+      ? "bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300"
+      : "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300";
 
   return (
     <Card>
@@ -369,14 +370,17 @@ function SystemHealthCard({ health }: { health: SystemHealth }) {
         <div>
           <h3 className="text-lg font-semibold">Builder API</h3>
           <div className="mt-2 flex items-center gap-2">
-            <span className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300">
+            <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${statusColor}`}>
               {statusLabel}
             </span>
             <span className="text-sm text-muted-foreground">
-              {health.p95_latency !== null
-                ? `P95 Latency: ${health.p95_latency}ms`
+              {api.p95_latency_ms !== null
+                ? `P95 Latency: ${api.p95_latency_ms}ms`
                 : "Latency: 측정 불가"}
             </span>
+            {api.sample_count === null && (
+              <span className="text-sm text-muted-foreground">· 표본 없음</span>
+            )}
           </div>
         </div>
       </div>
@@ -384,32 +388,33 @@ function SystemHealthCard({ health }: { health: SystemHealth }) {
   );
 }
 
-function QueueStatsCard({ stats }: { stats: QueueStats | null }) {
-  if (!stats) {
-    return (
-      <Card>
-        <h3 className="text-lg font-semibold">Queue</h3>
-        <p className="mt-2 text-sm text-muted-foreground">데이터를 사용할 수 없습니다</p>
-      </Card>
-    );
-  }
+/** 측정값이 null(측정 불가)이면 0 대신 "—"로 표시한다(#516/#302 원칙). */
+function measured(value: number | null): string {
+  return value === null ? "—" : String(value);
+}
 
+function QueueStatsCard({ stats }: { stats: MonitoringQueueStats }) {
   return (
     <Card>
       <h3 className="text-lg font-semibold">Queue</h3>
+      <div className="mt-2 flex items-center gap-2">
+        <span className="text-xs text-muted-foreground">
+          {stats.availability === "unavailable" ? "측정 불가" : "측정 중"}
+        </span>
+      </div>
       <div className="mt-4 space-y-3">
         <div className="flex items-center justify-between">
           <span className="text-sm text-muted-foreground">대기 중</span>
-          <span className="text-lg font-semibold">{stats.queued}</span>
+          <span className="text-lg font-semibold">{measured(stats.waiting)}</span>
         </div>
         <div className="flex items-center justify-between">
           <span className="text-sm text-muted-foreground">실행 중</span>
-          <span className="text-lg font-semibold">{stats.running}</span>
+          <span className="text-lg font-semibold">{measured(stats.running)}</span>
         </div>
         <div className="border-t border-border pt-3">
           <div className="flex items-center justify-between">
             <span className="text-sm font-medium">전체</span>
-            <span className="text-xl font-bold">{stats.total}</span>
+            <span className="text-xl font-bold">{measured(stats.total)}</span>
           </div>
         </div>
       </div>
@@ -417,21 +422,17 @@ function QueueStatsCard({ stats }: { stats: QueueStats | null }) {
   );
 }
 
-function WorkerStatsCard({ stats }: { stats: WorkerStats | null }) {
-  if (!stats) {
-    return (
-      <Card>
-        <h3 className="text-lg font-semibold">Workers</h3>
-        <p className="mt-2 text-sm text-muted-foreground">데이터를 사용할 수 없습니다</p>
-      </Card>
-    );
-  }
-
+function WorkerStatsCard({ stats }: { stats: MonitoringWorkerStats }) {
   const utilizationPercent = Math.round(stats.utilization * 100);
 
   return (
     <Card>
       <h3 className="text-lg font-semibold">Workers</h3>
+      <div className="mt-2 flex items-center gap-2">
+        <span className="text-xs text-muted-foreground">
+          {stats.availability === "unavailable" ? "측정 불가" : "측정 중"}
+        </span>
+      </div>
       <div className="mt-4 space-y-3">
         <div className="flex items-center justify-between">
           <span className="text-sm text-muted-foreground">활성</span>
@@ -458,20 +459,20 @@ function WorkerStatsCard({ stats }: { stats: WorkerStats | null }) {
   );
 }
 
-function ArtifactStoreCard({ stats }: { stats: ArtifactStoreStats }) {
+function ArtifactStoreCard({ stats }: { stats: MonitoringArtifactStoreStats }) {
   const statusLabel =
-    stats.status === "ok"
+    stats.availability === "available"
       ? "정상"
-      : stats.status === "error"
-      ? "오류"
+      : stats.availability === "partial"
+      ? "부분 가용"
       : "사용 불가";
 
   const statusColor =
-    stats.status === "ok"
+    stats.availability === "available"
       ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300"
-      : stats.status === "error"
-      ? "bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300"
-      : "bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300";
+      : stats.availability === "partial"
+      ? "bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300"
+      : "bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300";
 
   return (
     <Card>
@@ -481,8 +482,8 @@ function ArtifactStoreCard({ stats }: { stats: ArtifactStoreStats }) {
           {statusLabel}
         </span>
         <span className="text-sm text-muted-foreground">
-          {stats.last_write
-            ? `마지막 쓰기: ${new Date(stats.last_write).toLocaleString("ko-KR")}`
+          {stats.last_write_at
+            ? `마지막 쓰기: ${new Date(stats.last_write_at).toLocaleString("ko-KR")}`
             : "마지막 쓰기: 없음"}
         </span>
       </div>
@@ -490,8 +491,8 @@ function ArtifactStoreCard({ stats }: { stats: ArtifactStoreStats }) {
   );
 }
 
-function BuildChart({ stats }: { stats: BuildStats[] }) {
-  if (stats.length === 0) {
+function BuildChart({ buckets }: { buckets: MonitoringBucket[] }) {
+  if (buckets.length === 0) {
     return (
       <Card>
         <EmptyState
@@ -503,7 +504,7 @@ function BuildChart({ stats }: { stats: BuildStats[] }) {
   }
 
   const maxValue = Math.max(
-    ...stats.map((s) => Math.max(s.success, s.failed, s.cancelled))
+    ...buckets.map((b) => Math.max(b.success, b.failed, b.cancelled))
   );
 
   return (
@@ -527,16 +528,17 @@ function BuildChart({ stats }: { stats: BuildStats[] }) {
       </div>
       <div className="mt-4">
         <div className="flex items-end gap-2 min-h-[200px]">
-          {stats.map((stat, index) => {
-            const successHeight = maxValue > 0 ? (stat.success / maxValue) * 100 : 0;
-            const failedHeight = maxValue > 0 ? (stat.failed / maxValue) * 100 : 0;
-            const cancelledHeight = maxValue > 0 ? (stat.cancelled / maxValue) * 100 : 0;
+          {buckets.map((bucket, index) => {
+            const successHeight = maxValue > 0 ? (bucket.success / maxValue) * 100 : 0;
+            const failedHeight = maxValue > 0 ? (bucket.failed / maxValue) * 100 : 0;
+            const cancelledHeight = maxValue > 0 ? (bucket.cancelled / maxValue) * 100 : 0;
+            const label = bucket.bucket_start.slice(11, 16) || bucket.bucket_start;
 
             return (
               <div
                 key={index}
                 className="flex flex-1 flex-col gap-0.5 group"
-                title={`${stat.time}: 성공 ${stat.success}, 실패 ${stat.failed}, 취소 ${stat.cancelled}`}
+                title={`${bucket.bucket_start}: 성공 ${bucket.success}, 실패 ${bucket.failed}, 취소 ${bucket.cancelled}`}
               >
                 <div className="flex gap-0.5 items-end h-[180px] bg-muted/30 rounded-t relative">
                   <div
@@ -553,13 +555,136 @@ function BuildChart({ stats }: { stats: BuildStats[] }) {
                   />
                 </div>
                 <span className="text-[10px] text-center text-muted-foreground">
-                  {stat.time}
+                  {label}
                 </span>
               </div>
             );
           })}
         </div>
       </div>
+    </Card>
+  );
+}
+
+/** BuildIndex 내부 상태 값(ok/failed/cancelled 등)을 표시 라벨로 매핑한다. */
+function runStatusLabel(status: string): { label: string; className: string } {
+  switch (status) {
+    case "ok":
+    case "succeeded":
+      return {
+        label: "성공",
+        className: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300",
+      };
+    case "failed":
+      return {
+        label: "실패",
+        className: "bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300",
+      };
+    case "running":
+      return {
+        label: "실행 중",
+        className: "bg-blue-100 text-blue-800 dark:bg-blue-950/50 dark:text-blue-300",
+      };
+    case "cancelled":
+      return {
+        label: "취소됨",
+        className: "bg-muted text-muted-foreground",
+      };
+    case "queued":
+      return {
+        label: "대기 중",
+        className: "bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300",
+      };
+    default:
+      return { label: status, className: "bg-muted text-muted-foreground" };
+  }
+}
+
+/** started/finished 타임스탬프로 소요 시간(초)을 계산한다 — builder는 duration을 내려주지 않는다. */
+function runDurationSeconds(run: MonitoringRecentRun): number | null {
+  if (run.started_at === null || run.finished_at === null) return null;
+  const duration =
+    (new Date(run.finished_at).getTime() - new Date(run.started_at).getTime()) / 1000;
+  return Number.isFinite(duration) && duration >= 0 ? Math.round(duration) : null;
+}
+
+function RecentRunsTab({
+  loading,
+  runs,
+}: {
+  loading: LoadingState;
+  runs: MonitoringRecentRun[] | undefined;
+}) {
+  if (loading === "error") {
+    return (
+      <Card variant="error">
+        <p className="font-semibold">데이터를 가져올 수 없습니다</p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          잠시 후 다시 시도해 주세요.
+        </p>
+      </Card>
+    );
+  }
+
+  if (loading === "loading" || runs === undefined) {
+    return <RecentRunsSkeleton />;
+  }
+
+  if (runs.length === 0) {
+    return (
+      <Card>
+        <EmptyState
+          title="최근 실행 이력이 없습니다"
+          description="아직 빌드가 실행되지 않았습니다."
+          actionLabel="새 빌드 만들기"
+          actionHref="/builds/new"
+        />
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-0">
+      <div className="p-6 border-b border-border">
+        <h3 className="text-lg font-semibold">최근 빌드 실행</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          최근 실행된 빌드들의 상태와 결과를 확인할 수 있습니다.
+        </p>
+      </div>
+      <ul>
+        {runs.map((run) => {
+          const status = runStatusLabel(run.status);
+          const duration = runDurationSeconds(run);
+          return (
+            <li
+              key={run.run_id}
+              className="grid grid-cols-[1fr_0.8fr_0.8fr_0.6fr_0.6fr] items-center gap-4 border-b border-border px-6 py-4 text-sm last:border-0 hover:bg-muted/50 transition-colors"
+            >
+              <div>
+                <span className="font-medium">{run.run_id}</span>
+              </div>
+              <div>
+                <span
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${status.className}`}
+                >
+                  {status.label}
+                </span>
+              </div>
+              <div className="text-muted-foreground">
+                {run.started_at ? new Date(run.started_at).toLocaleString("ko-KR") : "—"}
+              </div>
+              <div className="text-muted-foreground">
+                {duration !== null ? `${duration}초` : "—"}
+              </div>
+              <div className="text-right">
+                <LinkButton variant="secondary" size="sm" to={`/builds/${run.run_id}`}>
+                  보기
+                </LinkButton>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
     </Card>
   );
 }
@@ -629,97 +754,6 @@ function BuildStatisticsSkeleton() {
   );
 }
 
-function RecentRunsTab({
-  loading,
-  data,
-}: {
-  loading: LoadingState;
-  data: RecentRun[] | undefined;
-}) {
-  if (loading === "error") {
-    return (
-      <Card variant="error">
-        <p className="font-semibold">데이터를 가져올 수 없습니다</p>
-        <p className="mt-2 text-sm text-muted-foreground">
-          잠시 후 다시 시도해 주세요.
-        </p>
-      </Card>
-    );
-  }
-
-  if (loading === "loading" || !data) {
-    return <RecentRunsSkeleton />;
-  }
-
-  if (data.length === 0) {
-    return (
-      <Card>
-        <EmptyState
-          title="최근 실행 이력이 없습니다"
-          description="아직 빌드가 실행되지 않았습니다."
-          actionLabel="새 빌드 만들기"
-          actionHref="/builds/new"
-        />
-      </Card>
-    );
-  }
-
-  return (
-    <Card className="p-0">
-      <div className="p-6 border-b border-border">
-        <h3 className="text-lg font-semibold">최근 빌드 실행</h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          최근 실행된 빌드들의 상태와 결과를 확인할 수 있습니다.
-        </p>
-      </div>
-      <ul>
-        {data.map((run) => (
-          <li
-            key={run.id}
-            className="grid grid-cols-[1fr_0.8fr_0.8fr_0.6fr_0.6fr] items-center gap-4 border-b border-border px-6 py-4 text-sm last:border-0 hover:bg-muted/50 transition-colors"
-          >
-            <div>
-              <span className="font-medium">{run.title ?? run.id}</span>
-            </div>
-            <div>
-              <span
-                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                  run.status === "succeeded"
-                    ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300"
-                    : run.status === "failed"
-                    ? "bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300"
-                    : run.status === "running"
-                    ? "bg-blue-100 text-blue-800 dark:bg-blue-950/50 dark:text-blue-300"
-                    : run.status === "cancelled"
-                    ? "bg-muted text-muted-foreground"
-                    : "bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300"
-                }`}
-              >
-                {run.status === "succeeded" && "성공"}
-                {run.status === "failed" && "실패"}
-                {run.status === "running" && "실행 중"}
-                {run.status === "cancelled" && "취소됨"}
-                {run.status === "queued" && "대기 중"}
-              </span>
-            </div>
-            <div className="text-muted-foreground">
-              {run.started_at ? new Date(run.started_at).toLocaleString("ko-KR") : "—"}
-            </div>
-            <div className="text-muted-foreground">
-              {run.duration !== null ? `${run.duration}초` : "—"}
-            </div>
-            <div className="text-right">
-              <LinkButton variant="secondary" size="sm" to={`/builds/${run.id}`}>
-                보기
-              </LinkButton>
-            </div>
-          </li>
-        ))}
-      </ul>
-    </Card>
-  );
-}
-
 function RecentRunsSkeleton() {
   return (
     <Card className="p-0">
@@ -745,85 +779,70 @@ function RecentRunsSkeleton() {
   );
 }
 
-function getMockData(): MonitoringResponse {
-  const now = new Date();
-  const recentRuns: RecentRun[] = [
-    {
-      id: "run-001",
-      title: "서울시 공공주택 데이터 수집",
-      status: "succeeded",
-      started_at: new Date(now.getTime() - 3600000).toISOString(),
-      finished_at: new Date(now.getTime() - 1800000).toISOString(),
-      duration: 1800,
-    },
-    {
-      id: "run-002",
-      title: "부산시 교통통계 데이터",
-      status: "failed",
-      started_at: new Date(now.getTime() - 7200000).toISOString(),
-      finished_at: new Date(now.getTime() - 6000000).toISOString(),
-      duration: 1200,
-    },
-    {
-      id: "run-003",
-      title: "인천시 환경데이터",
-      status: "running",
-      started_at: new Date(now.getTime() - 600000).toISOString(),
-      finished_at: null,
-      duration: null,
-    },
-    {
-      id: "run-004",
-      title: "대구시 문화시설 정보",
-      status: "succeeded",
-      started_at: new Date(now.getTime() - 10800000).toISOString(),
-      finished_at: new Date(now.getTime() - 9000000).toISOString(),
-      duration: 1800,
-    },
-    {
-      id: "run-005",
-      title: "광주시 의료기관 데이터",
-      status: "cancelled",
-      started_at: new Date(now.getTime() - 14400000).toISOString(),
-      finished_at: new Date(now.getTime() - 12000000).toISOString(),
-      duration: 2400,
-    },
-  ];
+/** mock 모드 fixture — Builder 실제 wire 계약(/monitoring/summary + /monitoring/builds)과 동일 형상. */
+function getMockData(): MonitoringData {
+  const now = Date.now();
+  const hourAgo = (hours: number) => new Date(now - hours * 3600000).toISOString();
 
-  return {
-    system: {
-      health: {
-        status: "healthy",
-        p95_latency: 245,
-      },
-      queue: {
-        queued: 3,
-        running: 2,
-        total: 5,
-      },
-      workers: {
-        active: 2,
-        capacity: 4,
-        utilization: 0.5,
-      },
-      artifact_store: {
-        status: "ok",
-        last_write: new Date().toISOString(),
-      },
-    },
-    builds: {
-      stats: [
-        { time: "00:00", success: 12, failed: 1, cancelled: 0 },
-        { time: "04:00", success: 8, failed: 0, cancelled: 1 },
-        { time: "08:00", success: 15, failed: 2, cancelled: 0 },
-        { time: "12:00", success: 20, failed: 1, cancelled: 0 },
-        { time: "16:00", success: 18, failed: 0, cancelled: 0 },
-        { time: "20:00", success: 10, failed: 1, cancelled: 1 },
-      ],
-      total_success: 83,
-      total_failed: 5,
-      total_cancelled: 2,
-      recent_runs: recentRuns,
+  const summary: MonitoringSummaryResponse = {
+    generated_at: new Date(now).toISOString(),
+    status: "healthy",
+    api: { availability: "available", sample_count: 128, p95_latency_ms: 245 },
+    queue: { availability: "available", waiting: 3, running: 2, total: 5 },
+    workers: { availability: "available", active: 2, capacity: 4, utilization: 0.5 },
+    artifact_store: {
+      availability: "available",
+      last_write_at: new Date(now).toISOString(),
     },
   };
+
+  const buckets: MonitoringBucket[] = [0, 4, 8, 12, 16, 20].map((hour, index) => {
+    const success = [12, 8, 15, 20, 18, 10][index];
+    const failed = [1, 0, 2, 1, 0, 1][index];
+    const cancelled = [0, 1, 0, 0, 0, 1][index];
+    return {
+      bucket_start: `2026-01-01T${String(hour).padStart(2, "0")}:00:00+00:00`,
+      bucket_end: `2026-01-01T${String(hour + 1).padStart(2, "0")}:00:00+00:00`,
+      total: success + failed + cancelled,
+      success,
+      failed,
+      cancelled,
+    };
+  });
+
+  const builds: MonitoringBuildsResponse = {
+    window: "24h",
+    bucket: "hour",
+    availability: "available",
+    excluded_count: 0,
+    buckets,
+    recent_runs: [
+      {
+        run_id: "run-001",
+        status: "ok",
+        started_at: hourAgo(1),
+        finished_at: hourAgo(0.5),
+      },
+      {
+        run_id: "run-002",
+        status: "failed",
+        started_at: hourAgo(2),
+        finished_at: hourAgo(1.6),
+      },
+      {
+        run_id: "run-003",
+        status: "running",
+        started_at: hourAgo(0.2),
+        finished_at: null,
+      },
+      {
+        run_id: "run-004",
+        status: "cancelled",
+        started_at: hourAgo(3),
+        finished_at: hourAgo(2.7),
+      },
+    ],
+  };
+
+  return { summary, builds };
 }

--- a/src/shared/lib/builderApi.schema.ts
+++ b/src/shared/lib/builderApi.schema.ts
@@ -651,73 +651,89 @@ export type BuildQualityResponse = z.infer<typeof buildQualityResponseSchema>;
 export type DatasetQualityHistoryEntry = z.infer<typeof datasetQualityHistoryEntrySchema>;
 export type DatasetQualityHistoryResponse = z.infer<typeof datasetQualityHistoryResponseSchema>;
 
-/** Monitoring 관련 스키마 (#516) */
+/**
+ * Monitoring (#516) — Builder 실제 wire 계약(GET /monitoring/summary,
+ * GET /monitoring/builds) 그대로. availability 어휘는 quality(#486)와 공유하는
+ * available/partial/unavailable이고, 측정된 적 없는 값은 0으로 위장하지 않고
+ * null로 내려온다(#516 원칙).
+ */
+const monitoringAvailabilitySchema = z.enum(["available", "partial", "unavailable"]);
 
-const systemHealthSchema = z.object({
-  status: z.enum(["healthy", "degraded", "unavailable"]),
-  p95_latency: z.number().nullable(),
+export const monitoringApiStatusSchema = z.object({
+  availability: monitoringAvailabilitySchema,
+  sample_count: z.number().int().nullable(),
+  p95_latency_ms: z.number().nullable(),
 });
 
-const queueStatsSchema = z.object({
-  queued: z.number(),
-  running: z.number(),
-  total: z.number(),
+export const monitoringQueueSchema = z.object({
+  availability: monitoringAvailabilitySchema,
+  waiting: z.number().int().nullable(),
+  running: z.number().int().nullable(),
+  total: z.number().int().nullable(),
 });
 
-const workerStatsSchema = z.object({
-  active: z.number(),
-  capacity: z.number(),
+export const monitoringWorkersSchema = z.object({
+  availability: monitoringAvailabilitySchema,
+  active: z.number().int(),
+  capacity: z.number().int(),
   utilization: z.number(),
 });
 
-const artifactStoreStatsSchema = z.object({
-  status: z.enum(["ok", "error", "unavailable"]),
-  last_write: z.string().datetime().nullable(),
+export const monitoringArtifactStoreSchema = z.object({
+  availability: monitoringAvailabilitySchema,
+  last_write_at: z.string().nullable(),
 });
 
-const buildStatsSchema = z.object({
-  time: z.string(),
-  success: z.number(),
-  failed: z.number(),
-  cancelled: z.number(),
+/** GET /monitoring/summary 응답. aggregate status는 healthy/degraded 2값(#516). */
+export const monitoringSummaryResponseSchema = z.object({
+  generated_at: z.string(),
+  status: z.enum(["healthy", "degraded"]),
+  api: monitoringApiStatusSchema,
+  queue: monitoringQueueSchema,
+  workers: monitoringWorkersSchema,
+  artifact_store: monitoringArtifactStoreSchema,
 });
 
-const recentRunSchema = z.object({
-  id: z.string(),
-  title: z.string().nullable(),
-  status: z.enum(["queued", "running", "succeeded", "failed", "cancelled"]),
-  started_at: z.string().datetime().nullable(),
-  finished_at: z.string().datetime().nullable(),
-  duration: z.number().nullable(),
+export const monitoringBucketSchema = z.object({
+  bucket_start: z.string(),
+  bucket_end: z.string(),
+  total: z.number().int(),
+  success: z.number().int(),
+  failed: z.number().int(),
+  cancelled: z.number().int(),
 });
 
-const monitoringSystemSchema = z.object({
-  health: systemHealthSchema,
-  queue: queueStatsSchema.nullable(),
-  workers: workerStatsSchema.nullable(),
-  artifact_store: artifactStoreStatsSchema,
+/**
+ * recent run의 status는 BuildIndex 내부 값을 그대로 내려준다(builder는
+ * str로 직렬화) — ok/failed/cancelled 외 실행 중 상태도 올 수 있어 좁은
+ * enum 대신 string으로 받고 표시 매핑은 UI가 담당한다.
+ */
+export const monitoringRecentRunSchema = z.object({
+  run_id: z.string(),
+  status: z.string(),
+  started_at: z.string().nullable(),
+  finished_at: z.string().nullable(),
 });
 
-const monitoringBuildsSchema = z.object({
-  stats: z.array(buildStatsSchema),
-  total_success: z.number(),
-  total_failed: z.number(),
-  total_cancelled: z.number(),
-  recent_runs: z.array(recentRunSchema),
+/** GET /monitoring/builds?window=24h&bucket=hour 응답 (#516). */
+export const monitoringBuildsResponseSchema = z.object({
+  window: z.string(),
+  bucket: z.string(),
+  availability: monitoringAvailabilitySchema,
+  excluded_count: z.number().int(),
+  buckets: z.array(monitoringBucketSchema),
+  recent_runs: z.array(monitoringRecentRunSchema),
 });
 
-export const monitoringResponseSchema = z.object({
-  system: monitoringSystemSchema,
-  builds: monitoringBuildsSchema,
-});
-
-export type MonitoringResponse = z.infer<typeof monitoringResponseSchema>;
-export type SystemHealth = z.infer<typeof systemHealthSchema>;
-export type QueueStats = z.infer<typeof queueStatsSchema>;
-export type WorkerStats = z.infer<typeof workerStatsSchema>;
-export type ArtifactStoreStats = z.infer<typeof artifactStoreStatsSchema>;
-export type BuildStats = z.infer<typeof buildStatsSchema>;
-export type RecentRun = z.infer<typeof recentRunSchema>;
+export type MonitoringAvailability = z.infer<typeof monitoringAvailabilitySchema>;
+export type MonitoringApiStatus = z.infer<typeof monitoringApiStatusSchema>;
+export type MonitoringQueueStats = z.infer<typeof monitoringQueueSchema>;
+export type MonitoringWorkerStats = z.infer<typeof monitoringWorkersSchema>;
+export type MonitoringArtifactStoreStats = z.infer<typeof monitoringArtifactStoreSchema>;
+export type MonitoringSummaryResponse = z.infer<typeof monitoringSummaryResponseSchema>;
+export type MonitoringBucket = z.infer<typeof monitoringBucketSchema>;
+export type MonitoringRecentRun = z.infer<typeof monitoringRecentRunSchema>;
+export type MonitoringBuildsResponse = z.infer<typeof monitoringBuildsResponseSchema>;
 export type PublishTarget = z.infer<typeof publishTargetSchema>;
 export type PublishIssue = z.infer<typeof publishIssueSchema>;
 export type PublishReadinessResponse = z.infer<typeof publishReadinessResponseSchema>;

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -586,12 +586,26 @@ export const builderApi = {
        schemas.queryResponseSchema,
      ),
 
-  /** GET /monitoring — 시스템 리소스·Build 통계 monitoring 데이터 (#516). */
-  getMonitoring: (signal?: AbortSignal) =>
+  /**
+   * GET /monitoring/summary — Builder API/Queue/Workers/Artifact Store 시스템
+   * 상태 요약 (#516). 개인 데이터는 포함하지 않는다.
+   */
+  getMonitoringSummary: (signal?: AbortSignal) =>
     apiFetch(
-      "/monitoring",
+      "/monitoring/summary",
       { signal },
-      schemas.monitoringResponseSchema,
+      schemas.monitoringSummaryResponseSchema,
+    ),
+
+  /**
+   * GET /monitoring/builds — 24시간 시간별 build 통계와 recent runs (#516).
+   * ENFORCE_OWNERSHIP에서는 요청 principal이 접근 가능한 run만 집계된다.
+   */
+  getMonitoringBuilds: (signal?: AbortSignal) =>
+    apiFetch(
+      "/monitoring/builds?window=24h&bucket=hour",
+      { signal },
+      schemas.monitoringBuildsResponseSchema,
     ),
 
   /**


### PR DESCRIPTION
## 목적
이슈 #302 체크리스트의 "Builder #516 실제 엔드포인트와 연동 검증" 결과 **실제 계약 드리프트**가 확인되어 이를 수정한다.

## 발견된 드리프트 (검증 결과)
| 항목 | 기존 Studio | Builder 실제 (#516) |
|---|---|---|
| 엔드포인트 | `GET /monitoring` (존재하지 않음) | `GET /monitoring/summary` + `GET /monitoring/builds?window=24h&bucket=hour` |
| 시스템 상태 | `system.health.status` | 최상위 `status`(healthy/degraded) + `api.availability`(available/partial/unavailable) |
| latency | `p95Latency` | `p95_latency_ms` + `sample_count` |
| queue | `queued` | `waiting` (null 가능) |
| artifact store | `status: ok/error/unavailable`, `last_write` | `availability`, `last_write_at` |
| 통계 | `stats[]`, 총계 필드 | `buckets[]`(총계 없음 — 합산 필요) |
| recent run | `id/title/duration` | `run_id`, 제목·소요시간 없음(status는 BuildIndex 내부값) |
| 401 처리 | `err.message === 'unauthorized'` 문자열 매칭 (동작 안 함) | `ApiError.status === 401/403` |
| 실패 시 동작 | mock 데이터 폴백 (정상 오인) | error state (폴백 제거) |

## 수정 내용
- `builderApi.schema.ts`: monitoring 스키마를 실제 wire 계약으로 재작성 (availability 3값, nullable 정밀 반영)
- `builderApi.ts`: `getMonitoring` → `getMonitoringSummary` + `getMonitoringBuilds`
- `MonitoringPage.tsx`: 두 엔드포인트 병렬 호출, ok→성공 상태 매핑, bucket 합산 총계, duration 클라이언트 계산, run_id→`/builds/{run_id}` 링크, null→"—" 표시, partial 제외 건수 안내, 401 권한 상태, mock 폴백 제거
- 테스트 13개: #302 체크리스트 항목 충족 — 네비게이션 테스트, 401 실API 기준, unavailable/null/partial 회귀

## #302 체크리스트
- [x] 최종 통합 + 잔여 PR 정리 (#295-#299 머지, #284 클로즈 — 이전 세션)
- [x] Builder #516 실제 엔드포인트와 연동 검증 → **드리프트 발견·수정 (본 PR)**
- [x] recent run → Runs 상세 네비게이션 테스트
- [x] unauthorized를 실API 응답(401) 기준으로 검증
- [x] unavailable/partial 정상 오인 방지 회귀 테스트

Closes #302