### PR TITLE
feat(storage): 로그인 사용자별 로컬 저장 격리 — Saved BuildSpec·Report·초안 네임스페이싱 (#293)

### DIFF
--- a/__tests__/storageOwner.test.ts
+++ b/__tests__/storageOwner.test.ts
@@ -1,0 +1,126 @@
+/**
+ * 사용자별 localStorage 저장 격리 테스트 (#293).
+ *
+ * - 로그인 사용자마다 별도 버킷(Saved BuildSpec/Report/초안)
+ * - 로그아웃 상태는 기존 무소속 키(하위 호환, 데모 데이터 무손실)
+ * - 다른 사용자 로그인 시 이전 사용자 초안 자동 복원 없음
+ * - 전체 삭제는 현재 소유자 버킷만
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store";
+import { ownedStorageKey, resolveStorageOwnerKey } from "@/features/auth/storageOwner";
+import { clearAllSavedSpecs, createSavedSpec, listSavedSpecSummaries } from "@/features/workspace/savedSpecs";
+import { saveDraft, loadDraft } from "@/features/build-spec/draftStorage";
+
+function emptySpec() {
+  return {
+    datasetId: "demo",
+    title: "demo",
+    description: "",
+    sources: [],
+    exports: [],
+    metadata: {},
+  } as never;
+}
+
+describe("storageOwner (#293)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAuthStore.getState().clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    useAuthStore.getState().clear();
+  });
+
+  it("미로그인은 무소속 키를 그대로 쓴다(하위 호환)", () => {
+    expect(ownedStorageKey("kpubdata-studio:saved-build-specs")).toBe(
+      "kpubdata-studio:saved-build-specs",
+    );
+    expect(resolveStorageOwnerKey()).toBe("anonymous");
+  });
+
+  it("이메일을 정규화(trim+lowercase)한 소유자 키로 네임스페이싱한다", () => {
+    useAuthStore.getState().setSession({
+      token: "t",
+      email: "  User@Example.COM ",
+      name: null,
+      provider: "mock",
+    });
+
+    expect(resolveStorageOwnerKey()).toBe("user:user@example.com");
+    expect(ownedStorageKey("kpubdata-studio:saved-build-specs")).toBe(
+      "kpubdata-studio:saved-build-specs:user:user@example.com",
+    );
+  });
+
+  it("사용자마다 Saved BuildSpec 버킷이 분리된다", () => {
+    useAuthStore.getState().setSession({
+      token: "t1",
+      email: "a@example.com",
+      name: null,
+      provider: "mock",
+    });
+    createSavedSpec({ name: "A의 스펙", spec: emptySpec(), validation: { status: "not_validated", errors: [] } });
+    expect(listSavedSpecSummaries()).toHaveLength(1);
+
+    useAuthStore.getState().setSession({
+      token: "t2",
+      email: "b@example.com",
+      name: null,
+      provider: "mock",
+    });
+    expect(listSavedSpecSummaries()).toHaveLength(0);
+
+    useAuthStore.getState().clear();
+    expect(listSavedSpecSummaries()).toHaveLength(0);
+  });
+
+  it("다른 사용자 로그인 시 이전 사용자 초안이 자동으로 열리지 않는다", () => {
+    useAuthStore.getState().setSession({
+      token: "t1",
+      email: "a@example.com",
+      name: null,
+      provider: "mock",
+    });
+    saveDraft({ title: "A의 초안" });
+
+    useAuthStore.getState().setSession({
+      token: "t2",
+      email: "b@example.com",
+      name: null,
+      provider: "mock",
+    });
+    expect(loadDraft<{ title: string }>()).toBeNull();
+  });
+
+  it("전체 삭제는 현재 소유자 버킷만 지운다", () => {
+    useAuthStore.getState().setSession({
+      token: "t1",
+      email: "a@example.com",
+      name: null,
+      provider: "mock",
+    });
+    createSavedSpec({ name: "A의 스펙", spec: emptySpec(), validation: { status: "not_validated", errors: [] } });
+
+    useAuthStore.getState().setSession({
+      token: "t2",
+      email: "b@example.com",
+      name: null,
+      provider: "mock",
+    });
+    createSavedSpec({ name: "B의 스펙", spec: emptySpec(), validation: { status: "not_validated", errors: [] } });
+
+    expect(clearAllSavedSpecs()).toBe(true);
+    expect(listSavedSpecSummaries()).toHaveLength(0);
+
+    useAuthStore.getState().setSession({
+      token: "t1",
+      email: "a@example.com",
+      name: null,
+      provider: "mock",
+    });
+    expect(listSavedSpecSummaries()).toHaveLength(1);
+  });
+});

--- a/src/features/add-data/draftStorage.ts
+++ b/src/features/add-data/draftStorage.ts
@@ -19,11 +19,14 @@
  * 재입력을 요구한다 — placeholder를 실제 값처럼 복원/제출하지 않는다.
  */
 import { clearDraft, hasDraft, loadDraft, saveDraft } from "@/features/build-spec/draftStorage";
+import { ownedStorageKey } from "@/features/auth/storageOwner";
 import { sanitizeUrlEndpointForStorage } from "@/features/add-data/urlRedaction";
 import { redactSourceParamsObject, redactSourceParamsText } from "@/features/add-data/paramsRedaction";
 import type { AddDataDraft } from "@/features/add-data/model";
 
-const ADD_DATA_DRAFT_KEY = "kpubdata-studio:add-data-draft";
+// 호출 시점 소유자 키로 네임스페이싱한다(#293) — 모듈 로드 시점이 아니라
+// 저장/복원 함수가 불릴 때의 로그인 상태를 반영해야 한다.
+const ADD_DATA_DRAFT_KEY = () => ownedStorageKey("kpubdata-studio:add-data-draft");
 
 export function saveAddDataDraft(draft: AddDataDraft): void {
   const canonicalBase = draft.canonicalBase
@@ -47,19 +50,19 @@ export function saveAddDataDraft(draft: AddDataDraft): void {
       ? { ...draft.publicApi, sourceParams: redactSourceParamsText(draft.publicApi.sourceParams).text }
       : draft.publicApi,
   };
-  saveDraft(safeDraft, ADD_DATA_DRAFT_KEY);
+  saveDraft(safeDraft, ADD_DATA_DRAFT_KEY());
 }
 
 export function loadAddDataDraft(): AddDataDraft | null {
   // draft 형태는 자유롭게 진화할 수 있어(초기 버전) zod 스키마 없이 버전 봉투만 확인한다 —
   // 손상되거나 형태가 크게 다르면 loadDraft가 이미 null로 정리한다.
-  return loadDraft<AddDataDraft>(undefined, ADD_DATA_DRAFT_KEY);
+  return loadDraft<AddDataDraft>(undefined, ADD_DATA_DRAFT_KEY());
 }
 
 export function clearAddDataDraft(): void {
-  clearDraft(ADD_DATA_DRAFT_KEY);
+  clearDraft(ADD_DATA_DRAFT_KEY());
 }
 
 export function hasAddDataDraft(): boolean {
-  return hasDraft(ADD_DATA_DRAFT_KEY);
+  return hasDraft(ADD_DATA_DRAFT_KEY());
 }

--- a/src/features/auth/storageOwner.ts
+++ b/src/features/auth/storageOwner.ts
@@ -1,0 +1,36 @@
+/**
+ * 사용자별 localStorage 네임스페이스 (#293).
+ *
+ * 같은 브라우저를 여러 사람이 쓸 수 있어 Saved BuildSpec/Report/초안 같은
+ * 로컬 저장 작업도 로그인한 사용자별로 분리한다. 미로그인 세션은 기존
+ * (무소속) 키를 그대로 쓴다 — 데모 데이터 정책: 로그인 전 만든 항목은
+ * 이관하지 않고 anonymous 버킷에 그대로 남는다(#293 정책).
+ *
+ * 소유자 판별은 현재 mock auth의 email(정규화: trim+lowercase)을 쓴다.
+ * ADR 0015(builder #515) 이후 실 IdP가 붙으면 여기 한 곳만 안정 식별자
+ * (OIDC sub 기반 owner)로 교체하면 저장 키 정책 전체가 따라온다.
+ */
+import { useAuthStore } from "./store";
+
+const ANONYMOUS_OWNER = "anonymous";
+
+/** 로그인 사용자의 저장 소유자 키. 미로그인이면 "anonymous". */
+export function resolveStorageOwnerKey(): string {
+  const { email } = useAuthStore.getState();
+  if (!email || !email.trim()) return ANONYMOUS_OWNER;
+  return `user:${email.trim().toLowerCase()}`;
+}
+
+/** 로그인 여부. 미로그인 저장은 기존 무소속 키를 쓴다(하위 호환). */
+export function isOwnedStorageSession(): boolean {
+  return resolveStorageOwnerKey() !== ANONYMOUS_OWNER;
+}
+
+/**
+ * 저장 키를 소유자로 네임스페이싱한다.
+ * 미로그인이면 baseKey를 그대로 돌려준다(기존 데이터 무손실).
+ */
+export function ownedStorageKey(baseKey: string): string {
+  if (!isOwnedStorageSession()) return baseKey;
+  return `${baseKey}:${resolveStorageOwnerKey()}`;
+}

--- a/src/features/build-spec/draftStorage.ts
+++ b/src/features/build-spec/draftStorage.ts
@@ -7,6 +7,8 @@
  * localStorage 접근 실패(SSR/프라이빗 모드 등)도 안전한 기본값(null/false)으로 폴백한다.
  */
 /** 기본 초안 저장 키(New Build Wizard). 다른 초안 흐름(Add Data 등)은 별도 key를 넘긴다(#250). */
+import { ownedStorageKey } from "@/features/auth/storageOwner";
+
 const DRAFT_KEY = "kpubdata-studio:new-build-draft";
 
 /** 초안 봉투 스키마 버전. 호환되지 않게 형태가 바뀌면 올린다. */
@@ -32,7 +34,7 @@ interface DraftValidator<T> {
  *
  * @param value - 직렬화 가능한 초안 값.
  */
-export function saveDraft<T>(value: T, key: string = DRAFT_KEY): void {
+export function saveDraft<T>(value: T, key: string = ownedStorageKey(DRAFT_KEY)): void {
   try {
     const envelope: DraftEnvelope<T> = {
       version: DRAFT_VERSION,
@@ -55,7 +57,7 @@ export function saveDraft<T>(value: T, key: string = DRAFT_KEY): void {
  * @param key - 초안 저장 key(선택). 미제공 시 New Build Wizard 기본 key를 쓴다.
  * @returns 저장된 초안 값 또는 null.
  */
-export function loadDraft<T>(validator?: DraftValidator<T>, key: string = DRAFT_KEY): T | null {
+export function loadDraft<T>(validator?: DraftValidator<T>, key: string = ownedStorageKey(DRAFT_KEY)): T | null {
   try {
     const raw = localStorage.getItem(key);
     if (!raw) return null;
@@ -89,7 +91,7 @@ export function loadDraft<T>(validator?: DraftValidator<T>, key: string = DRAFT_
  *
  * @param key - 초안 저장 key(선택). 미제공 시 New Build Wizard 기본 key를 쓴다.
  */
-export function clearDraft(key: string = DRAFT_KEY): void {
+export function clearDraft(key: string = ownedStorageKey(DRAFT_KEY)): void {
   try {
     localStorage.removeItem(key);
   } catch {
@@ -103,7 +105,7 @@ export function clearDraft(key: string = DRAFT_KEY): void {
  * @param key - 초안 저장 key(선택). 미제공 시 New Build Wizard 기본 key를 쓴다.
  * @returns 초안 존재 여부.
  */
-export function hasDraft(key: string = DRAFT_KEY): boolean {
+export function hasDraft(key: string = ownedStorageKey(DRAFT_KEY)): boolean {
   try {
     return localStorage.getItem(key) !== null;
   } catch {

--- a/src/features/build-spec/specStore.ts
+++ b/src/features/build-spec/specStore.ts
@@ -15,6 +15,7 @@
  */
 import { buildSpecSchema } from "@/shared/lib/schemas";
 import type { BuildSpec } from "@/shared/lib/types";
+import { ownedStorageKey } from "@/features/auth/storageOwner";
 
 const SPEC_STORE_KEY = "kpubdata-studio:build-specs";
 
@@ -51,7 +52,7 @@ interface SpecStoreEnvelope {
 function readEnvelope(): SpecStoreEnvelope {
   const empty: SpecStoreEnvelope = { version: SPEC_STORE_VERSION, entries: {} };
   try {
-    const raw = localStorage.getItem(SPEC_STORE_KEY);
+    const raw = localStorage.getItem(ownedStorageKey(SPEC_STORE_KEY));
     if (!raw) return empty;
     const parsed = JSON.parse(raw) as unknown;
     if (
@@ -79,7 +80,7 @@ function readEnvelope(): SpecStoreEnvelope {
  */
 function writeEnvelope(envelope: SpecStoreEnvelope): void {
   try {
-    localStorage.setItem(SPEC_STORE_KEY, JSON.stringify(envelope));
+    localStorage.setItem(ownedStorageKey(SPEC_STORE_KEY), JSON.stringify(envelope));
   } catch {
     // 용량 초과/사용 불가 시 무시.
   }
@@ -154,7 +155,7 @@ export function hasBuildSpec(runId: string): boolean {
  */
 export function clearBuildSpecs(): void {
   try {
-    localStorage.removeItem(SPEC_STORE_KEY);
+    localStorage.removeItem(ownedStorageKey(SPEC_STORE_KEY));
   } catch {
     // 무시.
   }

--- a/src/features/kubi/reportInbox.ts
+++ b/src/features/kubi/reportInbox.ts
@@ -6,6 +6,8 @@
  * Reports 진입점으로 연결"하는 최소 handoff만 제공한다. `draftStorage.ts`와 동일한
  * `{version, data, savedAt}` 봉투 규약을 따른다.
  */
+import { ownedStorageKey } from "@/features/auth/storageOwner";
+
 export interface KubiReportNote {
   note: string;
   reason: string;
@@ -25,7 +27,7 @@ interface InboxEnvelope {
 function readEnvelope(): InboxEnvelope {
   const empty: InboxEnvelope = { version: INBOX_VERSION, notes: [] };
   try {
-    const raw = localStorage.getItem(INBOX_KEY);
+    const raw = localStorage.getItem(ownedStorageKey(INBOX_KEY));
     if (!raw) return empty;
     const parsed = JSON.parse(raw) as unknown;
     if (
@@ -50,7 +52,7 @@ export function queueKubiReportNote(note: KubiReportNote): void {
     if (envelope.notes.length > INBOX_LIMIT) {
       envelope.notes = envelope.notes.slice(envelope.notes.length - INBOX_LIMIT);
     }
-    localStorage.setItem(INBOX_KEY, JSON.stringify(envelope));
+    localStorage.setItem(ownedStorageKey(INBOX_KEY), JSON.stringify(envelope));
   } catch {
     // localStorage 사용 불가 시 무시.
   }
@@ -76,7 +78,7 @@ export function removeKubiReportNote(note: KubiReportNote): void {
     );
     if (index === -1) return;
     envelope.notes.splice(index, 1);
-    localStorage.setItem(INBOX_KEY, JSON.stringify(envelope));
+    localStorage.setItem(ownedStorageKey(INBOX_KEY), JSON.stringify(envelope));
   } catch {
     // localStorage 사용 불가 시 무시.
   }

--- a/src/features/reports/repository.ts
+++ b/src/features/reports/repository.ts
@@ -11,6 +11,7 @@
  * "저장됨"이라고 잘못 표시하지 않도록 항상 명시적 결과를 반환한다(#258 §11, §12).
  */
 import { REPORT_VERSION, type ReportDraft, type ReportSummary } from "./types";
+import { ownedStorageKey } from "@/features/auth/storageOwner";
 
 const STORE_KEY = "kpubdata-studio:reports";
 export const STORE_VERSION = 1;
@@ -43,7 +44,7 @@ function isStorageAvailable(): boolean {
 function readEnvelope(): StoreEnvelope {
   if (!isStorageAvailable()) return emptyEnvelope();
   try {
-    const raw = localStorage.getItem(STORE_KEY);
+    const raw = localStorage.getItem(ownedStorageKey(STORE_KEY));
     if (!raw) return emptyEnvelope();
     const parsed = JSON.parse(raw) as unknown;
     if (
@@ -53,7 +54,7 @@ function readEnvelope(): StoreEnvelope {
       typeof (parsed as StoreEnvelope).reports !== "object" ||
       (parsed as StoreEnvelope).reports === null
     ) {
-      localStorage.removeItem(STORE_KEY);
+      localStorage.removeItem(ownedStorageKey(STORE_KEY));
       return emptyEnvelope();
     }
     return parsed as StoreEnvelope;
@@ -77,7 +78,7 @@ function writeEnvelope(envelope: StoreEnvelope): SaveResult {
     return { ok: false, reason: "Report 내용을 저장 형식으로 변환하지 못했습니다." };
   }
   try {
-    localStorage.setItem(STORE_KEY, serialized);
+    localStorage.setItem(ownedStorageKey(STORE_KEY), serialized);
     return { ok: true, revision: 0 };
   } catch (cause) {
     const isQuota =

--- a/src/features/workspace/savedSpecs.ts
+++ b/src/features/workspace/savedSpecs.ts
@@ -10,6 +10,7 @@
  * 값이 로컬 저장소에 평문으로 남지 않게 한다.
  */
 import { redactSecrets } from "@/features/assistant/scrub";
+import { ownedStorageKey } from "@/features/auth/storageOwner";
 import type { BuildSpec } from "@/shared/lib/types";
 import {
   SAVED_SPEC_VERSION,
@@ -49,7 +50,7 @@ function isStorageAvailable(): boolean {
 function readEnvelope(): StoreEnvelope {
   if (!isStorageAvailable()) return emptyEnvelope();
   try {
-    const raw = localStorage.getItem(STORE_KEY);
+    const raw = localStorage.getItem(ownedStorageKey(STORE_KEY));
     if (!raw) return emptyEnvelope();
     const parsed = JSON.parse(raw) as unknown;
     if (
@@ -59,7 +60,7 @@ function readEnvelope(): StoreEnvelope {
       typeof (parsed as StoreEnvelope).specs !== "object" ||
       (parsed as StoreEnvelope).specs === null
     ) {
-      localStorage.removeItem(STORE_KEY);
+      localStorage.removeItem(ownedStorageKey(STORE_KEY));
       return emptyEnvelope();
     }
     return parsed as StoreEnvelope;
@@ -83,7 +84,7 @@ function writeEnvelope(envelope: StoreEnvelope): SaveResult {
     return { ok: false, reason: "BuildSpec을 저장 형식으로 변환하지 못했습니다." };
   }
   try {
-    localStorage.setItem(STORE_KEY, serialized);
+    localStorage.setItem(ownedStorageKey(STORE_KEY), serialized);
     return { ok: true, revision: 0 };
   } catch (cause) {
     const isQuota =
@@ -237,6 +238,20 @@ export function deleteSavedSpec(id: string): boolean {
   if (!envelope.specs[id]) return false;
   delete envelope.specs[id];
   return writeEnvelope(envelope).ok;
+}
+
+/**
+ * 현재 소유자(로그인 사용자 또는 anonymous)의 Saved BuildSpec을 전부 삭제한다 (#293).
+ * 다른 소유자 버킷은 건드리지 않는다.
+ */
+export function clearAllSavedSpecs(): boolean {
+  if (!isStorageAvailable()) return false;
+  try {
+    localStorage.removeItem(ownedStorageKey(STORE_KEY));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** 저장된 Saved BuildSpec이 있는지 확인한다(빈 상태 안내용). */

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -13,6 +13,7 @@ import { listBuilds } from "@/features/runs/api";
 import { listReportSummaries } from "@/features/reports/repository";
 import type { ReportSummary } from "@/features/reports/types";
 import {
+  clearAllSavedSpecs,
   deleteSavedSpec,
   duplicateSavedSpec,
   listSavedSpecSummaries,
@@ -156,6 +157,17 @@ export function WorkspacePage() {
     refreshLocal();
   }
 
+  function handleClearAllSpecs() {
+    if (
+      !window.confirm(
+        "현재 로그인 사용자의 Saved BuildSpec을 모두 삭제하시겠습니까? 되돌릴 수 없습니다.",
+      )
+    )
+      return;
+    clearAllSavedSpecs();
+    refreshLocal();
+  }
+
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
       <PageHeader
@@ -237,7 +249,23 @@ export function WorkspacePage() {
       </section>
 
       <section className="flex flex-col gap-3">
-        <PageHeader eyebrow="Saved BuildSpecs" title="저장한 BuildSpec" className="mb-0" />
+        <PageHeader
+          eyebrow="Saved BuildSpecs"
+          title="저장한 BuildSpec"
+          className="mb-0"
+          actions={
+            savedSpecSummaries.length > 0 ? (
+              <Button
+                variant="secondary"
+                size="sm"
+                type="button"
+                onClick={handleClearAllSpecs}
+              >
+                전체 삭제
+              </Button>
+            ) : undefined
+          }
+        />
 
         {actionError ? <ErrorState className="py-4" message={actionError} /> : null}
 


### PR DESCRIPTION
## 목적
이슈 #293 — 같은 브라우저를 여러 사람이 쓸 때 로컬 저장 작업을 사용자별로 분리한다. 이 이슈의 전제조건이던 Builder #515 IdP 결정이 ADR 0015(PR #554)로 승인되어 진행했다.

## 정책 (이슈 체크리스트 매핑)
| 이슈 요구 | 구현 |
|---|---|
| 사용자별 저장 키 분리 | `ownedStorageKey()` — 로그인 시 `{base}:user:{email 정규화}`, 미로그인 시 기존 키 그대로 |
| 로그아웃 시 이전 사용자 항목 숨김 | 소유자 키가 세션을 따르므로 자동으로 다른 버킷을 봄 (데이터 삭제 없음) |
| 이전 사용자 Draft 자동 열림 방지 | new-build·add-data 초안 모두 호출 시점 소유자 키 |
| 미로그인 항목 이관 정책 | **자동 이관 없음** — anonymous 버킷(기존 키)에 잔류, 하위 호환으로 데모 데이터 무손실 |
| 전체 삭제 기능 | `clearAllSavedSpecs()` + Workspace "전체 삭제" 버튼 — 현재 소유자 버킷만 |
| 저장 경계 안내 | 기존 "이 브라우저에만 저장됩니다" 카드 유지 (#260) |

## 소유자 판별 설계
`features/auth/storageOwner.ts` 한 곳에서 판별 — 현재는 mock auth email(trim+lowercase), ADR 0015 이후 실 IdP의 안정 식별자(OIDC sub)로 **한 함수만** 교체하면 된다.

## 적용 저장소 (6곳)
saved-build-specs, reports, build-specs(run spec 캐시), new-build-draft, add-data-draft, kubi-report-inbox

## 검증
- 격리/하위호환/초안차단/전체삭제 스코프 테스트 5개 신규 (`storageOwner.test.ts`)
- 전체 949 테스트 통과 (기존 테스트는 미로그인 키 유지로 무수정 통과)

Closes #293