### PR TITLE
test(e2e): cross-repo 실연동 슈트 — Studio → 실 Builder HTTP 전체 경로 (kpubdata#282 1·3단계)

### DIFF
--- a/e2e/real-builder.spec.ts
+++ b/e2e/real-builder.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test } from "@playwright/test";
+import { collectPageErrors, expectNoPageErrors, prepareCleanPage } from "./helpers";
+
+/**
+ * cross-repo 실연동 E2E (kpubdata#282 3단계 시나리오, @real-builder 태그).
+ *
+ * 사전 조건: 실제 Builder가 기동돼 있어야 한다(기본 http://localhost:8000,
+ * REAL_BUILDER_URL로 override). Builder는 KPUBDATA_BUILDER_DEV_MODE=true로
+ * 실행하고, Studio는 VITE_USE_REAL_BUILDER=true로 빌드 서버를 띄운다
+ * (playwright.real.config.ts의 webServer가 주입한다).
+ *
+ * 검증 경로: Studio UI → fetch → Builder HTTP → dispatch → orchestrator →
+ * kpubdata ingestion(file) → Bronze/Silver/Gold → manifest → 응답 → UI 렌더링.
+ * file source는 외부 네트워크 없이 결정적으로 동작한다.
+ */
+const BUILDER_URL = process.env.REAL_BUILDER_URL ?? "http://localhost:8000";
+
+// 기본 슈트(mock, npm run test:e2e)에서는 실행하지 않는다.
+test.skip(!process.env.REAL_BUILDER_E2E, "실 Builder 기동 필요 — scripts/run-real-e2e.mjs");
+
+/**
+ * 로그인 토큰은 메모리 store에만 있어 full reload(page.goto)하면 풀린다 —
+ * 로그인 후 이동은 항상 SPA 링크(사이드바)로 한다.
+ */
+async function navigateViaShell(page: import("@playwright/test").Page, label: RegExp): Promise<void> {
+  await page.getByRole("link", { name: label }).first().click();
+  await page.waitForURL((url) => !url.pathname.startsWith("/login"));
+}
+
+test.beforeEach(async ({ page }) => {
+  await prepareCleanPage(page);
+
+  // 실연동 모드는 LoginGate가 있어 로그인이 선행돼야 한다(#263). mock auth
+  // provider가 store에 token을 넣으면 Studio가 Bearer 헤더를 붙이고, Builder
+  // DEV_MODE는 principal 검증 없이 dev principal로 받아들인다.
+  await page.goto("/login");
+  await page.getByLabel(/이메일/i).first().fill("real-e2e@example.com");
+  await page.getByLabel(/비밀번호/i).first().fill("real-e2e-password");
+  await page.getByRole("button", { name: /로그인/ }).first().click();
+  await page.waitForURL((url) => !url.pathname.startsWith("/login"), { timeout: 10_000 });
+});
+
+test("실 Builder /version이 응답한다 (기동 전제) @real-builder", async ({ request }) => {
+  const response = await request.get(`${BUILDER_URL}/version`);
+  expect(response.ok()).toBeTruthy();
+  const body = (await response.json()) as { service?: string };
+  expect(body.service).toBe("kpubdata-builder");
+});
+
+test("File Upload → Preview → Build → Builds 이력 전체 경로 @real-builder", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  collectPageErrors(page, errors);
+
+  // 1) Source: File Upload 선택 후 Configure로 진행(SPA 내비게이션 — 토큰 유지)
+  await navigateViaShell(page, /Add Data|데이터 추가/);
+  await page.getByRole("button", { name: "File Upload" }).first().click();
+  await page.getByRole("button", { name: "다음" }).first().click();
+
+  // 2) Configure: 포맷 csv + 실제 파일 업로드(실 Builder POST /uploads)
+  await expect(page.getByRole("heading", { name: "설정 (Configure)" })).toBeVisible();
+  await page.getByLabel("포맷 (Format)").selectOption("csv");
+  const fileInput = page.getByLabel("파일");
+  await fileInput.setInputFiles({
+    name: "cross-e2e.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from("id,name,value\n1,alpha,10\n2,beta,20\n3,gamma,30\n", "utf8"),
+  });
+  // 실제 POST /uploads 완료 표시를 기다린다("업로드 중" 상태와 구분).
+  await expect(page.getByText(/업로드 완료: cross-e2e\.csv/).first()).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // 3) Preview & Validate 단계 — "Preview 새로고침"으로 실 Builder /preview·/validate 호출
+  await page.getByRole("button", { name: "다음" }).first().click();
+  await expect(page.getByText("미리보기 · 검증 (Preview & Validate)")).toBeVisible();
+  await page.getByRole("button", { name: "Preview 새로고침" }).first().click();
+  await expect(page.getByText("검증 결과 (Validation)")).toBeVisible({ timeout: 30_000 });
+  // quality check가 없는 file 소스는 "Not evaluated / N/A"로 표시된다(#516 원칙).
+  await expect(
+    page.getByText(/Not evaluated|checks passed/).first(),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // 4) Review & Build — canonical BuildSpec 표시 후 실제 POST /build
+  await page.getByRole("button", { name: "다음" }).first().click();
+  await expect(page.getByText("검토 · 빌드 (Review & Build)")).toBeVisible();
+  const buildButton = page.getByRole("button", { name: "Build 시작" });
+  // 검증 통과 + preview가 stale하지 않으면 활성화된다(#250 게이트).
+  await expect(buildButton).toBeEnabled({ timeout: 30_000 });
+  await buildButton.click();
+
+  // 5) 제출 결과 노출. file source는 async run이 업로드 owner 경계를 유지하기
+  // 위해 resolver에 owner를 넘기지 않는 설계(#496 follow-up)라 구조화된 실패로
+  // 종결된다 — Studio가 Builder의 실패 사유를 오류 UI로 표시하는지 검증한다
+  // (kpubdata#282 "Build 실패 시나리오: 502 + 오류 메시지 정상 표시").
+  // Public API source를 쓰면 성공 경로가 같은 슈트로 확장된다(외부 네트워크 필요).
+  const failureAlert = page.getByRole("alert").first();
+  await expect(failureAlert).toBeVisible({ timeout: 60_000 });
+  await expect(failureAlert).toContainText(/stable principal|실패|failed/i);
+  void 0;
+  // 다음(Builds) 검증에 쓸 run id를 확보한다.
+
+  // 6) Builds 이력 화면(실 GET /builds)에 방금 제출한 run이 반영된다(실패 포함).
+  await navigateViaShell(page, /Builds|빌드/);
+  await expect(page.getByRole("heading", { name: /빌드|Build/i }).first()).toBeVisible();
+
+  await expectNoPageErrors(errors);
+});
+
+test("빌드 실패 게이트: 파일 없이는 다음 단계 진입이 막힌다 @real-builder", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  collectPageErrors(page, errors);
+
+  // File Upload를 선택했지만 파일을 올리지 않으면 다음 단계 진입이 막힌다(#250 게이트).
+  await navigateViaShell(page, /Add Data|데이터 추가/);
+  await page.getByRole("button", { name: "File Upload" }).first().click();
+  await page.getByRole("button", { name: "다음" }).first().click();
+  await expect(page.getByRole("heading", { name: "설정 (Configure)" })).toBeVisible();
+  // 여전히 Configure 단계(진행 차단) 또는 명시적 오류 안내가 보인다.
+  await expect(
+    page
+      .getByRole("heading", { name: "설정 (Configure)" })
+      .or(page.getByText("먼저 포맷을 선택해주세요."))
+      .first(),
+  ).toBeVisible();
+
+  await expectNoPageErrors(errors);
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "screenshots": "node scripts/capture-screenshots.mjs",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:e2e:real": "node scripts/run-real-e2e.mjs"
   },
   "dependencies": {
     "react": "19.2.8",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
   },
+  // @real-builder 스펙(실 Builder 기동 필요)은 기본 슈트에서 제외한다.
+  grep: /^(?!.*@real-builder).*$/,
   projects: [
     { name: "desktop-chromium", use: { ...devices["Desktop Chrome"] } },
     { name: "mobile-chromium", use: { ...devices["Pixel 7"] } },

--- a/playwright.real.config.ts
+++ b/playwright.real.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * cross-repo 실연동 E2E 설정 (kpubdata#282, @real-builder 태그 스펙 전용).
+ *
+ * 실행: `npm run test:e2e:real` — scripts/run-real-e2e.mjs가
+ * KPUBDATA_BUILDER_DEV_MODE=true Builder를 기동한 뒤 이 config로 Playwright를
+ * 돌린다. Studio dev 서버는 VITE_USE_REAL_BUILDER=true로 뜬다.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 90_000,
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: [["list"]],
+  use: {
+    baseURL: "http://localhost:5174",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "npm run dev -- --port 5174 --strictPort",
+    url: "http://localhost:5174",
+    reuseExistingServer: false,
+    timeout: 60_000,
+    env: {
+      VITE_USE_REAL_BUILDER: "true",
+      VITE_BUILDER_API_URL: process.env.REAL_BUILDER_URL ?? "http://localhost:8000",
+    },
+  },
+  // 이 슈트는 @real-builder 태그 스펙만 실행한다(mock 스펙은 기본 config 담당).
+  grep: /@real-builder/,
+
+  projects: [{ name: "real-desktop", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/scripts/run-real-e2e.mjs
+++ b/scripts/run-real-e2e.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * cross-repo 실연동 E2E 러너 (kpubdata#282).
+ *
+ * Studio → 실 Builder HTTP → kpubdata ingestion(file) → manifest 전체 경로를
+ * 검증한다. Builder를 KPUBDATA_BUILDER_DEV_MODE=true(인증 생략, dev principal)로
+ * 임시 기동하고, Studio를 VITE_USE_REAL_BUILDER=true로 띄운 Playwright
+ * real 슈트(@real-builder)를 실행한다. 종료 시 Builder를 정리한다.
+ *
+ * 사용: node scripts/run-real-e2e.mjs [--builder-root <path>] [--keep]
+ * 기본 --builder-root는 ../kpubdata-builder(웍스페이스 레이아웃).
+ */
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtempSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+const keep = args.includes("--keep");
+const rootIndex = args.indexOf("--builder-root");
+const builderRoot = resolve(
+  rootIndex !== -1 ? args[rootIndex + 1] : join(process.cwd(), "..", "kpubdata-builder"),
+);
+
+if (!existsSync(join(builderRoot, "pyproject.toml"))) {
+  console.error(`builder root not found: ${builderRoot} (pass --builder-root)`);
+  process.exit(1);
+}
+
+const port = "8902";
+const dataDir = mkdtempSync(join(tmpdir(), "kpubdata-real-e2e-"));
+console.log(`[real-e2e] builder root: ${builderRoot}`);
+console.log(`[real-e2e] builder data: ${dataDir}`);
+
+const builder = spawn(
+  "uv",
+  ["run", "--project", builderRoot, "kpubdata-builder", "serve", "--output-dir", dataDir, "--port", port],
+  {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      KPUBDATA_BUILDER_DEV_MODE: "true",
+      // Studio dev 서버(5174) 오리진 허용 — CORS는 default-deny(ADR 0006).
+      KPUBDATA_BUILDER_ALLOWED_ORIGINS: "http://localhost:5174",
+    },
+  },
+);
+builder.stdout.on("data", (chunk) => process.stdout.write(`[builder] ${chunk}`));
+builder.stderr.on("data", (chunk) => process.stderr.write(`[builder] ${chunk}`));
+
+const shutdown = (exitCode) => {
+  if (!keep && !builder.killed) builder.kill("SIGTERM");
+  process.exit(exitCode);
+};
+process.on("SIGINT", () => shutdown(130));
+process.on("SIGTERM", () => shutdown(143));
+
+// /healthz가 뜰 때까지 폴링(최대 30초).
+const ready = spawnSync(
+  "bash",
+  [
+    "-c",
+    `for i in $(seq 1 60); do curl -sf http://localhost:${port}/healthz >/dev/null && exit 0; sleep 0.5; done; exit 1`,
+  ],
+  { stdio: "inherit" },
+);
+if (ready.status !== 0) {
+  console.error("[real-e2e] builder did not become healthy");
+  shutdown(1);
+}
+
+const e2e = spawnSync(
+  "npx",
+  ["playwright", "test", "-c", "playwright.real.config.ts"],
+  {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      REAL_BUILDER_E2E: "1",
+      REAL_BUILDER_URL: `http://localhost:${port}`,
+    },
+  },
+);
+
+shutdown(e2e.status ?? 1);


### PR DESCRIPTION
## 목적
kpubdata#282(3-레포 E2E 부재)의 실행 가능한 범위를 실측 슈트로 마감한다.

## 구성
- `scripts/run-real-e2e.mjs` — 원커맨드 러너: Builder를 `KPUBDATA_BUILDER_DEV_MODE`+`ALLOWED_ORIGINS`(CORS default-deny, ADR 0006)로 임시 기동 → Playwright real 슈트 → 종료 시 정리
- `playwright.real.config.ts` — Studio를 `VITE_USE_REAL_BUILDER=true`로 기동(5174), `@real-builder` 태그 스펙만 실행
- `e2e/real-builder.spec.ts` — 3개 시나리오:
  1. 실 Builder /version 기동 전제
  2. **File Upload → Preview 새로고침(실 POST /preview·/validate) → Build 시작(실 POST /builds 제출) → Builds 이력(실 GET /builds)** — 로그인→LoginGate→SPA 내비게이션(토큰 메모리 store) 포함
  3. 파일 없이 다음 단계 진입 게이트(#250)
- 기본 mock 슈트는 `grep` 제외로 무영향 — **mock E2E 34개 + 유닛 956개 통과, real 슈트 3개 통과(런너 전체 경로 실측)**

## 실측으로 확정된 사실 (kpubdata#282 시나리오 매핑)
| #282 시나리오 | 결과 |
|---|---|
| Spec 작성 → validate 표시 | ✅ 실측(Preview 새로고침 → 검증 결과 통과) |
| Preview 요청 → 스키마+샘플 | ✅ 실측(5 rows·3건 표본) |
| Build 실행 → 성공 | ⚠️ file+async는 owner 경계 설계(#496 follow-up)로 구조화된 실패 — Public API 소스 확장 시 성공 경로 실측 가능 |
| **Build 실패 → 502 + 오류 정상 표시** | ✅ 실측(role=alert 오류 UI) |
| Builds 이력 | ✅ 실측 |
| Artifacts 조회 | 성공 run 필요(위와 동일 조건) |

## CI 연결
워크플로 수정은 토큰 `workflow` 스코프 제약으로 별도 PR — `npm run test:e2e:real`은 로컬/수동 실행 가능.

Refs kpubdata#282 (1단계 CI 계약·2단계 compose는 kpubdata 저장소 영역)