### PR TITLE
fix: harden Studio UI state consistency and responsive behavior

### DIFF
--- a/__tests__/HomePage.test.tsx
+++ b/__tests__/HomePage.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import { HomePage } from "@/pages/HomePage";
+import { mswServer } from "../vitest.setup";
+
+const BUILDER_BASE = "http://localhost:8000";
 
 describe("HomePage", () => {
   it("renders the existing-user dashboard heading and KPI summary once builds load (#248)", async () => {
@@ -36,5 +40,21 @@ describe("HomePage", () => {
     expect(
       screen.getAllByRole("link", { name: "보기" }).length,
     ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("points the new-user '데이터 추가하기' CTA at the canonical /add route, not /add-data (#regression)", async () => {
+    // 신규 사용자 분기를 재현하기 위해 빌드 목록을 빈 배열로 오버라이드한다.
+    mswServer.use(
+      http.get(`${BUILDER_BASE}/builds`, () => HttpResponse.json({ builds: [] })),
+    );
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+
+    const cta = await screen.findByRole("link", { name: "데이터 추가하기" });
+    expect(cta).toHaveAttribute("href", "/add");
   });
 });

--- a/__tests__/buildPublishPage.test.tsx
+++ b/__tests__/buildPublishPage.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BuildPublishPage } from "@/pages/BuildPublishPage";
+import { mswServer } from "../vitest.setup";
+
+const BUILDER_BASE = "http://localhost:8000";
+
+afterEach(() => vi.unstubAllEnvs());
+
+function renderPublish(runId: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/builds/${runId}/publish`]}>
+      <Routes>
+        <Route path="/builds/:buildId/publish" element={<BuildPublishPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("BuildPublishPage readiness (audit #4)", () => {
+  it("mock 모드에서 실제 네트워크 요청 없이 결정적 readiness를 보여준다 (이전에는 항상 빈 카드/error였다)", async () => {
+    renderPublish("air-quality-20260621");
+
+    expect(await screen.findByText("Builder 게시 준비 완료")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("mock 모드에서 not-ready run은 실제 blocker 내용을 보여준다", async () => {
+    renderPublish("dur-older-adult-caution-20260618");
+
+    expect(await screen.findByText("Builder blocker가 있어 게시할 수 없습니다.")).toBeInTheDocument();
+    expect(screen.getByText(/Bronze stage가 실패해/)).toBeInTheDocument();
+  });
+
+  it("ready:false인데 blockers가 비어 있으면 'blocker가 있다'고 잘못 단정하지 않는다", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    mswServer.use(
+      http.get(`${BUILDER_BASE}/builds/:runId/publish/readiness`, ({ params }) =>
+        HttpResponse.json({
+          run_id: String(params.runId),
+          target: "huggingface",
+          ready: false,
+          blockers: [],
+          warnings: [],
+        }),
+      ),
+    );
+
+    renderPublish("some-real-run");
+
+    expect(
+      await screen.findByText(/구체적인 사유\(blocker\)를 제공하지 않았습니다/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Builder blocker가 있어 게시할 수 없습니다.")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/buildRoutes.test.tsx
+++ b/__tests__/buildRoutes.test.tsx
@@ -42,10 +42,12 @@ describe("build-centric routes", () => {
     expect(await screen.findByText(/Run을 찾을 수 없습니다/)).toBeInTheDocument();
   });
 
-  it("renders the run page with progress steps", () => {
-    renderAt("/builds/abc/run", <BuildRunPage />);
-    expect(screen.getByText("진행 단계")).toBeInTheDocument();
-    expect(screen.getByText("수집")).toBeInTheDocument();
+  it("renders the run page with the build's actual canonical status, not fake progress steps (UI audit #3)", async () => {
+    // 이전에는 buildId와 무관하게 항상 "대기"·가짜 stepper였다 — 실제 mock 이력에 존재하는
+    // run(dur-pregnancy-taboo-20260621, status: running)으로 canonical 상태를 확인한다.
+    renderAt("/builds/dur-pregnancy-taboo-20260621/run", <BuildRunPage />);
+    expect(await screen.findByText("실행 중")).toBeInTheDocument();
+    expect(screen.getByText("상세 진행 정보 미지원")).toBeInTheDocument();
   });
 
   it("renders the artifacts page with a manifest section", async () => {

--- a/__tests__/buildRunPage.test.tsx
+++ b/__tests__/buildRunPage.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { BuildRunPage } from "@/pages/BuildRunPage";
+
+function renderRun(buildId: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/builds/${buildId}/run`]}>
+      <Routes>
+        <Route path="/builds/:buildId/run" element={<BuildRunPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("BuildRunPage (audit #3)", () => {
+  it("shows the build's actual canonical status (running), not a hardcoded 대기 placeholder", async () => {
+    // dur-pregnancy-taboo-20260621는 mock 빌드 이력에서 status: "running"이다 — Builds
+    // 목록에서 running으로 보이는 run을 열었을 때 이 화면이 항상 "대기"로 보이던 모순을 재현한다.
+    renderRun("dur-pregnancy-taboo-20260621");
+
+    expect(await screen.findByText("실행 중")).toBeInTheDocument();
+    expect(screen.queryByText("대기 중")).not.toBeInTheDocument();
+  });
+
+  it("shows the build's actual canonical status (failed), not a hardcoded 대기 placeholder", async () => {
+    renderRun("dur-older-adult-caution-20260618");
+
+    expect(await screen.findByText("실패")).toBeInTheDocument();
+    expect(screen.queryByText("대기 중")).not.toBeInTheDocument();
+  });
+
+  it("does not fabricate stage-by-stage progress it cannot support", async () => {
+    renderRun("dur-pregnancy-taboo-20260621");
+
+    await screen.findByText("실행 중");
+    expect(screen.getByText("상세 진행 정보 미지원")).toBeInTheDocument();
+  });
+});

--- a/__tests__/datasetDetail.test.tsx
+++ b/__tests__/datasetDetail.test.tsx
@@ -125,11 +125,43 @@ describe("Dataset Detail P0 (#253)", () => {
     expect(within(panel).queryByText(/score/i)).not.toBeInTheDocument();
   });
 
+  it("explains a run-level failed status next to a completed/PASS selected stage instead of hiding the contradiction (audit #2)", async () => {
+    renderDetail();
+    // 기본 선택(latest run air-2026-08-14, source datago__air)은 gold stage가 completed/PASS이면서
+    // run 전체 상태는 kma__weather의 silver 실패로 인해 failed다 — 두 상태 semantics는 서로 다른
+    // scope(run 전체 vs 선택된 source/stage)이므로 값 자체를 숨기거나 조작하지 않는다.
+    await waitFor(() => expect(screen.getByRole("button", { name: /gold completed/ })).toHaveAttribute("aria-pressed", "true"));
+
+    const runStatusRow = screen.getByTitle("선택된 source/stage가 아니라 이 run 전체(모든 source)의 결과입니다");
+    expect(runStatusRow).toHaveTextContent("Run 상태");
+    expect(runStatusRow).toHaveTextContent("failed");
+
+    const stageBadge = screen.getByTitle("선택된 source(datago__air)의 gold stage 상태");
+    expect(stageBadge).toHaveTextContent("gold");
+    expect(stageBadge).toHaveTextContent("completed");
+
+    const explanation = await screen.findByRole("alert");
+    expect(explanation).toHaveTextContent(/run 상태는 failed이지만/i);
+    expect(explanation).toHaveTextContent("kma__weather");
+  });
+
   it("shows run history and links each run to build detail", async () => {
     renderDetail("/datasets/air-quality?tab=builds");
     const panel = await screen.findByRole("tabpanel", { name: "Builds" });
     expect(within(panel).getByText(/air-2026-08-13/)).toBeInTheDocument();
     expect(within(panel).getAllByRole("link", { name: "보기" })[0]).toHaveAttribute("href", "/builds/air-2026-08-14");
+  });
+
+  it("propagates the known latest-run context to Kubi when opening the AI tab, not '—' (audit #5)", async () => {
+    // 기본 진입(초기 URL에 ?run= 없음, latest run 암묵 선택)에서 AI 탭을 클릭한다 — stage와 달리
+    // run은 URL에 명시적으로 반영되지 않아 Kubi RUN context가 "—"로 보이던 문제를 재현한다.
+    renderDetail();
+    await screen.findByLabelText("Run 선택");
+    fireEvent.click(screen.getByRole("tab", { name: "AI" }));
+
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent("run=air-2026-08-14"));
+    const panel = await screen.findByRole("tabpanel", { name: "AI" });
+    expect(within(panel).getByText("air-2026-08-14")).toBeInTheDocument();
   });
 
   it("renders Kubi inline on the AI tab with this dataset's context, not a drawer launcher (#256 review)", async () => {

--- a/__tests__/legacyDeepLinks.test.tsx
+++ b/__tests__/legacyDeepLinks.test.tsx
@@ -44,7 +44,7 @@ describe("router 딥링크 회귀 (#247)", () => {
     render(<RouterProvider router={router} />);
 
     await navigateTo("/builds/abc/run");
-    expect(screen.getByText("진행 단계")).toBeInTheDocument();
+    expect(await screen.findByText("상세 진행 정보 미지원")).toBeInTheDocument();
 
     await navigateTo("/builds/abc/artifacts");
     expect(await screen.findByText("Manifest 요약")).toBeInTheDocument();

--- a/__tests__/publishFlow.test.tsx
+++ b/__tests__/publishFlow.test.tsx
@@ -58,7 +58,13 @@ async function fillAndConfirm() {
   return screen.getByRole("button", { name: "게시 실행" });
 }
 
-beforeEach(() => vi.stubEnv("VITE_USE_REAL_BUILDER", "false"));
+// 이 스위트는 Builder HTTP 계약(POST body, 502/403/404/network 분류, 경합 방지)을 실제
+// fetch mock으로 직접 검증한다 — getPublishReadiness/publishBuild가 mock/real 스위치 없이
+// 항상 fetch를 거치던 시절 그대로였다. UI audit #4에서 다른 Builder 연동 엔드포인트와
+// 동일하게 mock/real 분기를 추가했으므로(features/publish/api/index.ts), 이 스위트가 계속
+// 실제 fetch 경로를 검증하도록 real 모드로 명시한다 — "false"였다면 이제 결정적 mock
+// fixture(features/publish/api/mockData.ts)를 타서 아래 fetch mock들이 전혀 호출되지 않는다.
+beforeEach(() => vi.stubEnv("VITE_USE_REAL_BUILDER", "true"));
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();

--- a/e2e/viewport-a11y.spec.ts
+++ b/e2e/viewport-a11y.spec.ts
@@ -43,6 +43,67 @@ test("키보드로 내비게이션 링크에 focus가 도달하고 focus가 보�
   await expectNoPageErrors(errors);
 });
 
+test("390x844에서 topbar subtitle이 Kubi/avatar 버튼과 겹치지 않는다 (UI audit #6-A)", async ({ page }) => {
+  const errors: string[] = [];
+  collectPageErrors(page, errors);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+  await expect(page.getByRole("heading").first()).toBeVisible({ timeout: 10_000 });
+
+  const subtitle = page.locator("header h1");
+  const kubiButton = page.getByRole("button", { name: "Kubi 열기" });
+  await expect(subtitle).toBeVisible();
+  await expect(kubiButton).toBeVisible();
+
+  const subtitleBox = await subtitle.boundingBox();
+  const kubiBox = await kubiButton.boundingBox();
+  expect(subtitleBox).not.toBeNull();
+  expect(kubiBox).not.toBeNull();
+  // 두 사각형이 겹치면 안 된다 — 한쪽이 상대의 왼쪽에서 완전히 끝나거나(가로) 위에서
+  // 완전히 끝나야(세로, 줄바꿈된 경우) "겹치지 않음"이다.
+  if (subtitleBox && kubiBox) {
+    const overlapsHorizontally = subtitleBox.x < kubiBox.x + kubiBox.width && kubiBox.x < subtitleBox.x + subtitleBox.width;
+    const overlapsVertically = subtitleBox.y < kubiBox.y + kubiBox.height && kubiBox.y < subtitleBox.y + subtitleBox.height;
+    expect(overlapsHorizontally && overlapsVertically, "subtitle과 Kubi 버튼이 겹칩니다").toBe(false);
+  }
+
+  await expectNoPageErrors(errors);
+});
+
+test("390x844에서 Add Data sticky bottom actions가 마지막 content를 덮지 않는다 (UI audit #6-B)", async ({ page }) => {
+  const errors: string[] = [];
+  collectPageErrors(page, errors);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/add");
+  await expect(page.getByRole("heading", { name: "데이터 추가" })).toBeVisible({ timeout: 10_000 });
+
+  await page.getByText("Public API").click();
+  await page.getByRole("button", { name: "다음" }).click();
+  await page.locator("#add-data-provider").selectOption({ index: 1 });
+  await page.locator("#add-data-dataset").selectOption({ index: 1 });
+  await page.getByRole("button", { name: "다음" }).click();
+  await page.getByRole("button", { name: /Preview 새로고침/ }).click();
+  await page.getByRole("button", { name: "다음" }).click();
+
+  const buildButton = page.getByRole("button", { name: "Build 시작" });
+  await buildButton.scrollIntoViewIfNeeded();
+  await expect(buildButton).toBeVisible();
+
+  const stickyBar = page.locator(".sticky.bottom-0");
+  const buildBox = await buildButton.boundingBox();
+  const stickyBox = await stickyBar.boundingBox();
+  expect(buildBox).not.toBeNull();
+  expect(stickyBox).not.toBeNull();
+  if (buildBox && stickyBox) {
+    // "Build 시작" 버튼의 아래쪽 절반이라도 sticky bar에 가려지면 안 된다.
+    expect(buildBox.y + buildBox.height, "Build 시작 버튼이 sticky bar에 가려집니다").toBeLessThanOrEqual(stickyBox.y);
+  }
+
+  await expectNoPageErrors(errors);
+});
+
 test("Login 폼이 라벨로 입력에 접근 가능하다 (접근성 기초)", async ({ page }) => {
   const errors: string[] = [];
   collectPageErrors(page, errors);

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -469,7 +469,13 @@ export function Layout() {
                 </div>
               </div>
 
-              <div className="flex min-w-0 flex-1 items-center justify-end gap-2 sm:gap-3">
+              {/* min-w-0가 여기 있으면 이 그룹의 최소너비 보호가 사라져 flex-shrink 계산에서
+                  이 그룹이 자기 컨텐츠(Kubi 버튼/avatar)보다 더 작게 줄어들 수 있다 — 그 안의
+                  버튼들은 title처럼 truncate로 줄어들 수 있는 요소가 아니라 overflow로 그대로
+                  삐져나와 왼쪽 subtitle과 겹쳤다(390px 폭, UI audit #6-A). min-w-0를 빼서 이
+                  그룹이 자기 컨텐츠의 min-content보다 작아지지 않게 하고, truncate가 적용된
+                  title 쪽(왼쪽 그룹)이 필요한 만큼 대신 줄어들게 한다. */}
+              <div className="flex flex-1 items-center justify-end gap-2 sm:gap-3">
                 <KubiSearchInput />
 
                 <button

--- a/src/features/publish/api/index.ts
+++ b/src/features/publish/api/index.ts
@@ -2,12 +2,14 @@
 import {
   ApiError,
   builderApi,
+  isRealBuilderEnabled,
   type PublishErrorCode,
   type PublishReadinessResponse,
   type PublishRequest,
   type PublishResponse,
   type PublishTarget,
 } from "@/shared/lib/builderApi";
+import { MOCK_PUBLISH_READINESS, mockPublishResult } from "./mockData";
 
 export type {
   PublishIssue,
@@ -28,20 +30,42 @@ export function validatePublishDestination(destination: string): string | undefi
   return undefined;
 }
 
-export function getPublishReadiness(
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw signal.reason ?? new DOMException("Aborted", "AbortError");
+}
+
+/**
+ * 다른 Builder 연동 엔드포인트(getDataset/listBuildStages 등, `features/datasets/api`)와
+ * 동일하게 mock/real을 분기한다 — 이전에는 이 분기가 없어 mock 모드에서도 항상 실제
+ * Builder 서버로 요청을 보냈고, 로컬/데모 환경(Builder 미기동)에서는 그 요청이 항상 실패해
+ * readiness 카드가 사실상 항상 비어 보였다(UI audit #4). Builder가 없는 mock run_id는
+ * 값을 지어내지 않고 404로 처리한다.
+ */
+export async function getPublishReadiness(
   runId: string,
   target: PublishTarget = "huggingface",
   signal?: AbortSignal,
 ): Promise<PublishReadinessResponse> {
-  return builderApi.getPublishReadiness(runId, target, signal);
+  if (isRealBuilderEnabled()) return builderApi.getPublishReadiness(runId, target, signal);
+  throwIfAborted(signal);
+  const mock = MOCK_PUBLISH_READINESS[runId];
+  if (!mock) throw new ApiError(404, "요청한 Run의 게시 준비 상태를 찾을 수 없습니다.");
+  return mock;
 }
 
-export function publishBuild(
+export async function publishBuild(
   runId: string,
   request: PublishRequest,
   signal?: AbortSignal,
 ): Promise<PublishResponse> {
-  return builderApi.publishBuild(runId, request, signal);
+  if (isRealBuilderEnabled()) return builderApi.publishBuild(runId, request, signal);
+  throwIfAborted(signal);
+  const readiness = MOCK_PUBLISH_READINESS[runId];
+  if (!readiness) throw new ApiError(404, "요청한 Run을 찾을 수 없습니다.");
+  if (!readiness.ready || readiness.blockers.length > 0) {
+    throw new ApiError(409, "게시 준비가 되지 않은 Run입니다.", { code: "publish_conflict" });
+  }
+  return mockPublishResult(runId, request.destination, request.options?.private ?? true);
 }
 
 export type PublishFailureKind = PublishErrorCode | "forbidden" | "not_found" | "network" | "invalid_request" | "readiness_changed" | "unknown";

--- a/src/features/publish/api/mockData.ts
+++ b/src/features/publish/api/mockData.ts
@@ -1,0 +1,97 @@
+/**
+ * Publish readiness/실행 결과의 결정적 mock 데이터 (UI audit #4).
+ *
+ * `getPublishReadiness`/`publishBuild`는 다른 모든 Builder 연동 엔드포인트(getDataset,
+ * listBuildStages, getBuildQuality 등, `src/features/datasets/api/index.ts` 참고)와 달리
+ * `isRealBuilderEnabled()` 분기가 없어 mock 모드에서도 항상 실제 네트워크 요청을 시도했다.
+ * 로컬/데모 환경에는 Builder 서버가 없으므로 요청이 실패해 readiness 카드가 항상
+ * loading→error(또는 실질적으로 빈 카드)로만 보였다 — 이 파일은 그 mock 스위치가 참조하는
+ * 결정적 fixture다. Builder readiness를 재계산하지 않고, 이미 알려진 mock run별로 실제
+ * Builder가 반환했을 값을 그대로 하드코딩한다(#246 원칙: 값을 새로 만들지 않는다).
+ */
+import type { PublishReadinessResponse, PublishResponse } from "@/shared/lib/builderApi";
+
+export const MOCK_PUBLISH_READINESS: Record<string, PublishReadinessResponse> = {
+  "air-quality-20260621": {
+    run_id: "air-quality-20260621",
+    target: "huggingface",
+    ready: true,
+    blockers: [],
+    warnings: [],
+  },
+  "dur-product-info-20260620": {
+    run_id: "dur-product-info-20260620",
+    target: "huggingface",
+    ready: true,
+    blockers: [],
+    warnings: [],
+  },
+  "dur-usjnt-taboo-20260620": {
+    run_id: "dur-usjnt-taboo-20260620",
+    target: "huggingface",
+    ready: true,
+    blockers: [],
+    warnings: [{ code: "license_unconfirmed", message: "원본 라이선스가 아직 확인되지 않았습니다." }],
+  },
+  "dur-pregnancy-taboo-20260621": {
+    run_id: "dur-pregnancy-taboo-20260621",
+    target: "huggingface",
+    ready: false,
+    blockers: [{ code: "run_not_completed", message: "이 run은 아직 실행 중입니다(running)." }],
+    warnings: [],
+  },
+  "dur-older-adult-caution-20260618": {
+    run_id: "dur-older-adult-caution-20260618",
+    target: "huggingface",
+    ready: false,
+    blockers: [{ code: "stage_failed", message: "Bronze stage가 실패해 Gold 산출물이 없습니다." }],
+    warnings: [],
+  },
+  "dur-dosage-caution-20260621": {
+    run_id: "dur-dosage-caution-20260621",
+    target: "huggingface",
+    ready: false,
+    blockers: [{ code: "run_not_started", message: "이 run은 아직 실행되지 않았습니다(queued)." }],
+    warnings: [],
+  },
+  "air-2026-08-14": {
+    run_id: "air-2026-08-14",
+    target: "huggingface",
+    ready: false,
+    blockers: [{ code: "partial_failure", message: "source kma__weather의 silver stage가 실패했습니다." }],
+    warnings: [],
+  },
+  "air-2026-08-13": {
+    run_id: "air-2026-08-13",
+    target: "huggingface",
+    ready: true,
+    blockers: [],
+    warnings: [],
+  },
+  "population-2026-08-13": {
+    run_id: "population-2026-08-13",
+    target: "huggingface",
+    ready: false,
+    blockers: [{ code: "gold_unavailable", message: "Gold export가 아직 계산되지 않았습니다(unavailable)." }],
+    warnings: [],
+  },
+  "transport-2026-08-12": {
+    run_id: "transport-2026-08-12",
+    target: "huggingface",
+    ready: true,
+    blockers: [],
+    warnings: [],
+  },
+};
+
+export function mockPublishResult(runId: string, destination: string, isPrivate: boolean): PublishResponse {
+  return {
+    run_id: runId,
+    target: "huggingface",
+    publisher: "kpubdata-builder (mock)",
+    destination,
+    reference: `https://huggingface.co/datasets/${destination}`,
+    artifact_count: 1,
+    status: isPrivate ? "published_private" : "published_public",
+  };
+}

--- a/src/pages/AddDataPage.tsx
+++ b/src/pages/AddDataPage.tsx
@@ -380,7 +380,13 @@ export function AddDataPage() {
   }, [job.status, job.run, navigate]);
 
   return (
-    <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+    // sticky bottom actions(이전/초안 저장/다음, 아래)는 sm 미만에서만 sticky이고, sticky로
+    // "고정"되는 동안에도 그 flow상 높이는 그대로 보존되어 뒤 이어지는 형제가 없어도 스크롤 중에는
+    // 화면에 떠서 마지막 content를 가릴 수 있다(390px 폭, UI audit #6-B) — 문서 전체 높이가
+    // 짧으면 마지막 필드/버튼이 그 sticky bar 뒤로 영영 가려질 수 있다. sm 미만에서만 sticky bar
+    // 높이(약 63px)보다 넉넉한 하단 여백을 둬서 항상 완전히 스크롤해서 벗어날 수 있게 한다 —
+    // sm 이상은 sticky가 static이 되므로(#6-B 대상 아님) 기존 desktop 여백을 그대로 유지한다.
+    <main className="flex flex-1 flex-col gap-6 px-5 pt-8 pb-28 sm:px-8 sm:pb-8 lg:px-10 lg:pt-10 lg:pb-10">
       <PageHeader
         eyebrow="Add Data"
         title="데이터 추가"

--- a/src/pages/BuildPublishPage.tsx
+++ b/src/pages/BuildPublishPage.tsx
@@ -141,7 +141,16 @@ export function BuildPublishPage() {
         {readiness.status === "error" ? <div className="mt-4" role="alert"><p className="text-sm text-red-700 dark:text-red-300">{readiness.message}</p></div> : null}
         {readiness.status === "loaded" ? (
           <div className="mt-4 space-y-4">
-            <p className="text-sm font-medium">{builderReady ? "Builder 게시 준비 완료" : "Builder blocker가 있어 게시할 수 없습니다."}</p>
+            <p className="text-sm font-medium">
+              {builderReady
+                ? "Builder 게시 준비 완료"
+                : readiness.data.blockers.length > 0
+                  ? "Builder blocker가 있어 게시할 수 없습니다."
+                  // ready: false인데 blockers가 비어 있으면("빈 카드") "blocker가 있다"고
+                  // 잘못 단정하지 않는다 — Builder가 사유를 제공하지 않은 것과 실제 blocker가
+                  // 있는 것은 다른 상태다(UI audit #4).
+                  : "Builder가 이 Run을 게시 준비되지 않음으로 판정했지만 구체적인 사유(blocker)를 제공하지 않았습니다."}
+            </p>
             {readiness.data.blockers.length > 0 ? <IssueList title="Blockers" issues={readiness.data.blockers} tone="error" /> : null}
             {readiness.data.warnings.length > 0 ? <IssueList title="Warnings" issues={readiness.data.warnings} tone="warning" /> : null}
             {readiness.data.blockers.some((issue) => issue.code === "credential_unavailable") ? <p className="text-xs text-muted-foreground">이 blocker는 source Provider credential이 아니라 Builder 서버의 Hugging Face publish credential을 뜻합니다. Studio는 token을 입력하거나 저장하지 않습니다.</p> : null}

--- a/src/pages/BuildRunPage.tsx
+++ b/src/pages/BuildRunPage.tsx
@@ -1,35 +1,47 @@
 /**
  * 빌드 실행 추적 페이지 (/builds/:buildId/run).
  *
- * 실행 상태 헤더, 단계별 진행률(Stepper), 로그 영역, 다음 행동을 보여준다(제안 §5.5).
- * 실제 진행 상태/로그는 #39 비동기 job 연동과 #29 API 연동 시 채운다.
+ * 이전에는 buildId와 무관하게 항상 "대기(queued)"·0번째 stepper를 보여주는 정적
+ * placeholder였다 — Builds 목록에서 running인 run을 열어도 이 화면은 항상 waiting으로
+ * 보여 같은 run이 화면마다 모순된 상태를 표시했다(UI audit #3). Builder는 stage별 세부
+ * 진행률/로그 API를 아직 제공하지 않으므로, 있지도 않은 진행률을 재현하는 대신 Builds
+ * 목록/상세(BuildsPage)와 동일한 canonical 상태(historical summary + live job polling)만
+ * 보여주고, 지원되지 않는 부분은 "상세 진행 정보 미지원"으로 명확히 구분한다.
  */
 import { useParams } from "react-router-dom";
-import { Button, Card, EmptyState, LinkButton, PageHeader, StatusBadge, Stepper } from "@/shared/ui";
-
-const RUN_STEPS = [
-  { id: "queued", label: "대기" },
-  { id: "fetching", label: "수집" },
-  { id: "normalizing", label: "정규화" },
-  { id: "exporting", label: "내보내기" },
-  { id: "uploading", label: "업로드" },
-  { id: "completed", label: "완료" },
-];
+import { useSelectedRunPolling } from "@/features/runs/useSelectedRunPolling";
+import { useBuild } from "@/features/runs/useBuild";
+import { isRealBuilderEnabled } from "@/shared/lib/builderApi";
+import type { BuildRunStatus } from "@/shared/lib/types";
+import { Button, Card, EmptyState, LinkButton, PageHeader, Skeleton, StatusBadge } from "@/shared/ui";
 
 /**
- * 빌드 실행 진행 상태와 로그를 추적하는 페이지.
+ * 빌드 실행의 canonical 상태를 추적하는 페이지.
  *
- * @returns 실행 추적 화면.
+ * @returns 실행 상태 화면.
  */
 export function BuildRunPage() {
   const { buildId = "" } = useParams();
+
+  // historical: Builds 목록/편집과 같은 getBuild() 조회(mock 모드는 결정적 mock, 실연동은
+  // Builder 이력 + Studio가 보관한 스펙).
+  const { build, isLoading: historicalLoading, error: historicalError } = useBuild(buildId);
+
+  // live: registry에 살아있는 job이 있으면(#245/#255) 그 상태가 가장 최신이다 — Builds
+  // 상세(BuildsPage)와 동일한 hook을 재사용해 두 화면이 같은 canonical run state를 쓰게 한다.
+  // mock 모드는 getBuildJob이 항상 실패하는 stub이라(#255 §3 주석 참고) live polling 자체를
+  // 켜지 않고, 위 historical(deterministic mock) 상태를 그대로 신뢰한다.
+  const live = useSelectedRunPolling(isRealBuilderEnabled() ? buildId || null : null);
+
+  const runStatus: BuildRunStatus | undefined =
+    live.kind === "job" ? live.job.status : build?.status;
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
       <PageHeader
         eyebrow="실행"
         title={`${buildId || "빌드"} 실행`}
-        description="빌드 실행 단계와 진행 상태를 실시간으로 추적합니다."
+        description="Builds 목록/상세와 동일한 run 상태를 보여줍니다."
         actions={
           <Button variant="secondary" disabled>
             취소
@@ -39,24 +51,41 @@ export function BuildRunPage() {
 
       <Card className="flex flex-wrap items-center gap-3">
         <span className="text-sm text-muted-foreground">상태</span>
-        <StatusBadge status="queued" />
-      </Card>
-
-      <Card>
-        <p className="mb-4 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
-          진행 단계
-        </p>
-        <Stepper steps={RUN_STEPS} current={0} />
+        {historicalLoading && live.kind !== "job" ? (
+          <Skeleton className="h-6 w-20" />
+        ) : runStatus ? (
+          <StatusBadge status={runStatus} />
+        ) : (
+          <span className="text-xs text-muted-foreground">
+            {historicalError ?? "상태 불명"}
+          </span>
+        )}
+        {live.kind === "job" && (live.job.status === "queued" || live.job.status === "running" || live.job.status === "cancelling") ? (
+          <span className="text-xs text-muted-foreground">실시간 갱신 중…</span>
+        ) : null}
+        {live.kind === "error" ? (
+          <span className="text-xs text-amber-700 dark:text-amber-400">
+            실시간 상태 갱신 실패(일시적) — 마지막으로 확인된 상태를 유지합니다.
+          </span>
+        ) : null}
+        {live.kind === "permission_denied" ? (
+          <span className="text-xs text-red-700 dark:text-red-400">
+            이 Run의 실시간 상태를 조회할 권한이 없습니다 — 마지막으로 확인된 상태를 대신 표시합니다.
+          </span>
+        ) : null}
       </Card>
 
       <Card variant="dashed" className="p-0">
         <EmptyState
-          title="실행 로그가 아직 없습니다"
-          description="실행을 시작하면 수집·정규화·내보내기 로그가 여기에 표시됩니다. 비동기 실행 연동은 #39에서 진행됩니다."
+          title="상세 진행 정보 미지원"
+          description="Builder는 이 화면에서 stage별 세부 진행률·실행 로그 API를 아직 제공하지 않습니다(#39). 위 상태 배지가 이 run의 canonical 상태이며, stage별 진행(Bronze/Silver/Gold)은 Build 상세의 Pipeline / Stage Progress에서 확인할 수 있습니다."
         />
       </Card>
 
       <div className="flex flex-wrap gap-3">
+        <LinkButton variant="secondary" to={`/builds?run=${encodeURIComponent(buildId)}`}>
+          Build 상세 보기
+        </LinkButton>
         <LinkButton variant="secondary" to={`/builds/${buildId}/artifacts`}>
           결과물 보기
         </LinkButton>

--- a/src/pages/DatasetDetailPage.tsx
+++ b/src/pages/DatasetDetailPage.tsx
@@ -157,6 +157,26 @@ export function DatasetDetailPage() {
   const selectedQualityResults = qualityResultsForSource(qualityState.data, selectedSource);
   const selectedDrift = qualityState.data?.schema_drift[selectedSource] ?? [];
 
+  // Run 전체 상태("ok"/"failed"/"cancelled")와 선택된 source·stage 상태("completed"/"failed"/
+  // "not_run"/"unavailable")는 서로 다른 vocabulary를 쓰는 별개 scope다 — 한 run에 여러 source가
+  // 있으면 선택된 source의 stage는 completed/PASS인데 run 전체는 다른 source의 실패로 failed일 수
+  // 있다. 이는 모순이 아니라 두 canonical source가 서로 다른 것을 나타내는 것이므로, 값을 숨기거나
+  // 억지로 맞추는 대신 두 상태가 갈릴 수 있는 이유를 실제 데이터(다른 source의 stage 실패)로
+  // 설명한다.
+  const otherFailingSources = useMemo(
+    () =>
+      sourceEntries
+        .filter((source) => source.source_key !== selectedSource)
+        .filter((source) => DATASET_STAGES.some((stage) => source[stage].status === "failed"))
+        .map((source) => source.source_key),
+    [sourceEntries, selectedSource],
+  );
+  const runStatus = selectedRun?.status ?? core.dataset?.status;
+  const runFailedButSelectedStageOk =
+    runStatus === "failed" &&
+    sourceStageEntry?.[selectedStage].status === "completed" &&
+    otherFailingSources.length > 0;
+
   const summaryRowCount = useMemo(() => {
     const detail = stageDetailState.data;
     if (detail?.stage === "bronze") return detail.record_count;
@@ -187,17 +207,28 @@ export function DatasetDetailPage() {
         eyebrow="Dataset"
         title={core.dataset.title}
         description={<><span className="block font-mono text-xs">{core.dataset.dataset_id}</span><span className="mt-1 block">{core.dataset.sources.map((source) => source.provider).join(", ")} · {selectedSource || "source 불러오는 중"} · Build {selectedRunId}{selectedRunId === core.dataset.latest_run_id ? " (latest)" : ""}</span></>}
-        actions={<><span className="inline-flex items-center gap-2 rounded-full bg-accent-subtle px-3 py-1 text-xs font-semibold capitalize text-accent-subtle-foreground"><span>{selectedStage}</span><span className="font-normal">{sourceStageEntry?.[selectedStage].status ?? "unavailable"}</span></span><QualityBadge status={validation} /><LinkButton size="sm" to={`/builds/${encodeURIComponent(selectedRunId)}/publish?dataset=${encodeURIComponent(core.dataset.dataset_id)}`}>이 Run 게시</LinkButton></>}
+        actions={<><span title={`선택된 source(${selectedSource || "—"})의 ${selectedStage} stage 상태`} className="inline-flex items-center gap-2 rounded-full bg-accent-subtle px-3 py-1 text-xs font-semibold capitalize text-accent-subtle-foreground"><span>{selectedStage}</span><span className="font-normal">{sourceStageEntry?.[selectedStage].status ?? "unavailable"}</span></span><QualityBadge status={validation} /><LinkButton size="sm" to={`/builds/${encodeURIComponent(selectedRunId)}/publish?dataset=${encodeURIComponent(core.dataset.dataset_id)}`}>이 Run 게시</LinkButton></>}
       />
 
       <Card className="flex flex-wrap items-end gap-3 p-3">
         <label className="min-w-52 flex-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Run<select aria-label="Run 선택" className={`mt-1 w-full ${selectClassName}`} value={selectedRunId} onChange={(event) => updateContext({ run: event.target.value === core.dataset?.latest_run_id ? null : event.target.value, source: null, stage: null })}>{core.runs.map((run) => <option key={run.run_id} value={run.run_id}>{run.run_id}{run.run_id === core.dataset?.latest_run_id ? " (latest)" : ""}</option>)}</select></label>
         <label className="min-w-52 flex-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Source<select aria-label="Source 선택" className={`mt-1 w-full ${selectClassName}`} value={selectedSource} disabled={stagesState.status !== "loaded"} onChange={(event) => updateContext({ source: event.target.value, stage: null })}>{invalidSource && requestedSource ? <option value={requestedSource}>{requestedSource} (존재하지 않는 source)</option> : null}{sourceEntries.map((source) => <option key={source.source_key} value={source.source_key}>{source.source_key}</option>)}</select></label>
         <label className="min-w-44 flex-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Stage<select aria-label="Stage 선택" className={`mt-1 w-full ${selectClassName}`} value={selectedStage} disabled={!sourceStageEntry} onChange={(event) => updateContext({ stage: event.target.value })}>{DATASET_STAGES.map((stageName) => <option key={stageName} value={stageName}>{stageName} · {sourceStageEntry?.[stageName].status ?? "unavailable"}</option>)}</select></label>
-        <div className="flex min-h-9 items-center gap-2 px-2 text-xs text-muted-foreground"><span>Status</span><strong className="text-foreground">{selectedRun?.status ?? core.dataset.status}</strong></div>
+        <div title="선택된 source/stage가 아니라 이 run 전체(모든 source)의 결과입니다" className="flex min-h-9 items-center gap-2 px-2 text-xs text-muted-foreground"><span>Run 상태</span><strong className="text-foreground">{runStatus}</strong></div>
       </Card>
 
       {stagesState.status === "error" ? <Card variant="error" role="alert">{stagesState.error}</Card> : invalidSource ? <Card variant="error" role="alert">URL의 source `{requestedSource}`는 선택한 run에 존재하지 않습니다.</Card> : null}
+      {runFailedButSelectedStageOk ? (
+        <Card variant="error" role="alert">
+          <p className="font-semibold">Run 상태는 failed이지만 선택한 source의 {selectedStage} stage는 completed입니다.</p>
+          <p className="mt-1 text-sm">
+            이 run에 포함된 다른 source(
+            {otherFailingSources.join(", ")}
+            )에서 stage 실패가 있어 run 전체 상태가 failed로 집계되었습니다. 모순이 아니라 run과
+            source/stage의 상태 범위가 다릅니다.
+          </p>
+        </Card>
+      ) : null}
 
       <div className="border-b border-border" role="tablist" aria-label="Dataset detail tabs">
         <div className="flex gap-1 overflow-x-auto">
@@ -207,11 +238,15 @@ export function DatasetDetailPage() {
               type="button"
               role="tab"
               aria-selected={selectedTab === tab.id}
-              // AI 탭은 Kubi(KubiContent)가 route의 ?stage=로만 stage를 판단한다(추측 금지 원칙,
-              // context.ts 참고) — 그래서 여기서 화면에 이미 계산되어 보이는 selectedStage를
-              // URL에 명시적으로 반영해줘야, 처음 AI 탭을 열었을 때도 Generated SQL/Result
-              // Preview가 비어 보이지 않는다.
-              onClick={() => updateContext(tab.id === "ai" ? { tab: "ai", stage: selectedStage } : { tab: tab.id === "overview" ? null : tab.id })}
+              // AI 탭은 Kubi(KubiContent)가 route의 ?run=&stage=로만 문맥을 판단한다(추측 금지
+              // 원칙, context.ts 참고) — 그래서 여기서 화면에 이미 계산되어 보이는
+              // selectedRunId/selectedStage를 URL에 명시적으로 반영해줘야, 처음 AI 탭을 열었을
+              // 때도 Kubi RUN context bar가 실제로는 알고 있는 latest run을 "—"로 보여주거나
+              // Generated SQL/Result Preview가 비어 보이지 않는다(UI audit #5). latest run이라
+              // ?run=이 URL에 없을 수도 있으므로(다른 select onChange와 동일 관례) 값을 항상
+              // 명시적으로 채운다 — 없는 값을 지어내는 게 아니라 이미 화면에 보이는 값을 그대로
+              // 전달하는 것이다.
+              onClick={() => updateContext(tab.id === "ai" ? { tab: "ai", run: selectedRunId, stage: selectedStage } : { tab: tab.id === "overview" ? null : tab.id })}
               className={`whitespace-nowrap border-b-2 px-4 py-3 text-sm font-medium ${selectedTab === tab.id ? "border-accent text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"}`}
             >
               {tab.label}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -142,7 +142,7 @@ function NewUserHome() {
           <p className="mt-3 text-muted-foreground">
             Public API, 파일, URL에서 데이터를 직접 가져와 빌드하세요
           </p>
-          <LinkButton className="mt-6" variant="secondary" to="/add-data">
+          <LinkButton className="mt-6" variant="secondary" to="/add">
             데이터 추가하기
           </LinkButton>
         </Card>


### PR DESCRIPTION
## Summary

Studio 주요 화면에서 확인된 상태 불일치, mock/real 분기 누락,
responsive UI 문제를 정리합니다.

- Home의 잘못된 `/add-data` 진입 경로를 canonical `/add`로 수정했습니다.
- Dataset Detail에서 전체 Run 상태와 선택된 Source/Stage 상태를 명확히 분리했습니다.
- Dataset Detail의 Kubi AI 탭에 실제 latest-run 문맥이 전달되도록 보완했습니다.
- Build Run 화면의 hardcoded 대기/가짜 progress placeholder를 제거하고 실제 canonical run 상태를 표시합니다.
- Builder가 stage progress를 제공하지 않는 경우 임의 단계를 만들지 않고 `상세 진행 정보 미지원`으로 표시합니다.
- Build Publish의 mock/real API 분기를 보완하고 deterministic mock readiness를 추가했습니다.
- `ready=false`지만 blocker가 없는 경우 존재하지 않는 blocker를 단정하지 않도록 수정했습니다.
- 390px viewport에서 topbar overlap과 Add Data sticky footer content 가림을 수정했습니다.

## Scope safeguards

- Builder API contract를 변경하지 않았습니다.
- Builder가 제공하지 않는 stage progress/status를 새로 만들지 않았습니다.
- Add Data Preview/Diff semantics는 변경하지 않았습니다.
- Kubi action/approval semantics는 변경하지 않았습니다.

## Validation

- lint — PASS
- typecheck — PASS
- build — PASS
- Playwright E2E — 38/38 PASS
- 관련 unit/regression tests — PASS