### PR TITLE
feat(settings): Settings 통합 — account·Provider credential summary·Kubi BYOK 분리 (#301)

### DIFF
--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -39,6 +39,7 @@ const EXPECTED_OPERATIONS = [
   "getBuildEvents",
   "getMonitoringSummary",
   "getMonitoringBuilds",
+  "listProviders",
   "testProviderConnection",
   "uploadFile",
 ] as const;

--- a/__tests__/remainingPages.test.tsx
+++ b/__tests__/remainingPages.test.tsx
@@ -23,7 +23,7 @@ describe("remaining pages", () => {
   it("SettingsPage shows the API base URL section", () => {
     renderPage(<SettingsPage />);
     expect(screen.getByRole("heading", { name: "환경 설정" })).toBeInTheDocument();
-    expect(screen.getByText("Builder API 엔드포인트")).toBeInTheDocument();
+    expect(screen.getByText("Builder API base URL")).toBeInTheDocument();
   });
 
   it("ArtifactsPage guides to the build list", () => {

--- a/__tests__/settingsIntegration.test.tsx
+++ b/__tests__/settingsIntegration.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Settings 통합 테스트 (#301).
+ *
+ * - 계정/Provider 자격 증명/Kubi BYOK가 분리된 영역으로 존재
+ * - Provider 자격 증명 요약은 GET /providers 부울만 사용(원문 키 없음)
+ * - 실연동에서 구성 상태 배지·요약 카운트 렌더링, /provider CTA 동작
+ * - Kubi BYOK는 메모리 전용 기본값 + opt-in 경고 정책 유지
+ * - 가짜 team/project 기능이 표시되지 않음(#292 회귀 금지)
+ */
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+import { SettingsPage } from "@/pages/SettingsPage";
+import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
+import { useAuthStore } from "@/features/auth/store";
+
+vi.mock("@/shared/lib/builderApi", async () => {
+  const actual = await vi.importActual<typeof import("@/shared/lib/builderApi")>(
+    "@/shared/lib/builderApi",
+  );
+  return {
+    ...actual,
+    isRealBuilderEnabled: vi.fn(() => false),
+    builderApi: {
+      version: vi.fn(),
+      listProviders: vi.fn(),
+    },
+  };
+});
+
+function renderSettings() {
+  return render(
+    <MemoryRouter initialEntries={["/settings"]}>
+      <Routes>
+        <Route path="/settings" element={<SettingsPage />} />
+        <Route path="/provider" element={<div>PROVIDER_PAGE</div>} />
+        <Route path="/kubi" element={<div>KUBI_PAGE</div>} />
+        <Route path="/login" element={<div>LOGIN_PAGE</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("SettingsPage 통합 (#301)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isRealBuilderEnabled).mockReturnValue(false);
+    useAuthStore.getState().clear();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    useAuthStore.getState().clear();
+    localStorage.clear();
+  });
+
+  it("계정·Provider 자격 증명·Kubi BYOK가 서로 분리된 영역으로 렌더링된다", async () => {
+    renderSettings();
+
+    expect(screen.getByTestId("settings-account")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-provider-credentials")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-kubi-byok")).toBeInTheDocument();
+    expect(
+      screen
+        .getAllByText("데이터 Provider 자격 증명", { exact: false })
+        .some((node) => node.closest('[data-testid="settings-provider-credentials"]') !== null),
+    ).toBe(true);
+    expect(screen.getByText(/BYOK LLM 키/)).toBeInTheDocument();
+  });
+
+  it("mock 모드에서는 Provider 요약이 mock 안내와 /provider CTA를 표시한다", async () => {
+    renderSettings();
+
+    expect(
+      screen.getByText(/Provider 페이지에서 동작을 시연할 수 있습니다/),
+    ).toBeInTheDocument();
+    expect(builderApi.listProviders).not.toHaveBeenCalled();
+    expect(screen.getByRole("link", { name: "Provider 설정에서 관리" })).toHaveAttribute(
+      "href",
+      "/provider",
+    );
+  });
+
+  it("실연동에서는 GET /providers 요약(부울)으로 구성 상태를 표시한다", async () => {
+    vi.mocked(isRealBuilderEnabled).mockReturnValue(true);
+    vi.mocked(builderApi.version).mockResolvedValue({
+      name: "kpubdata-builder",
+      api_version: "1.17.0",
+    } as never);
+    vi.mocked(builderApi.listProviders).mockResolvedValue({
+      providers: [
+        { provider: "datago", requires_credential: true, configured: true },
+        { provider: "kosis", requires_credential: true, configured: false },
+        { provider: "seoul", requires_credential: false, configured: false },
+      ],
+    });
+
+    renderSettings();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("자격 증명이 필요한 Provider 2개 중 1개가 구성되었습니다."),
+      ).toBeInTheDocument();
+    });
+    // 배지는 provider명·상태가 분할 텍스트 노드로 렌더링된다 — 목록 기준으로 확인.
+    const badgeList = screen.getByLabelText("provider 구성 상태");
+    expect(badgeList.textContent).toContain("datago");
+    expect(badgeList.textContent).toContain("구성됨");
+    expect(badgeList.textContent).toContain("kosis");
+    expect(badgeList.textContent).toContain("미구성");
+    // 자격 증명이 필요 없는 provider는 요약에 나타나지 않는다.
+    expect(badgeList.textContent).not.toContain("seoul");
+  });
+
+  it("Provider CTA가 /provider로 이동한다", async () => {
+    const locationRef: { current: { pathname: string } | null } = { current: null };
+    function LocationProbe() {
+      locationRef.current = useLocation();
+      return null;
+    }
+    render(
+      <MemoryRouter initialEntries={["/settings"]}>
+        <Routes>
+          <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/provider" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Provider 설정에서 관리" }));
+
+    await waitFor(() => expect(locationRef.current).not.toBeNull());
+    expect(locationRef.current?.pathname).toBe("/provider");
+  });
+
+  it("Kubi BYOK는 기본 메모리 전용임을 알리고 opt-in 경고를 유지한다", async () => {
+    renderSettings();
+
+    expect(screen.getByText(/메모리에만 보관/)).toBeInTheDocument();
+    expect(screen.getByText(/브라우저 저장: 꺼짐/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Kubi에서 설정" })).toHaveAttribute("href", "/kubi");
+  });
+
+  it("로그인 상태에서 계정 영역이 이메일과 로그아웃을 표시한다", async () => {
+    useAuthStore.getState().setSession({
+      token: "t",
+      email: "user@example.com",
+      name: null,
+      provider: "mock",
+    });
+
+    renderSettings();
+
+    expect(screen.getByText("user@example.com")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "로그아웃" }));
+    await waitFor(() => {
+      expect(useAuthStore.getState().email).toBeNull();
+    });
+  });
+
+  it("가짜 team/project 기능을 표시하지 않는다 (#292 회귀 금지)", async () => {
+    renderSettings();
+
+    const pageText = document.body.textContent ?? "";
+    expect(pageText).not.toContain("팀");
+    expect(pageText).not.toContain("Team");
+    expect(pageText).not.toContain("프로젝트 설정");
+    expect(pageText).not.toContain("Project");
+  });
+});

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,8 +1,13 @@
 /**
  * Studio 환경 설정 페이지 (/settings).
  *
- * 환경 변수로 주입된 Builder API 엔드포인트를 노출하고, 실제 연동 모드일 때는 Builder
- * `/version`을 호출해 계약 버전 호환성을 점검한다(#29).
+ * 네 개의 분리된 영역으로 구성한다(#301):
+ * 1. 계정 — 로그인 상태/로그아웃(실연동) 또는 mock 안내
+ * 2. 연결 — Builder API 엔드포인트와 계약 버전 호환성 점검(#29)
+ * 3. 데이터 Provider 자격 증명 — GET /providers 요약(부울만, 원문 없음) + /provider CTA
+ * 4. Kubi BYOK — LLM 키는 Provider credential과 완전히 분리된 정책/영역(#256)
+ *
+ * 구현되지 않은 team/project backend를 있는 것처럼 표시하지 않는다(#292 회귀 금지).
  */
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
@@ -13,7 +18,9 @@ import {
   builderApi,
   isRealBuilderEnabled,
 } from "@/shared/lib/builderApi";
+import type { ProviderSummary } from "@/shared/lib/builderApi.schema";
 import { useAuthStore } from "@/features/auth/store";
+import { useAssistConfig } from "@/features/assistant/config";
 import { Card, PageHeader, StatusBadge } from "@/shared/ui";
 
 interface ConnectionState {
@@ -22,15 +29,16 @@ interface ConnectionState {
   error?: string;
 }
 
-/**
- * 환경 기반 설정 값과 Builder 연결 상태를 보여주는 페이지 컴포넌트.
- *
- * @returns 설정 화면.
- */
+type ProvidersState =
+  | { status: "idle" | "loading" }
+  | { status: "error"; message: string }
+  | { status: "ok"; providers: ProviderSummary[] };
+
 export function SettingsPage() {
   const realEnabled = isRealBuilderEnabled();
   const { email, clear } = useAuthStore();
   const [connection, setConnection] = useState<ConnectionState>({ status: "idle" });
+  const [providers, setProviders] = useState<ProvidersState>({ status: "idle" });
 
   useEffect(() => {
     if (!realEnabled) return;
@@ -49,25 +57,32 @@ export function SettingsPage() {
     return () => controller.abort();
   }, [realEnabled]);
 
+  useEffect(() => {
+    if (!realEnabled) return;
+    const controller = new AbortController();
+    setProviders({ status: "loading" });
+    builderApi
+      .listProviders(controller.signal)
+      .then((response) => setProviders({ status: "ok", providers: response.providers }))
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setProviders({
+          status: "error",
+          message: cause instanceof ApiError ? cause.message : "조회에 실패했습니다.",
+        });
+      });
+    return () => controller.abort();
+  }, [realEnabled]);
+
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
       <PageHeader
         eyebrow="설정"
         title="환경 설정"
-        description="Builder API 엔드포인트와 연결 상태를 확인합니다. 실제 저장 기능은 이후 연동됩니다."
+        description="계정, Builder 연결, 데이터 Provider 자격 증명, Kubi BYOK를 관리합니다."
       />
 
-      <Card>
-        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          Builder API 엔드포인트
-        </p>
-        <div className="mt-4 rounded-xl border border-dashed border-border bg-muted p-4">
-          <p className="text-sm font-medium">현재 base URL</p>
-          <code className="mt-3 block break-all text-sm text-accent-subtle-foreground">
-            {API_BASE}
-          </code>
-        </div>
-      </Card>
+      <AccountSection realEnabled={realEnabled} email={email} onLogout={clear} />
 
       <Card>
         <div className="flex items-center justify-between gap-3">
@@ -77,6 +92,12 @@ export function SettingsPage() {
           <span className="text-xs text-muted-foreground">
             Studio 계약 버전 {API_CONTRACT_VERSION}
           </span>
+        </div>
+        <div className="mt-4 rounded-xl border border-dashed border-border bg-muted p-4">
+          <p className="text-sm font-medium">Builder API base URL</p>
+          <code className="mt-3 block break-all text-sm text-accent-subtle-foreground">
+            {API_BASE}
+          </code>
         </div>
         <div className="mt-4 text-sm">
           {!realEnabled ? (
@@ -111,39 +132,9 @@ export function SettingsPage() {
         </div>
       </Card>
 
-      {realEnabled && (
-        <Card>
-          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            로그인 상태
-          </p>
-          <div className="mt-4 text-sm">
-            {email ? (
-              <div className="flex items-center justify-between gap-2">
-                <span className="text-foreground">{email}</span>
-                <button
-                  type="button"
-                  onClick={() => clear()}
-                  className="rounded-lg border border-border px-3 py-1 text-xs text-muted-foreground hover:bg-muted"
-                >
-                  로그아웃
-                </button>
-              </div>
-            ) : (
-              <div className="flex items-center justify-between gap-2">
-                <p className="text-muted-foreground">
-                  로그인되지 않았습니다. 실연동 모드에서는 Builder 호출을 위해 로그인이 필요합니다.
-                </p>
-                <Link
-                  to="/login"
-                  className="shrink-0 rounded-lg border border-border px-3 py-1 text-xs font-medium text-accent-subtle-foreground hover:bg-muted"
-                >
-                  로그인
-                </Link>
-              </div>
-            )}
-          </div>
-        </Card>
-      )}
+      <ProviderCredentialSection realEnabled={realEnabled} state={providers} />
+
+      <KubiByokSection />
 
       <Card variant="dashed">
         <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
@@ -164,5 +155,185 @@ export function SettingsPage() {
         </div>
       </Card>
     </main>
+  );
+}
+
+function AccountSection({
+  realEnabled,
+  email,
+  onLogout,
+}: {
+  realEnabled: boolean;
+  email: string | null;
+  onLogout: () => void;
+}) {
+  return (
+    <Card data-testid="settings-account">
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        계정
+      </p>
+      <div className="mt-4 text-sm">
+        {email ? (
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-foreground">{email}</span>
+            <button
+              type="button"
+              onClick={() => onLogout()}
+              className="rounded-lg border border-border px-3 py-1 text-xs text-muted-foreground hover:bg-muted"
+            >
+              로그아웃
+            </button>
+          </div>
+        ) : realEnabled ? (
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-muted-foreground">
+              로그인되지 않았습니다. 실연동 모드에서는 Builder 호출을 위해 로그인이 필요합니다.
+            </p>
+            <Link
+              to="/login"
+              className="shrink-0 rounded-lg border border-border px-3 py-1 text-xs font-medium text-accent-subtle-foreground hover:bg-muted"
+            >
+              로그인
+            </Link>
+          </div>
+        ) : (
+          <p className="text-muted-foreground">
+            mock 모드에서는 로그인 상태가 UI 시연용으로만 동작합니다. 계정/권한 백엔드는
+            실연동과 함께 연동됩니다.
+          </p>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function ProviderCredentialSection({
+  realEnabled,
+  state,
+}: {
+  realEnabled: boolean;
+  state: ProvidersState;
+}) {
+  // 요약은 서버가 계산한 configured 부울만 다룬다 — 원문 키 조회 자체를 하지 않는다.
+  const requiringCredential =
+    state.status === "ok" ? state.providers.filter((p) => p.requires_credential) : [];
+  const configuredCount = requiringCredential.filter((p) => p.configured).length;
+
+  return (
+    <Card data-testid="settings-provider-credentials">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          데이터 Provider 자격 증명
+        </p>
+        <Link
+          to="/provider"
+          className="shrink-0 rounded-lg border border-border px-3 py-1 text-xs font-medium text-accent-subtle-foreground hover:bg-muted"
+        >
+          Provider 설정에서 관리
+        </Link>
+      </div>
+      <div className="mt-4 text-sm">
+        {!realEnabled ? (
+          <p className="text-muted-foreground">
+            mock 모드에서는 Provider 페이지에서 동작을 시연할 수 있습니다. 실제 자격 증명은
+            실연동 모드에서 Builder가 서버에 안전하게 보관합니다.
+          </p>
+        ) : state.status === "loading" ? (
+          <p className="text-muted-foreground">Provider 구성 상태를 조회하는 중입니다…</p>
+        ) : state.status === "error" ? (
+          <p className="text-red-700 dark:text-red-300">{state.message}</p>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-muted-foreground">
+              자격 증명이 필요한 Provider {requiringCredential.length}개 중 {configuredCount}개가
+              구성되었습니다.
+            </p>
+            <ul className="flex flex-wrap gap-2" aria-label="provider 구성 상태">
+              {requiringCredential.map((provider) => (
+                <li key={provider.provider}>
+                  <ProviderConfiguredBadge
+                    provider={provider.provider}
+                    configured={provider.configured}
+                  />
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function ProviderConfiguredBadge({ provider, configured }: { provider: string; configured: boolean }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${
+        configured
+          ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300"
+          : "bg-muted text-muted-foreground"
+      }`}
+    >
+      {provider}
+      <span aria-hidden="true">·</span>
+      {configured ? "구성됨" : "미구성"}
+    </span>
+  );
+}
+
+function KubiByokSection() {
+  // Kubi LLM 키는 Provider credential과 다른 BYOK 정책을 따른다(#256/#301 분리):
+  // 기본 메모리 전용, 브라우저 저장은 명시적 opt-in + 경고.
+  const { isConfigured, model, persistToStorage, resolvedBaseUrl, isDefaultBaseUrl } =
+    useAssistConfig();
+
+  return (
+    <Card data-testid="settings-kubi-byok">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Kubi · BYOK LLM 키
+        </p>
+        <Link
+          to="/kubi"
+          className="shrink-0 rounded-lg border border-border px-3 py-1 text-xs font-medium text-accent-subtle-foreground hover:bg-muted"
+        >
+          Kubi에서 설정
+        </Link>
+      </div>
+      <div className="mt-4 space-y-2 text-sm">
+        <p className="text-muted-foreground">
+          Kubi 어시스턴트의 LLM 키는 데이터 Provider 자격 증명과 별도로 사용자가 직접
+          관리합니다(Bring Your Own Key). 키는 기본적으로 메모리에만 보관되며 새로고침 시
+          사라집니다.
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+              isConfigured
+                ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300"
+                : "bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300"
+            }`}
+          >
+            {isConfigured ? "키 설정됨" : "키 미설정"}
+          </span>
+          {isConfigured && model ? <span className="text-muted-foreground">{model}</span> : null}
+          {isConfigured && !isDefaultBaseUrl ? (
+            <span className="text-amber-700 dark:text-amber-400" title={resolvedBaseUrl}>
+              사용자 지정 Base URL
+            </span>
+          ) : null}
+        </div>
+        {persistToStorage ? (
+          <p className="text-amber-700 dark:text-amber-400">
+            브라우저 저장이 켜져 있습니다 — LLM API 키가 이 브라우저에 평문으로 저장됩니다.
+            XSS 공격 시 탈취될 수 있으니 신뢰하지 않는 환경에서는 끄세요.
+          </p>
+        ) : (
+          <p className="text-muted-foreground">
+            브라우저 저장: 꺼짐(메모리 전용). Kubi 화면에서 명시적으로 켤 수 있습니다.
+          </p>
+        )}
+      </div>
+    </Card>
   );
 }

--- a/src/shared/lib/builderApi.schema.ts
+++ b/src/shared/lib/builderApi.schema.ts
@@ -264,6 +264,18 @@ export type CatalogResponse = z.infer<typeof catalogResponseSchema>;
  * ============================================
  */
 
+/** GET /providers — 런타임 Provider 목록과 현재 principal의 configured 상태(#492).
+ *  credential 원문은 포함하지 않는다(서버가 부울만 내려준다). */
+export const providerSummarySchema = z.object({
+  provider: z.string(),
+  requires_credential: z.boolean(),
+  configured: z.boolean(),
+});
+
+export const providersResponseSchema = z.object({
+  providers: z.array(providerSummarySchema),
+});
+
 /** POST /providers/{provider}/test, GET /providers/{provider}/status 공통 응답. */
 export const providerTestResponseSchema = z.object({
   provider: z.string(),
@@ -285,6 +297,8 @@ export const uploadMetadataSchema = z.object({
   created_at: z.string(),
 });
 
+export type ProviderSummary = z.infer<typeof providerSummarySchema>;
+export type ProvidersResponse = z.infer<typeof providersResponseSchema>;
 export type ProviderTestResponse = z.infer<typeof providerTestResponseSchema>;
 export type UploadMetadata = z.infer<typeof uploadMetadataSchema>;
 

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -614,6 +614,17 @@ export const builderApi = {
    * 버튼이 호출한다. credential 값 자체는 Studio가 주고받지 않는다 — Builder가
    * 서버에 저장된 credential(또는 무인증 provider)로 직접 검사한다.
    */
+  /**
+   * GET /providers — 런타임 Provider 목록과 현재 principal의 configured 상태(#492).
+   * 응답은 부울 요약만 담는다 — credential 원문은 어디에도 존재하지 않는다.
+   */
+  listProviders: (signal?: AbortSignal) =>
+    apiFetch(
+      "/providers",
+      { signal },
+      schemas.providersResponseSchema,
+    ),
+
   testProviderConnection: (provider: string, signal?: AbortSignal) =>
     apiFetch(
       `/providers/${encodeURIComponent(provider)}/test`,


### PR DESCRIPTION
## 목적
이슈 #301 — #259(PR #300)에서 분리됐던 Settings 통합을 구현한다.

## 구조 (분리된 4영역)
1. **계정** — 로그인 상태/로그아웃/로그인 CTA (mock 모드 안내 포함, 항상 표시)
2. **연결** — 기존 Builder API base URL + 계약 버전 점검(#29 유지)
3. **데이터 Provider 자격 증명** — `GET /providers`(신규 `listProviders` op) 요약: 자격 증명 필요 Provider N개 중 M개 구성 + provider별 배지 + `/provider` CTA
4. **Kubi · BYOK LLM 키** — Provider credential과 명확히 분리: 메모리 전용 기본값, opt-in 브라우저 저장 경고 유지, `/kubi` CTA

## 보안 (이슈 요구 사항)
- Provider API key 원문 GET/localStorage 금지 — 요약은 서버가 계산한 `configured` **부울만** 소비
- Kubi LLM 키는 기존 BYOK 정책 그대로(변경 없음, 기존 browser BYOK 유지)
- arbitrary Base URL override 추가하지 않음 — 기존 안전 검사(#256)만 표시

## 완료 조건 대응
- [x] Provider credential summary + `/provider` CTA 동작 (실연동/mock 분기, 네비게이션 테스트)
- [x] Kubi BYOK와 Provider credential의 UI/정책 분리 (별도 카드 + 정책 고지)
- [x] 가짜 team/project 기능 미표시 회귀 테스트 (#292)

## 검증
- 신규 `settingsIntegration.test.tsx` 7개 + 기존 956 테스트 전부 통과, typecheck 0 에러

Closes #301