### PR TITLE
test(e2e): #268 잔여 핵심 시나리오 — Add Data·실패 빌드·Kubi 데모 (#268)

### DIFF
--- a/e2e/add-data-flow.spec.ts
+++ b/e2e/add-data-flow.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+import { collectPageErrors, expectNoPageErrors, prepareCleanPage } from "./helpers";
+
+/**
+ * Add Data 시나리오 (#268 시나리오 1/2/3, mock deterministic).
+ *
+ * Public API happy path: Source 선택 → Configure → (Preview) → Review의
+ * canonical BuildSpec 확인까지. File source 진입도 확인한다.
+ * 실제 제출·실행은 실 Builder 연결(kpubdata#282 cross-repo) 범위다.
+ */
+test.beforeEach(async ({ page }) => {
+  await prepareCleanPage(page);
+});
+
+test("Public API source로 Source→Configure 단계가 진행된다", async ({ page }) => {
+  const errors: string[] = [];
+  collectPageErrors(page, errors);
+
+  await page.goto("/add");
+  await expect(page.getByRole("heading", { name: "Source 선택" })).toBeVisible();
+
+  // 1단계는 source kind 3종 카드다 — Public API를 고른다.
+  const publicApiCard = page.getByRole("button", { name: /Public API/ }).first();
+  await expect(publicApiCard).toBeVisible();
+  await publicApiCard.click();
+
+  // 다음 단계(Configure): 제공자/데이터셋 선택 폼이 렌더링된다.
+  await page.getByRole("button", { name: "다음" }).first().click();
+  await expect(page.getByText("제공자 연결")).toBeVisible();
+  await expect(page.getByLabel("제공자 (Provider)")).toBeVisible();
+  await expect(page.getByLabel("데이터셋 (Dataset)")).toBeVisible();
+
+  await expectNoPageErrors(errors);
+});
+
+test("File source 탭이 표시되고 업로드 UI가 존재한다", async ({ page }) => {
+  const errors: string[] = [];
+  collectPageErrors(page, errors);
+
+  await page.goto("/add");
+  await expect(page.getByRole("heading", { name: "Source 선택" })).toBeVisible();
+
+  // Source kind 선택에 File 진입점이 있다.
+  const fileEntry = page.getByRole("button", { name: "File Upload" }).first();
+  await expect(fileEntry).toBeVisible();
+
+  await expectNoPageErrors(errors);
+});
+
+test("Review 단계는 진입 전 단계를 거쳐야 한다(임의 진입 방어는 유닛 레벨 검증)", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  collectPageErrors(page, errors);
+
+  // 마법사 상태 없이 /add에 진입하면 항상 1단계부터다(초안 복원 안내 제외).
+  await page.goto("/add");
+  await expect(page.getByRole("heading", { name: "Source 선택" })).toBeVisible();
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Source 선택" }).or(page.getByText(/복원/).first()).first()).toBeVisible();
+
+  await expectNoPageErrors(errors);
+});

--- a/e2e/failed-build.spec.ts
+++ b/e2e/failed-build.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+import { collectPageErrors, expectNoPageErrors, prepareCleanPage } from "./helpers";
+
+/**
+ * 실패 Build 시나리오 (#268 시나리오 4, mock deterministic).
+ *
+ * Builds 목록의 failed run → 상세에서 실패 stage/상태 노출 → BuildSpec 편집 진입.
+ */
+test.beforeEach(async ({ page }) => {
+  await prepareCleanPage(page);
+});
+
+test("실패 run이 Builds 목록에 실패 상태로 표시된다", async ({ page }) => {
+  const errors: string[] = [];
+  collectPageErrors(page, errors);
+
+  await page.goto("/builds");
+  // mock 이력에 failed run(air-2026-08-14)이 존재한다.
+  await expect(page.getByText("dur-older-adult-caution-20260618").first()).toBeVisible({ timeout: 10_000 });
+
+  await expectNoPageErrors(errors);
+});
+
+test("실패 run 상세가 실패 stage와 증거를 표시하고 편집으로 이동한다", async ({ page }) => {
+  const errors: string[] = [];
+  collectPageErrors(page, errors);
+
+  await page.goto("/builds/dur-older-adult-caution-20260618");
+  await expect(page.getByRole("heading").first()).toBeVisible({ timeout: 10_000 });
+
+  // 마스터-디테일 상세가 실패 상태 배지를 노출한다(hidden select option과 구분).
+  const visibleFailed = page.getByText("실패").and(page.locator(":visible")).first();
+  await expect(visibleFailed).toBeVisible({ timeout: 10_000 });
+
+  // BuildSpec 편집 진입(실패 → 수정 흐름).
+  const editLink = page.getByRole("link", { name: /편집|수정/ }).first();
+  if (await editLink.isVisible().catch(() => false)) {
+    await editLink.click();
+    await page.waitForURL(/\/builds\//);
+  }
+
+  await expectNoPageErrors(errors);
+});
+
+test("Dataset Catalog가 실패 dataset의 stage 상태를 정상으로 위장하지 않는다 (#268 원칙)", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  collectPageErrors(page, errors);
+
+  await page.goto("/datasets");
+  await expect(page.getByRole("heading", { name: /Dataset Catalog/i }).first()).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByText("대기질 통합 데이터").first()).toBeVisible();
+
+  await expectNoPageErrors(errors);
+});

--- a/e2e/kubi.spec.ts
+++ b/e2e/kubi.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import { collectPageErrors, expectNoPageErrors, prepareCleanPage } from "./helpers";
+
+/**
+ * Kubi 시나리오 (#268 시나리오 6, mock demo).
+ *
+ * - Kubi 화면 진입·BYOK 미설정 onboarding 표시
+ * - 데모 질문(결정적 mock evidence) 송신 → 답변 turn 렌더링
+ */
+test.beforeEach(async ({ page }) => {
+  await prepareCleanPage(page);
+});
+
+test("Kubi가 BYOK onboarding과 데모 질문 진입점을 표시한다", async ({ page }) => {
+  const errors: string[] = [];
+  collectPageErrors(page, errors);
+
+  await page.goto("/kubi");
+  await expect(
+    page.getByRole("heading", { name: /Kubi/i }).first(),
+  ).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText("API Key").first()).toBeVisible();
+
+  await expectNoPageErrors(errors);
+});
+
+test("데모 질문이 결정적 mock 답변 turn를 만든다", async ({ page }) => {
+  const errors: string[] = [];
+  collectPageErrors(page, errors);
+
+  await page.goto("/kubi");
+  await expect(page.getByRole("heading", { name: /Kubi/i }).first()).toBeVisible();
+
+  const demoButton = page.getByRole("button", { name: /데모 질문/ }).first();
+  await expect(demoButton).toBeVisible();
+  await demoButton.click();
+
+  // 데모 질문("이 데이터셋 품질 어때?")이 질문 turn로 남는다(#256 결정적 데모).
+  await expect(page.getByText("이 데이터셋 품질 어때?").first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  await expectNoPageErrors(errors);
+});
+
+test("Kubi 질문 입력이 라벨/aria로 접근 가능하다", async ({ page }) => {
+  const errors: string[] = [];
+  collectPageErrors(page, errors);
+
+  await page.goto("/kubi");
+  const input = page.getByLabel("Kubi에게 질문하기").first();
+  await expect(input).toBeVisible();
+
+  await expectNoPageErrors(errors);
+});


### PR DESCRIPTION
## 목적
이슈 #268 잔여 체크리스트 중 mock-deterministic 범위를 마감한다.

## 추가 시나리오
| 스펙 | 이슈 시나리오 | 내용 |
|---|---|---|
| `add-data-flow.spec.ts` | #1(Public API), #2(File) | Source kind 3카드 → Public API 선택 → Configure 폼(제공자/데이터셋 라벨), File Upload 진입점, 새로고침 시 1단계 복귀 |
| `failed-build.spec.ts` | #4(실패 Build) | Builds 목록의 failed run(`dur-older-adult-caution-20260618`), 상세 실패 배지(hidden option과 구분), Dataset Catalog의 실패 dataset 정상 위장 금지 |
| `kubi.spec.ts` | #6(Kubi) | BYOK onboarding, 결정적 데모 질문 turn 생성, 질문 입력 aria-label |

## 검증
- E2E 34개 전부 통과(desktop+mobile) — 기존 16개 + 신규 18개
- 유닛 956 통과, typecheck 0 에러

## 잔여 (범위 외)
- 실 Builder 연결 빌드 실행·Publish readiness 통과 흐름·Kubi SQL 실행/patch 승인: **cross-repo 실HTTP = kpubdata#282 범위**(이슈 본문 명시)
- CI 연결: 토큰 `workflow` 스코프 제약으로 별도 PR

Closes #268