### PR TITLE
fix(e2e): mock E2E 슈트 직렬화 — vite 트랜스파일 경합으로 인한 간헐 실패 제거 (#268 후속)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,11 @@ export default defineConfig({
     baseURL: "http://localhost:5173",
     trace: "retain-on-failure",
   },
+  // 파일 병렬 실행은 하지 않는다 — 여러 worker가 단일 vite dev 서버의
+  // 온디맨드 트랜스파일을 경합해 뒤쪽 route의 첫 로드가 expect 타임아웃을
+  // 넘긴다(#268 리뷰에서 확인 — 직렬로만 전 스펙이 100% 통과).
+  fullyParallel: false,
+  workers: 1,
   webServer: {
     command: "npm run dev -- --port 5173 --strictPort",
     url: "http://localhost:5173",


### PR DESCRIPTION
## 발견 경로
전체 코드 리뷰(QA 레인) 중 재실행에서 **mock E2E가 슈트마다 2-4개 간헐 실패**(34개 기준 30-32 passed)하는 것을 확인 — 이전 세션 보고의 `tail -1`이 실패 라인을 가리고 있었다.

## 원인
- 기본 Playwright worker 수(코어 수)로 스펙 파일 병렬 실행 시, 여러 브라우저가 **단일 vite dev 서버**에 동시 첫 요청 → 온디맨드 트랜스파일 경합 → 뒤쪽 route(`/settings`)의 첫 로드가 expect 타임아웃(10s) 초과
- 증거: 동일 스펙 단독 실행/조합 실행/직렬(`--workers=1`) 실행은 100% 통과, 병렬에서만 실패하며 실패 조합이 매번 다름

## 수정
`playwright.config.ts`: `fullyParallel: false` + `workers: 1` (프로젝트 desktop/mobile 순차)

## 검증
- fresh 서버(CI=true) 3연속 **34/34 통과** (~50s, 이전 병렬 대비 실행시간 손해 없음)