### PR TITLE
feat: polish onboarding, Data Passport, and auth states (#314 재머지)

### DIFF
--- a/__tests__/HomePage.test.tsx
+++ b/__tests__/HomePage.test.tsx
@@ -1,11 +1,36 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAssistConfig } from "@/features/assistant/config";
+import { SUGGESTED_QUESTIONS } from "@/features/kubi/suggestedQuestions";
+import { useKubiStore } from "@/features/kubi/useKubiSession";
 import { HomePage } from "@/pages/HomePage";
+import { useUIStore } from "@/shared/hooks/useUIStore";
 import { mswServer } from "../vitest.setup";
 
 const BUILDER_BASE = "http://localhost:8000";
+
+function mockEmptyBuilds() {
+  mswServer.use(http.get(`${BUILDER_BASE}/builds`, () => HttpResponse.json({ builds: [] })));
+}
+
+/**
+ * mock 모드(`VITE_USE_REAL_BUILDER` 미설정)의 `listBuilds()`는 결정적 데모 데이터
+ * (DEMO_DATASETS, 항상 succeeded 빌드 포함)를 반환하고 msw를 아예 거치지 않는다
+ * (features/runs/api/index.ts) — 그래서 신규 사용자(빌드 0개) 상태를 결정적으로 재현하려면
+ * 실제 Builder 연동 모드로 전환해 `/builds` 응답 자체를 msw로 통제해야 한다.
+ */
+function useEmptyBuildsRealMode() {
+  vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+  mockEmptyBuilds();
+}
+
+function configureKey() {
+  act(() => {
+    useAssistConfig.getState().setConfig({ apiKey: "sk-test-key", model: "gpt-4o-mini", baseUrl: "" });
+  });
+}
 
 describe("HomePage", () => {
   it("renders the existing-user dashboard heading and KPI summary once builds load (#248)", async () => {
@@ -56,5 +81,104 @@ describe("HomePage", () => {
 
     const cta = await screen.findByRole("link", { name: "데이터 추가하기" });
     expect(cta).toHaveAttribute("href", "/add");
+  });
+});
+
+const HERO_HEADING = "Kubi에게 필요한 데이터를 물어보세요";
+
+describe("Home Kubi Hero (#Phase2 UI polish)", () => {
+  beforeEach(() => {
+    useKubiStore.setState({ turns: [], onboarded: false, pendingSeed: null });
+    useAssistConfig.getState().clear();
+    act(() => useUIStore.setState({ isKubiDrawerOpen: false }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    localStorage.clear();
+  });
+
+  it("shows the Kubi hero only for a new user (no builds/datasets), not on the existing-user dashboard", async () => {
+    // 기존 사용자(데모 빌드 이력 존재) — ExistingUserHome에는 Hero가 중복 노출되지 않는다.
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+    await screen.findByRole("heading", { name: "작업 현황을 한눈에 확인하세요" });
+    expect(screen.queryByRole("heading", { name: HERO_HEADING })).not.toBeInTheDocument();
+  });
+
+  it("shows exactly one Kubi hero for a new user (empty builds/datasets)", async () => {
+    useEmptyBuildsRealMode();
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+    expect(await screen.findAllByRole("heading", { name: HERO_HEADING })).toHaveLength(1);
+  });
+
+  it("configured: submitting a question seeds it into the shared Kubi store and opens the drawer", async () => {
+    useEmptyBuildsRealMode();
+    configureKey();
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+    const input = await screen.findByLabelText("Kubi에게 자연어로 데이터 물어보기");
+    fireEvent.change(input, { target: { value: "서울 대기오염 데이터로 뭘 할 수 있어?" } });
+    fireEvent.submit(input.closest("form")!);
+
+    expect(useKubiStore.getState().pendingSeed).toBe("서울 대기오염 데이터로 뭘 할 수 있어?");
+    expect(useUIStore.getState().isKubiDrawerOpen).toBe(true);
+  });
+
+  it("not configured: submitting opens the drawer but does not seed a question or create a no_key turn", async () => {
+    useEmptyBuildsRealMode();
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+    const input = await screen.findByLabelText("Kubi에게 자연어로 데이터 물어보기");
+    fireEvent.change(input, { target: { value: "서울 대기오염 데이터로 뭘 할 수 있어?" } });
+    fireEvent.submit(input.closest("form")!);
+
+    expect(useUIStore.getState().isKubiDrawerOpen).toBe(true);
+    expect(useKubiStore.getState().pendingSeed).toBeNull();
+    expect(useKubiStore.getState().turns).toHaveLength(0);
+  });
+
+  it("configured: clicking a suggested-question chip seeds that shared question and opens the drawer", async () => {
+    useEmptyBuildsRealMode();
+    configureKey();
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+    const chip = await screen.findByRole("button", { name: SUGGESTED_QUESTIONS[0] });
+    fireEvent.click(chip);
+
+    expect(useKubiStore.getState().pendingSeed).toBe(SUGGESTED_QUESTIONS[0]);
+    expect(useUIStore.getState().isKubiDrawerOpen).toBe(true);
+  });
+
+  it("empty/whitespace query: does not seed a question or create a turn", async () => {
+    useEmptyBuildsRealMode();
+    configureKey();
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+    const input = await screen.findByLabelText("Kubi에게 자연어로 데이터 물어보기");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.submit(input.closest("form")!);
+
+    expect(useKubiStore.getState().pendingSeed).toBeNull();
+    expect(useKubiStore.getState().turns).toHaveLength(0);
   });
 });

--- a/__tests__/LoginPage.test.tsx
+++ b/__tests__/LoginPage.test.tsx
@@ -1,6 +1,7 @@
 /**
- * LoginPage (#263) — 이메일/비밀번호 입력, 로그인 버튼, 계정 만들기 링크, 실패 메시지를
- * 확인한다.
+ * LoginPage (#263 → #Phase2 UI polish) — 이메일/비밀번호 입력, 로그인 버튼, 계정 발급 안내
+ * 링크, 실패 메시지를 확인한다. mock/demo 환경(`VITE_USE_REAL_BUILDER` 미설정)을 가정한다 —
+ * 이때만 mock 폼이 보인다(LoginPage.tsx 주석 참고).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -29,12 +30,12 @@ afterEach(() => {
 });
 
 describe("LoginPage", () => {
-  it("renders email/password inputs, a login button, and a link to create an account", () => {
+  it("renders email/password inputs, a login button, and a link to the account-provisioning notice", () => {
     renderLogin();
     expect(screen.getByLabelText("이메일", { exact: false })).toBeInTheDocument();
     expect(screen.getByLabelText("비밀번호", { exact: false })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "로그인" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "계정 만들기" })).toHaveAttribute("href", "/signup");
+    expect(screen.getByRole("link", { name: "계정 발급 안내" })).toHaveAttribute("href", "/signup");
   });
 
   it("on success, sets the session and navigates home — the password never reaches the store", async () => {

--- a/__tests__/SignupPage.test.tsx
+++ b/__tests__/SignupPage.test.tsx
@@ -1,12 +1,12 @@
 /**
- * SignupPage (#263) — 이름/이메일/비밀번호, 개인 vs 팀·기관 선택, 기관/팀명(optional),
- * 계정 만들기 버튼, 로그인 링크, email verification 안내를 확인한다.
+ * SignupPage (#263 → #Phase2 UI polish) — ADR 0015 §5(public signup 기본 OFF)에 맞춰
+ * 자체 회원가입 폼 대신 계정 발급 안내 화면으로 바뀌었다. 폼/email verification 관련
+ * 이전 테스트는 더 이상 유효하지 않다 — 안내 화면과 로그인 링크만 확인한다.
  */
-import { afterEach, describe, expect, it } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { SignupPage } from "@/pages/SignupPage";
-import { useAuthStore } from "@/features/auth/store";
 
 function renderSignup() {
   return render(
@@ -16,44 +16,13 @@ function renderSignup() {
   );
 }
 
-afterEach(() => {
-  useAuthStore.getState().clear();
-});
-
 describe("SignupPage", () => {
-  it("renders name/email/password, account type choice, and a link back to login", () => {
+  it("does not offer a self-serve signup form — shows a policy notice and a link back to login", () => {
     renderSignup();
-    expect(screen.getByLabelText("이름", { exact: false })).toBeInTheDocument();
-    expect(screen.getByLabelText("이메일", { exact: false })).toBeInTheDocument();
-    expect(screen.getByLabelText("비밀번호", { exact: false })).toBeInTheDocument();
-    expect(screen.getByLabelText("개인")).toBeChecked();
-    expect(screen.getByLabelText("팀 · 기관")).not.toBeChecked();
-    expect(screen.getByRole("button", { name: "계정 만들기" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "로그인" })).toHaveAttribute("href", "/login");
-  });
-
-  it("does not show the organization name field until 팀 · 기관 is selected (it is optional)", () => {
-    renderSignup();
-    expect(screen.queryByLabelText("기관/팀명")).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByLabelText("팀 · 기관"));
-    expect(screen.getByLabelText("기관/팀명")).toBeInTheDocument();
-  });
-
-  it("on submit, does not sign the user in yet — it shows an email verification notice instead", async () => {
-    renderSignup();
-    fireEvent.change(screen.getByLabelText("이름", { exact: false }), { target: { value: "홍길동" } });
-    fireEvent.change(screen.getByLabelText("이메일", { exact: false }), { target: { value: "new@example.com" } });
-    fireEvent.change(screen.getByLabelText("비밀번호", { exact: false }), { target: { value: "hunter2" } });
-    fireEvent.click(screen.getByRole("button", { name: "계정 만들기" }));
-
-    expect(await screen.findByRole("heading", { name: "이메일을 확인해주세요" })).toBeInTheDocument();
-    expect(screen.getByText("new@example.com", { exact: false })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "계정 발급 안내" })).toBeInTheDocument();
+    expect(screen.getByText("공개 회원가입을 제공하지 않습니다", { exact: false })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "계정 만들기" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("이메일", { exact: false })).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "로그인하러 가기" })).toHaveAttribute("href", "/login");
-
-    // 이메일 인증 전이므로 아직 로그인 세션을 만들지 않는다.
-    expect(useAuthStore.getState().token).toBeNull();
-    // password는 어디에도 남지 않는다.
-    expect(document.body.innerHTML).not.toMatch(/hunter2/);
   });
 });

--- a/__tests__/datasetDetail.test.tsx
+++ b/__tests__/datasetDetail.test.tsx
@@ -188,3 +188,81 @@ describe("Dataset Detail P0 (#253)", () => {
     expect(within(panel).getByText("123")).toBeInTheDocument();
   });
 });
+
+async function findPassport() {
+  const heading = await screen.findByRole("heading", { name: "Data Passport" });
+  return heading.closest("[class*='rounded-xl']") as HTMLElement;
+}
+
+describe("Data Passport (#Phase2 UI polish)", () => {
+  it("shows Provider/Source, dataset identity, run status, selected source·stage status, quality, schema, spec digest and artifact from the fetched fixture", async () => {
+    renderDetail();
+    await waitFor(() => expect(screen.getByRole("button", { name: /gold completed/ })).toHaveAttribute("aria-pressed", "true"));
+
+    const passport = await findPassport();
+    expect(within(passport).getByText("data.go.kr.air, kma.weather")).toBeInTheDocument();
+    expect(within(passport).getByText("대기질 통합 데이터")).toBeInTheDocument();
+    expect(within(passport).getByText("air-quality")).toBeInTheDocument();
+    expect(within(passport).getByText("sha256:air14")).toBeInTheDocument();
+    // Schema/Artifact는 selected stage detail의 별도 비동기 조회(getBuildStageDetail) 결과라 좀 더 늦게 반영된다.
+    expect(await within(passport).findByText("2 columns")).toBeInTheDocument();
+    expect(await within(passport).findByText("parquet")).toBeInTheDocument();
+    expect(within(passport).getByText("PASS")).toBeInTheDocument();
+  });
+
+  it("labels run-level status and selected source/stage status separately, without collapsing them into one generic status (audit #2)", async () => {
+    renderDetail();
+    await waitFor(() => expect(screen.getByRole("button", { name: /gold completed/ })).toHaveAttribute("aria-pressed", "true"));
+
+    const passport = await findPassport();
+    const runRow = within(passport).getByText("Run 상태(전체)").closest("div")!;
+    expect(runRow).toHaveTextContent("failed");
+
+    const stageRow = within(passport).getByText("선택된 Source·Stage 상태").closest("div")!;
+    expect(within(stageRow).getByText("completed")).toBeInTheDocument();
+    // 같은 값으로 뭉개지지 않는다 — run은 failed, 선택된 stage는 completed.
+    expect(within(stageRow).queryByText("failed")).not.toBeInTheDocument();
+  });
+
+  it("labels the spec value as a digest/fingerprint, not a version string", async () => {
+    renderDetail();
+    const passport = await findPassport();
+    expect(await within(passport).findByText("sha256:air14")).toBeInTheDocument();
+    expect(within(passport).getByText("BuildSpec digest")).toBeInTheDocument();
+    expect(within(passport).queryByText(/^v\d/)).not.toBeInTheDocument();
+  });
+
+  it("does not crash and uses the defined fallback ('확인 불가') for a run with no spec digest, instead of inventing one", async () => {
+    renderDetail("/datasets/population");
+    await screen.findByLabelText("Run 선택");
+    const passport = await findPassport();
+    const digestRow = within(passport).getByText("BuildSpec digest").closest("div")!;
+    expect(within(digestRow).getByText("확인 불가")).toBeInTheDocument();
+  });
+
+  it("shows the defined '제공되지 않음' fallback for schema when the selected stage carries no schema (bronze), without crashing", async () => {
+    renderDetail("/datasets/air-quality?stage=bronze");
+    await screen.findByLabelText("Run 선택");
+    const passport = await findPassport();
+    const schemaRow = within(passport).getByText("Schema").closest("div")!;
+    expect(await within(schemaRow).findByText("제공되지 않음")).toBeInTheDocument();
+  });
+
+  it("does not present fields absent from the schema, like license/freshness/verified score", async () => {
+    renderDetail();
+    const passport = await findPassport();
+    expect(within(passport).queryByText(/license/i)).not.toBeInTheDocument();
+    expect(within(passport).queryByText(/freshness/i)).not.toBeInTheDocument();
+    expect(within(passport).queryByText(/verified/i)).not.toBeInTheDocument();
+    expect(within(passport).queryByText(/인증/)).not.toBeInTheDocument();
+  });
+
+  it("navigates to the AI tab from the Passport's Kubi entry point", async () => {
+    renderDetail();
+    const passport = await findPassport();
+    fireEvent.click(within(passport).getByRole("button", { name: /Kubi가 이 dataset의 BuildSpec 수정안을 제안할 수 있습니다/ }));
+
+    const panel = await screen.findByRole("tabpanel", { name: "AI" });
+    expect(within(panel).getByText("air-quality")).toBeInTheDocument();
+  });
+});

--- a/__tests__/kubiPatchBuildspecBadge.test.tsx
+++ b/__tests__/kubiPatchBuildspecBadge.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * PATCH_BUILDSPEC "BuildSpec 변경 제안" type badge 테스트 (Phase 2 UI polish).
+ *
+ * ActionCard(KubiContent.tsx)에 badge를 추가한 변경이 (1) PATCH_BUILDSPEC에만 표시되고 다른
+ * action type에는 새지 않는지, (2) 기존 승인(pending_approval → approve → preview/SpecDiff →
+ * confirm) semantics를 그대로 유지하는지 확인한다. approve/preview/confirm 로직 자체는 이미
+ * `kubiSession.test.tsx`(#256 리뷰 §10)가 hook 레벨에서 충분히 검증하므로, 여기서는 그 흐름을
+ * 실제 DOM(KubiPage)에서 재확인하며 badge assertion만 추가한다.
+ */
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAssistConfig } from "@/features/assistant/config";
+import { createProvider } from "@/features/assistant/provider";
+import { saveBuildSpec } from "@/features/build-spec/specStore";
+import type { BuildSpec } from "@/shared/lib/types";
+import { useKubiStore } from "@/features/kubi/useKubiSession";
+import { KubiPage } from "@/pages/KubiPage";
+
+vi.mock("@/features/assistant/provider", () => ({
+  createProvider: vi.fn(),
+}));
+
+const BADGE_TEXT = "BuildSpec 변경 제안";
+
+const SPEC: BuildSpec = {
+  datasetId: "air-quality",
+  title: "대기질",
+  description: "설명",
+  sources: [{ provider: "data.go.kr", dataset: "air", params: { region: "서울" } }],
+  exports: [{ format: "jsonl" }],
+  metadata: { note: "orig" },
+};
+
+function jsonText(payload: unknown): AsyncIterable<string> {
+  return (async function* () {
+    yield "```json\n" + JSON.stringify(payload) + "\n```";
+  })();
+}
+
+function mockStream(stream: (messages: unknown, signal?: AbortSignal) => AsyncIterable<string>) {
+  vi.mocked(createProvider).mockReturnValue({
+    isConfigured: true,
+    stream,
+  } as unknown as ReturnType<typeof createProvider>);
+}
+
+function configureKey() {
+  act(() => {
+    useAssistConfig.getState().setConfig({ apiKey: "sk-test-key", model: "gpt-4o-mini", baseUrl: "" });
+  });
+}
+
+function renderKubiPage() {
+  render(
+    <MemoryRouter initialEntries={["/datasets/air-quality?run=air-2026-08-14"]}>
+      <KubiPage />
+    </MemoryRouter>,
+  );
+}
+
+function ask(question: string) {
+  fireEvent.change(screen.getByLabelText("Kubi에게 질문하기"), { target: { value: question } });
+  fireEvent.submit(screen.getByLabelText("Kubi에게 질문하기").closest("form")!);
+}
+
+beforeEach(() => {
+  useKubiStore.setState({ turns: [], onboarded: false, pendingSeed: null });
+  useAssistConfig.getState().clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe("Kubi PATCH_BUILDSPEC badge (#Phase2 UI polish)", () => {
+  it("shows the 'BuildSpec 변경 제안' badge only on the PATCH_BUILDSPEC action card", async () => {
+    saveBuildSpec("air-2026-08-14", SPEC);
+    configureKey();
+    mockStream(() =>
+      jsonText({
+        answer: "확인했습니다.",
+        evidenceRefs: [],
+        generatedSql: null,
+        suggestedActions: [
+          {
+            type: "PATCH_BUILDSPEC",
+            runId: "air-2026-08-14",
+            patch: [{ op: "replace", path: "/metadata/note", value: "kubi-updated" }],
+            reason: "Kubi 분석 참고",
+          },
+          { type: "OPEN_BUILD", runId: "air-2026-08-14", reason: "실패 원인을 확인하세요" },
+          { type: "ADD_REPORT_BLOCK", note: "참고 노트", reason: "품질 이슈 참고용" },
+        ],
+      }),
+    );
+    renderKubiPage();
+    ask("이 run에 대해 알려줘");
+
+    // 세 action card가 모두 뜰 때까지 기다린다(승인 버튼 두 개 + PATCH_BUILDSPEC 승인 버튼).
+    const approveButtons = await screen.findAllByRole("button", { name: "승인" });
+    expect(approveButtons).toHaveLength(3);
+
+    // badge는 정확히 한 번, PATCH_BUILDSPEC action card 안에만 나타난다.
+    expect(screen.getAllByText(BADGE_TEXT)).toHaveLength(1);
+
+    const patchCard = screen.getByText(/BuildSpec에 1건 변경 제안/).closest("div")!;
+    expect(within(patchCard).getByText(BADGE_TEXT)).toBeInTheDocument();
+
+    const openBuildCard = screen.getByText(/Build "air-2026-08-14" 상세 열기/).closest("div")!;
+    expect(within(openBuildCard).queryByText(BADGE_TEXT)).not.toBeInTheDocument();
+
+    const reportCard = screen.getByText("Report 참고 노트로 추가").closest("div")!;
+    expect(within(reportCard).queryByText(BADGE_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("badge 표시가 pending_approval → approve → preview/SpecDiff → confirm 흐름을 바꾸지 않는다", async () => {
+    saveBuildSpec("air-2026-08-14", SPEC);
+    configureKey();
+    mockStream(() =>
+      jsonText({
+        answer: "metadata에 참고 노트를 추가하는 patch를 제안합니다.",
+        evidenceRefs: [],
+        generatedSql: null,
+        suggestedActions: [
+          {
+            type: "PATCH_BUILDSPEC",
+            runId: "air-2026-08-14",
+            patch: [{ op: "replace", path: "/metadata/note", value: "kubi-updated" }],
+            reason: "Kubi 분석 참고",
+          },
+        ],
+      }),
+    );
+    renderKubiPage();
+    ask("metadata에 노트 추가해줘");
+
+    // pending_approval: badge와 승인 버튼이 함께 보이고, 아직 diff는 보이지 않는다.
+    expect(await screen.findByText(BADGE_TEXT)).toBeInTheDocument();
+    const approveButton = screen.getByRole("button", { name: "승인" });
+    expect(screen.queryByText("metadata.note")).not.toBeInTheDocument();
+
+    // approve → SpecDiff 미리보기가 뜬다(적용 전). diff 값은 "orig → kubi-updated"처럼 여러 text
+    // node로 쪼개져 렌더되므로, 바뀐 경로(metadata.note) 행 전체의 textContent로 확인한다.
+    fireEvent.click(approveButton);
+    const diffRow = (await screen.findByText("metadata.note")).closest("li")!;
+    expect(diffRow).toHaveTextContent("kubi-updated");
+    expect(screen.getByText(BADGE_TEXT)).toBeInTheDocument();
+
+    // confirm(적용) → validate까지 반영된 결과 메시지.
+    fireEvent.click(screen.getByRole("button", { name: "적용" }));
+    expect(await screen.findByText(/validate/)).toBeInTheDocument();
+    expect(screen.getByText(BADGE_TEXT)).toBeInTheDocument();
+  });
+});

--- a/__tests__/newBuildCatalogStates.test.tsx
+++ b/__tests__/newBuildCatalogStates.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * New Build 템플릿 catalog 상태(loading/error/loaded) 테스트 (#Phase2 UI polish).
+ *
+ * loading/error 상태에서는 아직 Builder catalog와 대조할 수 없으므로 어떤 템플릿도
+ * "준비 중"으로 잘못 분류하지 않는다(NewBuildPage.tsx의 isTemplateAvailable/폴백 grid 참고).
+ * loaded 상태에서만 실제 catalog 존재 여부로 available/unavailable을 나눈다.
+ */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { NewBuildPage } from "@/pages/NewBuildPage";
+import { API_BASE } from "@/shared/config/env";
+import { mswServer } from "../vitest.setup";
+
+function renderWizard() {
+  return render(
+    <MemoryRouter>
+      <NewBuildPage />
+    </MemoryRouter>,
+  );
+}
+
+/** catalog 요청이 이 테스트 동안 절대 resolve되지 않도록 막아, loading 상태를 고정한다. */
+function stallCatalog() {
+  mswServer.use(http.get(`${API_BASE}/catalog`, () => new Promise(() => {})));
+}
+
+function failCatalog() {
+  mswServer.use(http.get(`${API_BASE}/catalog`, () => HttpResponse.error()));
+}
+
+describe("New Build 템플릿 catalog 상태 (#Phase2 UI polish)", () => {
+  it("loading: shows the loading indicator and does not mislabel any template as 준비 중 (unavailable)", async () => {
+    stallCatalog();
+    renderWizard();
+
+    expect(await screen.findByText("Builder catalog를 불러오는 중입니다...")).toBeInTheDocument();
+    // catalog와 아직 대조할 수 없으므로 모든 템플릿(카탈로그 필요 템플릿 포함)이 활성 상태를 유지한다.
+    expect(screen.getByRole("button", { name: /인구 통계/ })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /기준금리 추이/ })).toBeEnabled();
+    expect(screen.queryByText(/준비 중인 템플릿/)).not.toBeInTheDocument();
+  });
+
+  it("error: shows the catalog fetch failure, not a '준비 중 source' framing", async () => {
+    failCatalog();
+    renderWizard();
+
+    // builderApi.apiFetch는 네트워크 오류를 지수 백오프로 재시도한다(최대 ~1.5초) — 기본
+    // findByRole 타임아웃(1초)보다 길게 기다린다.
+    const alert = await screen.findByRole("alert", {}, { timeout: 5000 });
+    expect(alert).toHaveTextContent("Builder catalog 조회 실패");
+    // 조회 실패와 "아직 준비 중인 source"는 다른 상태다 — 실패를 준비 중으로 뭉개지 않는다.
+    expect(screen.queryByText(/준비 중인 템플릿/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /인구 통계/ })).toBeEnabled();
+  });
+
+  it("loaded — available: a template present in the Builder catalog stays enabled and selectable", async () => {
+    // 기본 msw handler는 datago/air_quality만 제공한다(__tests__/msw/handlers.ts).
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /대기오염 정보/ })).toBeEnabled());
+
+    fireEvent.click(screen.getByRole("button", { name: /대기오염 정보/ }));
+    expect(await screen.findByRole("heading", { name: "기본 정보" })).toBeInTheDocument();
+  });
+
+  it("loaded — unavailable: templates missing from the Builder catalog move to a separate 준비 중 section, not the primary one", async () => {
+    // 기본 msw handler는 datago/air_quality만 제공한다 — bok/kosis 템플릿은 catalog에 없다(F).
+    renderWizard();
+
+    const unavailableHeading = await screen.findByText(/준비 중인 템플릿 2개/);
+    const unavailableSection = unavailableHeading.closest("div")!;
+
+    const population = screen.getByRole("button", { name: /인구 통계/ });
+    const interestRate = screen.getByRole("button", { name: /기준금리 추이/ });
+    expect(population).toBeDisabled();
+    expect(interestRate).toBeDisabled();
+    expect(within(unavailableSection).getByRole("button", { name: /인구 통계/ })).toBe(population);
+    expect(within(unavailableSection).getByRole("button", { name: /기준금리 추이/ })).toBe(interestRate);
+
+    // 사용 가능한 air_quality/직접 구성 템플릿은 준비 중 섹션 밖(primary)에 남는다.
+    expect(within(unavailableSection).queryByRole("button", { name: /대기오염 정보/ })).not.toBeInTheDocument();
+    expect(within(unavailableSection).queryByRole("button", { name: /직접 구성/ })).not.toBeInTheDocument();
+  });
+
+  it("'직접 구성' (blank/direct) template stays available in every catalog state", async () => {
+    stallCatalog();
+    renderWizard();
+    expect(screen.getByRole("button", { name: /직접 구성/ })).toBeEnabled();
+  });
+});

--- a/src/features/kubi/KubiContent.tsx
+++ b/src/features/kubi/KubiContent.tsx
@@ -244,6 +244,11 @@ function ActionCard({
 
   return (
     <div className="rounded-lg border border-border bg-card px-3 py-2 text-xs">
+      {action.type === "PATCH_BUILDSPEC" ? (
+        <span className="mb-1 inline-flex items-center gap-1 rounded-full bg-violet-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-violet-800 dark:bg-violet-950/50 dark:text-violet-300">
+          BuildSpec 변경 제안
+        </span>
+      ) : null}
       <p className="font-medium text-foreground">{describeAction(action)}</p>
       <p className="mt-0.5 text-muted-foreground">{action.reason}</p>
 

--- a/src/features/kubi/KubiContent.tsx
+++ b/src/features/kubi/KubiContent.tsx
@@ -13,19 +13,13 @@ import { Button, Card } from "@/shared/ui";
 import { describeAction } from "./actions";
 import { relatedCatalogDatasets } from "./relatedDatasets";
 import type { KubiAction } from "./schema";
+import { SUGGESTED_QUESTIONS } from "./suggestedQuestions";
 import { summarizeKubiQuality } from "./types";
 import type { KubiActionRunState, KubiContext, KubiErrorState, KubiQueryState, KubiTurn } from "./types";
 import { useKubiSession } from "./useKubiSession";
 
 /** 데모 CTA와 onboarding 예시 질문이 함께 쓰는 기본 질문(mock evidence만으로도 답이 나온다). */
 const DEMO_QUESTION = "이 데이터셋 품질 어때?";
-
-const SUGGESTED_QUESTIONS = [
-  "현재 화면 문맥을 요약해줘.",
-  "지금 확인된 Quality 이슈의 원인과 우선순위를 알려줘.",
-  "이 Build가 실패했다면 원인을 분석해줘.",
-  "이 데이터로 어떤 걸 SQL로 확인할 수 있을지 제안해줘.",
-];
 
 /**
  * 프로토타입 구조(DATASET/BUILD(RUN)/STAGE/QUALITY 4칸)를 따르는 context bar (#256 review).

--- a/src/features/kubi/suggestedQuestions.ts
+++ b/src/features/kubi/suggestedQuestions.ts
@@ -1,0 +1,12 @@
+/**
+ * Kubi 예시/추천 질문 목록.
+ *
+ * `KubiContent`(onboarding 칩 + 추천 질문 패널)와 Home의 Kubi hero(#Phase2 UI polish)가
+ * 이 목록을 공유한다 — 실제로 seed 가능한 질문만 담아 두 화면에서 복붙되지 않게 한다.
+ */
+export const SUGGESTED_QUESTIONS = [
+  "현재 화면 문맥을 요약해줘.",
+  "지금 확인된 Quality 이슈의 원인과 우선순위를 알려줘.",
+  "이 Build가 실패했다면 원인을 분석해줘.",
+  "이 데이터로 어떤 걸 SQL로 확인할 수 있을지 제안해줘.",
+];

--- a/src/pages/DatasetDetailPage.tsx
+++ b/src/pages/DatasetDetailPage.tsx
@@ -62,6 +62,13 @@ function Definition({ label, children }: { label: string; children: ReactNode })
   return <div><dt className="text-xs font-medium uppercase tracking-wider text-muted-foreground">{label}</dt><dd className="mt-1 break-words text-sm text-foreground">{children}</dd></div>;
 }
 
+/** Bronze/Silver/Gold의 일반적인 stage 역할(이 데이터셋의 실제 이력을 서술하는 것이 아니다). */
+const STAGE_EXPLAINER: Record<DatasetStage, string> = {
+  bronze: "원본 보존 수집 단계",
+  silver: "정규화·변환·검증 단계",
+  gold: "분석·배포를 위한 최종 가공 단계",
+};
+
 export function DatasetDetailPage() {
   const { datasetId = "" } = useParams<{ datasetId: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -148,6 +155,16 @@ export function DatasetDetailPage() {
       else next.delete(key);
     }
     setSearchParams(next);
+  }
+
+  // AI 탭은 Kubi(KubiContent)가 route의 ?run=&stage=로만 문맥을 판단한다(추측 금지 원칙,
+  // context.ts 참고) — 그래서 여기서 화면에 이미 계산되어 보이는 selectedRunId/selectedStage를
+  // URL에 명시적으로 반영해줘야, 처음 AI 탭을 열었을 때도 Kubi RUN context bar가 실제로는
+  // 알고 있는 latest run을 "—"로 보여주거나 Generated SQL/Result Preview가 비어 보이지
+  // 않는다(UI audit #5). 탭 바(button onClick)와 Overview 탭의 Kubi discoverability CTA 모두
+  // 이 helper 하나를 공유해 같은 규칙을 두 번 구현하지 않는다.
+  function goToTab(tab: DetailTab) {
+    updateContext(tab === "ai" ? { tab: "ai", run: selectedRunId, stage: selectedStage } : { tab: tab === "overview" ? null : tab });
   }
 
   const tabParam = searchParams.get("tab") as DetailTab | null;
@@ -238,15 +255,7 @@ export function DatasetDetailPage() {
               type="button"
               role="tab"
               aria-selected={selectedTab === tab.id}
-              // AI 탭은 Kubi(KubiContent)가 route의 ?run=&stage=로만 문맥을 판단한다(추측 금지
-              // 원칙, context.ts 참고) — 그래서 여기서 화면에 이미 계산되어 보이는
-              // selectedRunId/selectedStage를 URL에 명시적으로 반영해줘야, 처음 AI 탭을 열었을
-              // 때도 Kubi RUN context bar가 실제로는 알고 있는 latest run을 "—"로 보여주거나
-              // Generated SQL/Result Preview가 비어 보이지 않는다(UI audit #5). latest run이라
-              // ?run=이 URL에 없을 수도 있으므로(다른 select onChange와 동일 관례) 값을 항상
-              // 명시적으로 채운다 — 없는 값을 지어내는 게 아니라 이미 화면에 보이는 값을 그대로
-              // 전달하는 것이다.
-              onClick={() => updateContext(tab.id === "ai" ? { tab: "ai", run: selectedRunId, stage: selectedStage } : { tab: tab.id === "overview" ? null : tab.id })}
+              onClick={() => goToTab(tab.id)}
               className={`whitespace-nowrap border-b-2 px-4 py-3 text-sm font-medium ${selectedTab === tab.id ? "border-accent text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"}`}
             >
               {tab.label}
@@ -256,7 +265,7 @@ export function DatasetDetailPage() {
       </div>
 
       <section role="tabpanel" aria-label={TABS.find((tab) => tab.id === selectedTab)?.label}>
-        {selectedTab === "overview" ? <OverviewTab dataset={core.dataset} selectedRun={selectedRun} selectedSource={selectedSource} selectedStage={selectedStage} sourceStages={sourceStageEntry} stageDetail={stageDetailState.data} stageError={stageDetailState.error} rowCount={summaryRowCount} validation={validation} onSelectStage={(stageName) => updateContext({ stage: stageName })} onSelectTab={(tab) => updateContext({ tab })} /> : null}
+        {selectedTab === "overview" ? <OverviewTab dataset={core.dataset} selectedRun={selectedRun} runStatus={runStatus} selectedSource={selectedSource} selectedStage={selectedStage} sourceStages={sourceStageEntry} stageDetail={stageDetailState.data} stageError={stageDetailState.error} rowCount={summaryRowCount} validation={validation} onSelectStage={(stageName) => updateContext({ stage: stageName })} onSelectTab={goToTab} /> : null}
         {selectedTab === "schema" ? <SchemaTab state={stageDetailState} drift={selectedDrift} /> : null}
         {selectedTab === "preview" ? <PreviewTab state={stageDetailState} qualityState={qualityState} qualityStatus={validation} qualityResults={selectedQualityResults} onOpenQuality={() => updateContext({ tab: "quality" })} /> : null}
         {selectedTab === "quality" ? <QualityTab state={qualityState} status={validation} results={selectedQualityResults} drift={selectedDrift} datasetId={datasetId} runId={selectedRunId} source={selectedSource} stage={selectedStage} /> : null}
@@ -271,9 +280,51 @@ function MetricCard({ label, value, sub }: { label: string; value: ReactNode; su
   return <Card className="p-5"><p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{label}</p><div className="mt-2 text-2xl font-bold tracking-tight">{value}</div><div className="mt-1 text-xs text-muted-foreground">{sub}</div></Card>;
 }
 
-function OverviewTab({ dataset, selectedRun, selectedSource, selectedStage, sourceStages, stageDetail, stageError, rowCount, validation, onSelectStage, onSelectTab }: { dataset: DatasetDetailResponse; selectedRun?: DatasetRunSummary; selectedSource: string; selectedStage: DatasetStage; sourceStages?: RunStagesResponse["sources"][number]; stageDetail?: StageDetailResponse; stageError?: string; rowCount: number | null; validation: ReturnType<typeof summarizeQuality>; onSelectStage: (stage: DatasetStage) => void; onSelectTab: (tab: DetailTab) => void }) {
+function OverviewTab({ dataset, selectedRun, runStatus, selectedSource, selectedStage, sourceStages, stageDetail, stageError, rowCount, validation, onSelectStage, onSelectTab }: { dataset: DatasetDetailResponse; selectedRun?: DatasetRunSummary; runStatus?: string; selectedSource: string; selectedStage: DatasetStage; sourceStages?: RunStagesResponse["sources"][number]; stageDetail?: StageDetailResponse; stageError?: string; rowCount: number | null; validation: ReturnType<typeof summarizeQuality>; onSelectStage: (stage: DatasetStage) => void; onSelectTab: (tab: DetailTab) => void }) {
   const columnCount = stageDetail?.stage === "silver" ? stageDetail.schema.length : stageDetail?.stage === "gold" ? stageDetail.columns.length : null;
-  return <div className="space-y-4"><div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"><MetricCard label="Rows" value={rowCount === null ? "—" : rowCount.toLocaleString("ko-KR")} sub={selectedStage} /><MetricCard label="Columns" value={columnCount ?? "—"} sub="Builder stage response" /><MetricCard label="Validation" value={<QualityBadge status={validation} />} sub={selectedSource || "선택된 source 없음"} /><MetricCard label="Updated" value={<span className="text-lg">{formatDateTime(selectedRun?.finished_at ?? selectedRun?.started_at ?? dataset.updated_at)}</span>} sub={`Build ${selectedRun?.run_id ?? dataset.latest_run_id}`} /></div><div className="grid gap-4 lg:grid-cols-[1.35fr_1fr]"><Card><h3 className="text-sm font-semibold">Lineage</h3>{sourceStages ? <div className="mt-4 flex flex-col items-stretch gap-2 sm:flex-row sm:items-center"><div className="rounded-lg border border-border bg-muted/40 px-4 py-3 text-center text-sm font-semibold">Source<span className="mt-1 block text-xs font-normal text-muted-foreground">{selectedSource}</span></div>{DATASET_STAGES.map((stageName) => <div key={stageName} className="contents"><span aria-hidden="true" className="text-center text-muted-foreground">→</span><button type="button" aria-label={`${stageName} ${sourceStages[stageName].status}`} aria-pressed={selectedStage === stageName} onClick={() => onSelectStage(stageName)} className={`rounded-lg border px-4 py-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${selectedStage === stageName ? "border-accent bg-accent-subtle" : "border-border bg-card hover:bg-muted"}`}><span className="block text-sm font-semibold capitalize">{stageName}</span><span className="mt-1 block"><StageBadge status={sourceStages[stageName].status} /></span></button></div>)}</div> : <Skeleton className="mt-4 h-24 w-full" />}</Card><Card><h3 className="text-sm font-semibold">Stage Detail · <span className="capitalize">{selectedStage}</span></h3>{stageError ? <p className="mt-3 text-sm text-red-700 dark:text-red-300">{stageError}</p> : !stageDetail ? <Skeleton className="mt-4 h-24 w-full" /> : <><dl className="mt-4 space-y-3"><Definition label="Status"><StageBadge status={stageDetail.status} /></Definition><Definition label="Available">{stageDetail.available ? "yes" : "no"}</Definition><Definition label="Provider / Source">{dataset.sources.map((source) => `${source.provider}.${source.dataset}`).join(", ")} · {selectedSource}</Definition><Definition label="Output">{stageDetail.stage === "gold" ? (stageDetail.exports.map((item) => item.kind).join(", ") || "없음") : "이 stage 응답에서 제공하지 않음"}</Definition></dl><div className="mt-4 flex gap-2"><Button variant="secondary" size="sm" onClick={() => onSelectTab("preview")}>Preview</Button><Button variant="secondary" size="sm" onClick={() => onSelectTab("quality")}>Quality 보기</Button></div></>}</Card></div></div>;
+  const artifactSummary = stageDetail?.stage === "gold" ? stageDetail.exports.map((item) => item.kind).join(", ") || "미게시" : "gold stage 아님";
+  return <div className="space-y-4">
+    <DataPassport dataset={dataset} selectedRun={selectedRun} runStatus={runStatus} selectedSource={selectedSource} selectedStage={selectedStage} sourceStages={sourceStages} columnCount={columnCount} artifactSummary={artifactSummary} validation={validation} onSelectTab={onSelectTab} />
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"><MetricCard label="Rows" value={rowCount === null ? "—" : rowCount.toLocaleString("ko-KR")} sub={selectedStage} /><MetricCard label="Columns" value={columnCount ?? "—"} sub="Builder stage response" /><MetricCard label="Validation" value={<QualityBadge status={validation} />} sub={selectedSource || "선택된 source 없음"} /><MetricCard label="Updated" value={<span className="text-lg">{formatDateTime(selectedRun?.finished_at ?? selectedRun?.started_at ?? dataset.updated_at)}</span>} sub={`Build ${selectedRun?.run_id ?? dataset.latest_run_id}`} /></div>
+    <div className="grid gap-4 lg:grid-cols-[1.35fr_1fr]"><Card><h3 className="text-sm font-semibold">Lineage</h3>{sourceStages ? <div className="mt-4 flex flex-col items-stretch gap-2 sm:flex-row sm:items-center"><div className="rounded-lg border border-border bg-muted/40 px-4 py-3 text-center text-sm font-semibold">Source<span className="mt-1 block text-xs font-normal text-muted-foreground">{selectedSource}</span></div>{DATASET_STAGES.map((stageName) => <div key={stageName} className="contents"><span aria-hidden="true" className="text-center text-muted-foreground">→</span><button type="button" aria-label={`${stageName} ${sourceStages[stageName].status}`} aria-pressed={selectedStage === stageName} onClick={() => onSelectStage(stageName)} className={`rounded-lg border px-4 py-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${selectedStage === stageName ? "border-accent bg-accent-subtle" : "border-border bg-card hover:bg-muted"}`}><span className="block text-sm font-semibold capitalize">{stageName}</span><span className="mt-1 block"><StageBadge status={sourceStages[stageName].status} /></span><span className="mt-1 block text-[11px] font-normal text-muted-foreground">{STAGE_EXPLAINER[stageName]}</span></button></div>)}</div> : <Skeleton className="mt-4 h-24 w-full" />}</Card><Card><h3 className="text-sm font-semibold">Stage Detail · <span className="capitalize">{selectedStage}</span></h3>{stageError ? <p className="mt-3 text-sm text-red-700 dark:text-red-300">{stageError}</p> : !stageDetail ? <Skeleton className="mt-4 h-24 w-full" /> : <><dl className="mt-4 space-y-3"><Definition label="Status"><StageBadge status={stageDetail.status} /></Definition><Definition label="Available">{stageDetail.available ? "yes" : "no"}</Definition><Definition label="Provider / Source">{dataset.sources.map((source) => `${source.provider}.${source.dataset}`).join(", ")} · {selectedSource}</Definition><Definition label="Output">{stageDetail.stage === "gold" ? (stageDetail.exports.map((item) => item.kind).join(", ") || "없음") : "이 stage 응답에서 제공하지 않음"}</Definition></dl><div className="mt-4 flex gap-2"><Button variant="secondary" size="sm" onClick={() => onSelectTab("preview")}>Preview</Button><Button variant="secondary" size="sm" onClick={() => onSelectTab("quality")}>Quality 보기</Button></div></>}</Card></div>
+  </div>;
+}
+
+/**
+ * Data Passport — "이 dataset이 무엇이고 어디서 왔으며 신뢰 가능한지"를 한눈에 보여주는
+ * trust summary(#Phase2 UI polish). 새 backend 데이터를 요구하지 않는다 — 이미 이 페이지가
+ * fetch한 값만 재사용한다. 값이 없는 필드는 지어내지 않고 "확인 불가"/"제공되지 않음" 등으로
+ * 명확히 표기하거나 생략한다(License는 이 스키마 어디에도 실제 dataset 속성으로 존재하지
+ * 않아 — Publish 화면에서 사용자가 입력하는 값일 뿐이므로 — 아예 생략한다).
+ *
+ * "Run 상태(전체)"와 "선택된 Source·Stage 상태"는 서로 다른 vocabulary(run 전체 집계 vs
+ * source/stage 단위)라 값이 갈릴 수 있다(:174-178의 runFailedButSelectedStageOk 참고) — 두
+ * 필드를 하나로 합치지 않고 라벨을 분리해 그 scope 차이를 다시 흐리지 않는다.
+ */
+function DataPassport({ dataset, selectedRun, runStatus, selectedSource, selectedStage, sourceStages, columnCount, artifactSummary, validation, onSelectTab }: { dataset: DatasetDetailResponse; selectedRun?: DatasetRunSummary; runStatus?: string; selectedSource: string; selectedStage: DatasetStage; sourceStages?: RunStagesResponse["sources"][number]; columnCount: number | null; artifactSummary: string; validation: ReturnType<typeof summarizeQuality>; onSelectTab: (tab: DetailTab) => void }) {
+  return (
+    <Card>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold">Data Passport</h3>
+        <button type="button" className="text-xs font-medium text-accent-subtle-foreground underline" onClick={() => onSelectTab("ai")}>
+          Kubi가 이 dataset의 BuildSpec 수정안을 제안할 수 있습니다
+        </button>
+      </div>
+      <dl className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Definition label="Provider / Source">{dataset.sources.map((source) => `${source.provider}.${source.dataset}`).join(", ") || "확인 불가"}</Definition>
+        <Definition label="Dataset">{dataset.title}<span className="block font-mono text-xs text-muted-foreground">{dataset.dataset_id}</span></Definition>
+        <Definition label="Run 상태(전체)">{runStatus ?? "확인 불가"}</Definition>
+        <Definition label="선택된 Source·Stage 상태">{sourceStages ? <StageBadge status={sourceStages[selectedStage].status} /> : "확인 불가"}</Definition>
+        <Definition label="Quality"><QualityBadge status={validation} /></Definition>
+        <Definition label="Schema">{columnCount === null ? "제공되지 않음" : `${columnCount} columns`}</Definition>
+        <Definition label="BuildSpec digest">{selectedRun?.spec_digest ? <span className="break-all font-mono text-xs">{selectedRun.spec_digest}</span> : "확인 불가"}</Definition>
+        <Definition label="Artifact">{artifactSummary}</Definition>
+      </dl>
+      <p className="mt-4 text-xs text-muted-foreground">
+        Source: {selectedSource || "선택된 source 없음"} · Lineage/Schema/Quality 상세는 각 탭에서 확인할 수 있습니다.
+      </p>
+    </Card>
+  );
 }
 
 function SchemaTab({ state, drift }: { state: AsyncState<StageDetailResponse>; drift: BuildQualityResponse["schema_drift"][string] }) {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,13 +4,23 @@
  * Issue #248: Home을 신규 사용자·기존 사용자 상태로 구현한다.
  *
  * 신규 사용자 여부는 dataset/build 존재 여부로 판단한다.
- * - 신규 사용자: 환영 메시지, Kubi 검색 hero, 공공데이터 탐색, 데이터 바로 가져오기, 예시 데이터셋 둘러보기
+ * - 신규 사용자: 환영 메시지, Kubi 자연어 hero(topbar KubiSearchInput과 동일한 seed 흐름 재사용),
+ *   공공데이터 탐색, 데이터 바로 가져오기
  * - 기존 사용자: 실제 KPI (DATASETS, BUILD SUCCESS, VALIDATION WARN, RUNNING), 최근 데이터셋, 최근 Build stage 요약, 품질 경고/실패 Build
+ *
+ * Phase2 UI polish: "예시 데이터셋을 곧 만나보실 수 있습니다" placeholder 섹션은 제거했다 —
+ * 실제 예시 데이터셋이 없는 상태에서 서비스가 미완성인 인상을 줬다. 같은 CTA는 이미
+ * "공공데이터 탐색 → /discover" 카드가 담당한다.
  */
-import { useEffect, useState } from "react";
+import { useEffect, useState, type FormEvent } from "react";
+import { useAssistConfig } from "@/features/assistant/config";
 import { listBuilds } from "@/features/runs/api";
+import { SUGGESTED_QUESTIONS } from "@/features/kubi/suggestedQuestions";
+import { useKubiStore } from "@/features/kubi/useKubiSession";
+import { useUIStore } from "@/shared/hooks/useUIStore";
 import type { BuildListItem, BuildRunStatus } from "@/shared/lib/types";
 import {
+  Button,
   Card,
   EmptyState,
   LinkButton,
@@ -123,22 +133,24 @@ function NewUserHome() {
       <PageHeader
         eyebrow="시작하기"
         title="공공데이터를 쉽게 수집하고 변환하세요"
-        description="Kubi가 도와드립니다. 예시 데이터셋을 둘러보거나 바로 시작하세요."
+        description="Kubi가 도와드립니다. 자연어로 물어보거나 원하는 방식으로 바로 시작하세요."
       />
 
+      <KubiHero />
+
       <section className="grid gap-6 lg:grid-cols-2">
-        <Card variant="elevated" className="flex flex-col items-center justify-center p-12 text-center">
-          <h2 className="text-2xl font-semibold tracking-tight">Kubi로 데이터 찾기</h2>
+        <Card variant="elevated" className="flex flex-col items-center justify-center p-10 text-center">
+          <h2 className="text-xl font-semibold tracking-tight">공공데이터 탐색</h2>
           <p className="mt-3 text-muted-foreground">
-            한국어로 질문하면 Kubi가 적합한 공공데이터를 찾아드립니다
+            어떤 공공데이터를 다룰 수 있는지 카탈로그에서 둘러보세요
           </p>
-          <LinkButton className="mt-6" to="/kubi">
-            Kubi 열기
+          <LinkButton className="mt-6" variant="secondary" to="/discover">
+            탐색하기
           </LinkButton>
         </Card>
 
-        <Card variant="elevated" className="flex flex-col items-center justify-center p-12 text-center">
-          <h2 className="text-2xl font-semibold tracking-tight">데이터 바로 가져오기</h2>
+        <Card variant="elevated" className="flex flex-col items-center justify-center p-10 text-center">
+          <h2 className="text-xl font-semibold tracking-tight">데이터 바로 가져오기</h2>
           <p className="mt-3 text-muted-foreground">
             Public API, 파일, URL에서 데이터를 직접 가져와 빌드하세요
           </p>
@@ -147,19 +159,77 @@ function NewUserHome() {
           </LinkButton>
         </Card>
       </section>
-
-      <section>
-        <PageHeader eyebrow="둘러보기" title="예시 데이터셋" className="mb-4" />
-        <Card className="p-0">
-          <EmptyState
-            title="예시 데이터셋을 곧 만나보실 수 있습니다"
-            description="자주 사용하는 공공데이터 템플릿을 준비 중입니다"
-            actionLabel="공공데이터 탐색"
-            actionHref="/discover"
-          />
-        </Card>
-      </section>
     </>
+  );
+}
+
+/**
+ * Home의 Kubi 자연어 hero (#Phase2 UI polish).
+ *
+ * 새 assistant system이 아니라 topbar `KubiSearchInput`과 동일한 seed 흐름
+ * (`useKubiStore().seedQuestion` + `useUIStore().openKubiDrawer`)을 재사용한다. 여기서
+ * evidence 조회/LLM 호출을 직접 하지 않는다 — drawer가 열리면 `useKubiSession`이 이어받는다.
+ *
+ * `ask()`(useKubiSession.ts)는 seed를 받는 즉시 실행하고, API Key 미설정 시 `no_key` 에러
+ * turn을 만든다. 여기서 원치 않는 에러 turn을 일부러 만들지 않기 위해, seed는
+ * `isConfigured`일 때만 남기고 아니면 drawer만 열어 기존 API Key 설정 안내를 보여준다.
+ */
+function KubiHero() {
+  const [query, setQuery] = useState("");
+  const openKubiDrawer = useUIStore((state) => state.openKubiDrawer);
+  const seedQuestion = useKubiStore((state) => state.seedQuestion);
+  const { isConfigured } = useAssistConfig();
+
+  function ask(question: string) {
+    const trimmed = question.trim();
+    if (trimmed && isConfigured) seedQuestion(trimmed);
+    openKubiDrawer();
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    ask(query);
+    setQuery("");
+  }
+
+  return (
+    <Card variant="elevated" className="p-8">
+      <h2 className="text-xl font-semibold tracking-tight">Kubi에게 필요한 데이터를 물어보세요</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        한국어로 질문하면 Kubi가 적합한 공공데이터를 찾고 BuildSpec까지 제안합니다.
+      </p>
+      <form className="mt-4 flex flex-col gap-2 sm:flex-row" onSubmit={handleSubmit}>
+        <label className="sr-only" htmlFor="home-kubi-hero">
+          Kubi에게 자연어로 데이터 물어보기
+        </label>
+        <input
+          className="h-11 flex-1 rounded-lg border border-input bg-card px-4 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          id="home-kubi-hero"
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="예: 서울 대기오염 데이터로 뭘 할 수 있어?"
+          type="search"
+          value={query}
+        />
+        <Button type="submit">Kubi에게 물어보기</Button>
+      </form>
+      <div className="mt-4 flex flex-wrap gap-1.5">
+        {SUGGESTED_QUESTIONS.map((question) => (
+          <button
+            key={question}
+            type="button"
+            className="rounded-full border border-border px-2.5 py-1 text-xs text-muted-foreground hover:border-accent hover:text-foreground"
+            onClick={() => ask(question)}
+          >
+            {question}
+          </button>
+        ))}
+      </div>
+      {!isConfigured ? (
+        <p className="mt-3 text-xs text-muted-foreground">
+          아직 API Key가 설정되지 않았습니다. Kubi를 열면 설정 방법을 안내합니다.
+        </p>
+      ) : null}
+    </Card>
   );
 }
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,17 +1,34 @@
 /**
  * 로그인 화면 (/login, #263).
  *
- * 실제 IdP 연결은 Builder #515 결정 이후로 미루고, 지금은 mock/demo AuthProvider로
- * 이메일/비밀번호 로그인 UX와 generic AuthProvider 경계를 시연한다. 기존 Google 로그인
- * 플로우(#187, GoogleLoginButton/gis.ts)는 건드리지 않는다 — 이 화면은 별도의
- * mockAuthProvider를 통해 같은 세션 store(useAuthStore)에 로그인한다.
+ * 실제 IdP는 kpubdata-builder ADR 0015(Accepted)가 self-hosted Keycloak +
+ * Authorization Code + PKCE로 확정했지만, Studio에 아직 실제 Keycloak
+ * provider/callback/token 연동 코드가 없다(keycloak/PKCE 관련 구현 전무 확인). 그래서
+ * 이 화면은 `isRealBuilderEnabled()`(mock/demo vs 실제 Builder 연동)로 분기한다:
+ * - mock/demo 환경: 기존 mockAuthProvider 이메일/비밀번호 폼을 그대로 유지한다(dev/demo 전용).
+ * - 실제 Builder 연동인데 Keycloak이 아직 없는 환경: mock 폼을 실제 인증처럼 보여주지 않고
+ *   "OIDC 인증 미구성" 안내만 보여준다 — 가짜 Keycloak redirect/token flow를 만들지 않는다.
+ *
+ * 기존 Google 로그인 플로우(#187, GoogleLoginButton/gis.ts)는 건드리지 않는다 — 이 화면은
+ * 별도의 mockAuthProvider를 통해 같은 세션 store(useAuthStore)에 로그인한다.
  */
 import { useState, type FormEvent } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { mockAuthProvider } from "@/features/auth/mockAuthProvider";
 import { useAuthStore } from "@/features/auth/store";
 import { AuthError } from "@/features/auth/types";
-import { Button, Card, ErrorMessage, FormField, TextInput } from "@/shared/ui";
+import { isRealBuilderEnabled } from "@/shared/lib/builderApi";
+import { Button, Card, DemoBadge, ErrorMessage, FormField, TextInput } from "@/shared/ui";
+
+/** Auth 화면에 표시하는 짧은 제품 소개. */
+function ProductIntro() {
+  return (
+    <div className="mb-6 text-center">
+      <h1 className="text-2xl font-bold tracking-tight">KPubData</h1>
+      <p className="mt-1 text-sm text-muted-foreground">공공데이터를 AI-ready Dataset으로</p>
+    </div>
+  );
+}
 
 export function LoginPage() {
   const navigate = useNavigate();
@@ -38,55 +55,77 @@ export function LoginPage() {
     }
   }
 
+  const demoMode = !isRealBuilderEnabled();
+
   return (
     <main className="flex min-h-screen items-center justify-center bg-background px-5 py-12">
-      <Card className="w-full max-w-md">
-        <h1 className="text-2xl font-semibold tracking-tight">로그인</h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          KPubData Studio에 로그인하세요. (mock/demo — 실제 계정 인증은 아직 연결되지 않았습니다.)
-        </p>
+      <div className="w-full max-w-md">
+        <ProductIntro />
+        <Card>
+          <div className="flex items-center justify-between gap-2">
+            <h2 className="text-xl font-semibold tracking-tight">로그인</h2>
+            {demoMode ? <DemoBadge /> : null}
+          </div>
 
-        <form className="mt-6 flex flex-col gap-4" onSubmit={handleSubmit}>
-          <FormField id="login-email" label="이메일" required>
-            {(field) => (
-              <TextInput
-                {...field}
-                type="email"
-                autoComplete="email"
-                required
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-              />
-            )}
-          </FormField>
+          {demoMode ? (
+            <>
+              <p className="mt-2 text-sm text-muted-foreground">
+                KPubData Studio에 로그인하세요. mock/demo 계정입니다.
+              </p>
 
-          <FormField id="login-password" label="비밀번호" required>
-            {(field) => (
-              <TextInput
-                {...field}
-                type="password"
-                autoComplete="current-password"
-                required
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-              />
-            )}
-          </FormField>
+              <form className="mt-6 flex flex-col gap-4" onSubmit={handleSubmit}>
+                <FormField id="login-email" label="이메일" required>
+                  {(field) => (
+                    <TextInput
+                      {...field}
+                      type="email"
+                      autoComplete="email"
+                      required
+                      value={email}
+                      onChange={(event) => setEmail(event.target.value)}
+                    />
+                  )}
+                </FormField>
 
-          <ErrorMessage>{error}</ErrorMessage>
+                <FormField id="login-password" label="비밀번호" required>
+                  {(field) => (
+                    <TextInput
+                      {...field}
+                      type="password"
+                      autoComplete="current-password"
+                      required
+                      value={password}
+                      onChange={(event) => setPassword(event.target.value)}
+                    />
+                  )}
+                </FormField>
 
-          <Button type="submit" loading={isSubmitting} className="mt-2">
-            로그인
-          </Button>
-        </form>
+                <ErrorMessage>{error}</ErrorMessage>
 
-        <p className="mt-6 text-center text-sm text-muted-foreground">
-          계정이 없으신가요?{" "}
-          <Link to="/signup" className="font-medium text-accent-subtle-foreground underline">
-            계정 만들기
-          </Link>
-        </p>
-      </Card>
+                <Button type="submit" loading={isSubmitting} className="mt-2">
+                  로그인
+                </Button>
+              </form>
+
+              <p className="mt-6 text-center text-sm text-muted-foreground">
+                계정이 없으신가요?{" "}
+                <Link to="/signup" className="font-medium text-accent-subtle-foreground underline">
+                  계정 발급 안내
+                </Link>
+              </p>
+            </>
+          ) : (
+            <div className="mt-4 rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+              <p className="font-medium text-foreground">OIDC 인증이 아직 구성되지 않았습니다.</p>
+              <p className="mt-2">
+                이 환경은 실제 Builder에 연결되어 있지만, 사람 사용자 로그인을 위한 OIDC IdP(Keycloak)
+                연동이 아직 준비되지 않았습니다. 관리자에게 문의하거나 연동이 완료된 이후 다시
+                시도해주세요.
+              </p>
+            </div>
+          )}
+        </Card>
+      </div>
     </main>
   );
 }

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -70,7 +70,7 @@ interface BuildTemplate {
 const TEMPLATES: BuildTemplate[] = [
   {
     id: "blank",
-    name: "빈 빌드",
+    name: "직접 구성",
     description: "아무 값 없이 처음부터 직접 설정합니다.",
     values: initialValues,
   },
@@ -245,6 +245,30 @@ function catalogDataset(
 function isTemplateAvailable(template: BuildTemplate, catalog: CatalogState): boolean {
   if (!template.values.provider || !template.values.sourceDataset || catalog.status !== "loaded") return true;
   return catalogDataset(catalog.providers, template.values.provider, template.values.sourceDataset) !== undefined;
+}
+
+/** 템플릿 선택 버튼 — 사용 가능/준비 중 두 그리드가 이 렌더링 하나를 공유한다(#Phase2 UI polish). */
+function TemplateButton({ template, catalog, onSelect }: { template: BuildTemplate; catalog: CatalogState; onSelect: (template: BuildTemplate) => void }) {
+  const available = isTemplateAvailable(template, catalog);
+  const resolvedDataset = catalogDataset(catalog.providers, template.values.provider, template.values.sourceDataset);
+  return (
+    <button
+      type="button"
+      disabled={!available}
+      onClick={() => onSelect(template)}
+      className="rounded-2xl border border-border bg-card p-4 text-left transition enabled:hover:border-accent/50 enabled:hover:shadow-md disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <p className="text-base font-semibold tracking-tight">{template.name}</p>
+      <p className="mt-1 text-sm text-muted-foreground">{template.description}</p>
+      {template.values.provider && template.values.sourceDataset ? (
+        <p className="mt-3 text-xs font-medium text-muted-foreground">
+          {resolvedDataset
+            ? `${providerLabel(template.values.provider)} / ${resolvedDataset.title}`
+            : "현재 Builder catalog에 없는 source입니다."}
+        </p>
+      ) : null}
+    </button>
+  );
 }
 
 /**
@@ -574,47 +598,52 @@ export function NewBuildPage() {
             <div className="space-y-4">
               <h3 className="text-xl font-semibold tracking-tight">템플릿 선택</h3>
               <p className="text-sm text-muted-foreground">
-                자주 쓰는 공공데이터 조합으로 시작하거나 빈 빌드로 처음부터 설정하세요.
+                자주 쓰는 공공데이터 조합으로 시작하거나 직접 구성으로 처음부터 설정하세요.
               </p>
               {catalog.status === "loading" ? (
                 <p className="text-sm text-muted-foreground">Builder catalog를 불러오는 중입니다...</p>
               ) : null}
               {catalog.status === "error" ? (
                 <p role="alert" className="text-sm text-red-700 dark:text-red-300">
-                  {catalog.error}
+                  Builder catalog 조회 실패: {catalog.error}
                 </p>
               ) : null}
-              <div className="grid gap-3 sm:grid-cols-2">
-                {TEMPLATES.map((template) => {
-                  const available = isTemplateAvailable(template, catalog);
-                  const resolvedDataset = catalogDataset(
-                    catalog.providers,
-                    template.values.provider,
-                    template.values.sourceDataset,
-                  );
+              {catalog.status === "loaded" ? (
+                (() => {
+                  const available = TEMPLATES.filter((template) => isTemplateAvailable(template, catalog));
+                  const unavailable = TEMPLATES.filter((template) => !isTemplateAvailable(template, catalog));
                   return (
-                    <button
-                      key={template.id}
-                      type="button"
-                      disabled={!available}
-                      onClick={() => selectTemplate(template)}
-                      className="rounded-2xl border border-border bg-card p-4 text-left transition enabled:hover:border-accent/50 enabled:hover:shadow-md disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    >
-                      <p className="text-base font-semibold tracking-tight">{template.name}</p>
-                      <p className="mt-1 text-sm text-muted-foreground">
-                        {template.description}
-                      </p>
-                      {template.values.provider && template.values.sourceDataset ? (
-                        <p className="mt-3 text-xs font-medium text-muted-foreground">
-                          {resolvedDataset
-                            ? `${providerLabel(template.values.provider)} / ${resolvedDataset.title}`
-                            : "현재 Builder catalog에 없는 source입니다."}
-                        </p>
+                    <>
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        {available.map((template) => (
+                          <TemplateButton key={template.id} template={template} catalog={catalog} onSelect={selectTemplate} />
+                        ))}
+                      </div>
+                      {unavailable.length > 0 ? (
+                        <div className="rounded-2xl border border-dashed border-border p-4">
+                          <p className="text-sm font-medium text-muted-foreground">
+                            준비 중인 템플릿 {unavailable.length}개
+                          </p>
+                          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                            {unavailable.map((template) => (
+                              <TemplateButton key={template.id} template={template} catalog={catalog} onSelect={selectTemplate} />
+                            ))}
+                          </div>
+                        </div>
                       ) : null}
-                    </button>
+                    </>
                   );
-                })}
-              </div>
+                })()
+              ) : (
+                // catalog가 아직 loading/error인 동안은 가용성을 판정할 수 없으므로(isTemplateAvailable도
+                // 이 경우 항상 true를 반환) 원본 grid를 그대로 보여준다 — "대부분 disabled"처럼
+                // 보이는 깜빡임을 만들지 않는다.
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {TEMPLATES.map((template) => (
+                    <TemplateButton key={template.id} template={template} catalog={catalog} onSelect={selectTemplate} />
+                  ))}
+                </div>
+              )}
             </div>
           ) : null}
 

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,167 +1,28 @@
 /**
- * 계정 만들기 화면 (/signup, #263).
+ * 계정 발급 안내 화면 (/signup, #263 → #Phase2 UI polish).
  *
- * 실제 IdP 연결은 Builder #515 결정 이후로 미루고, 지금은 mock/demo AuthProvider로
- * 회원가입 UX와 generic AuthProvider 경계를 시연한다. 가입 성공 시 곧바로 로그인 세션을
- * 만들지 않고 email verification 안내만 보여준다 — 실제 인증 메일 발송/검증(자체 mail
- * server)은 이슈 스코프 밖이며 Builder #515 이후 real IdP가 담당한다.
+ * kpubdata-builder ADR 0015(Accepted) §5는 public signup을 기본 OFF로 하고 관리자
+ * 초대/이메일 도메인 제한을 기본 정책으로 둔다. 이전에는 이 라우트가 완전히 동작하는
+ * 자체 회원가입 폼(mockAuthProvider.signUp)을 열어 두고 있었는데, 이는 실제 정책(공개
+ * 자율 가입 없음)과 어긋난다. 실제 Keycloak 연동도 아직 없으므로(LoginPage 주석 참고)
+ * 여기서는 정책만 정직하게 안내하고, 구체적인 계정 발급 방식(관리자 초대 UI, 이메일
+ * 도메인 검증 등)은 아직 구현되지 않았으므로 확정된 사실처럼 서술하지 않는다.
  */
-import { useState, type FormEvent } from "react";
 import { Link } from "react-router-dom";
-import { mockAuthProvider } from "@/features/auth/mockAuthProvider";
-import type { AccountType } from "@/features/auth/types";
-import { Button, Card, ErrorMessage, FormField, TextInput } from "@/shared/ui";
+import { Card } from "@/shared/ui";
 
 export function SignupPage() {
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [accountType, setAccountType] = useState<AccountType>("individual");
-  const [organizationName, setOrganizationName] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [createdEmail, setCreatedEmail] = useState<string | null>(null);
-
-  async function handleSubmit(event: FormEvent) {
-    event.preventDefault();
-    setError(null);
-    setIsSubmitting(true);
-    try {
-      const session = await mockAuthProvider.signUp({
-        name,
-        email,
-        password,
-        accountType,
-        organizationName:
-          accountType === "organization" && organizationName ? organizationName : undefined,
-      });
-      // 계정은 생성됐지만 실제 email verification 전까지는 로그인 세션을 만들지 않는다.
-      setCreatedEmail(session.email);
-    } catch (cause) {
-      setError(
-        cause instanceof Error ? cause.message : "계정을 만들지 못했습니다. 잠시 후 다시 시도해주세요.",
-      );
-    } finally {
-      setIsSubmitting(false);
-    }
-  }
-
-  if (createdEmail) {
-    return (
-      <main className="flex min-h-screen items-center justify-center bg-background px-5 py-12">
-        <Card className="w-full max-w-md text-center">
-          <h1 className="text-2xl font-semibold tracking-tight">이메일을 확인해주세요</h1>
-          <p className="mt-3 text-sm text-muted-foreground">
-            <span className="font-medium text-foreground">{createdEmail}</span>로 인증 링크를
-            보냈습니다. (mock/demo 모드에서는 실제 이메일이 발송되지 않습니다.)
-          </p>
-          <Link
-            to="/login"
-            className="mt-6 inline-block font-medium text-accent-subtle-foreground underline"
-          >
-            로그인하러 가기
-          </Link>
-        </Card>
-      </main>
-    );
-  }
-
   return (
     <main className="flex min-h-screen items-center justify-center bg-background px-5 py-12">
-      <Card className="w-full max-w-md">
-        <h1 className="text-2xl font-semibold tracking-tight">계정 만들기</h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          KPubData Studio 계정을 만드세요. (mock/demo — 실제 계정 인증은 아직 연결되지 않았습니다.)
+      <Card className="w-full max-w-md text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">계정 발급 안내</h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          KPubData Studio는 공개 회원가입을 제공하지 않습니다. 계정 발급 방식은 조직 정책에 따라
+          관리자가 안내합니다.
         </p>
-
-        <form className="mt-6 flex flex-col gap-4" onSubmit={handleSubmit}>
-          <FormField id="signup-name" label="이름" required>
-            {(field) => (
-              <TextInput
-                {...field}
-                autoComplete="name"
-                required
-                value={name}
-                onChange={(event) => setName(event.target.value)}
-              />
-            )}
-          </FormField>
-
-          <FormField id="signup-email" label="이메일" required>
-            {(field) => (
-              <TextInput
-                {...field}
-                type="email"
-                autoComplete="email"
-                required
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-              />
-            )}
-          </FormField>
-
-          <FormField id="signup-password" label="비밀번호" required>
-            {(field) => (
-              <TextInput
-                {...field}
-                type="password"
-                autoComplete="new-password"
-                required
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-              />
-            )}
-          </FormField>
-
-          <fieldset className="flex flex-col gap-2">
-            <legend className="text-sm font-medium text-foreground">계정 유형</legend>
-            <label className="flex items-center gap-2 text-sm text-foreground">
-              <input
-                type="radio"
-                name="accountType"
-                value="individual"
-                checked={accountType === "individual"}
-                onChange={() => setAccountType("individual")}
-              />
-              개인
-            </label>
-            <label className="flex items-center gap-2 text-sm text-foreground">
-              <input
-                type="radio"
-                name="accountType"
-                value="organization"
-                checked={accountType === "organization"}
-                onChange={() => setAccountType("organization")}
-              />
-              팀 · 기관
-            </label>
-          </fieldset>
-
-          {accountType === "organization" ? (
-            <FormField id="signup-org" label="기관/팀명" help="선택 입력입니다.">
-              {(field) => (
-                <TextInput
-                  {...field}
-                  value={organizationName}
-                  onChange={(event) => setOrganizationName(event.target.value)}
-                />
-              )}
-            </FormField>
-          ) : null}
-
-          <ErrorMessage>{error}</ErrorMessage>
-
-          <Button type="submit" loading={isSubmitting} className="mt-2">
-            계정 만들기
-          </Button>
-        </form>
-
-        <p className="mt-6 text-center text-sm text-muted-foreground">
-          이미 계정이 있으신가요?{" "}
-          <Link to="/login" className="font-medium text-accent-subtle-foreground underline">
-            로그인
-          </Link>
-        </p>
+        <Link to="/login" className="mt-6 inline-block font-medium text-accent-subtle-foreground underline">
+          로그인하러 가기
+        </Link>
       </Card>
     </main>
   );

--- a/src/shared/ui/DemoBadge.tsx
+++ b/src/shared/ui/DemoBadge.tsx
@@ -1,0 +1,26 @@
+/**
+ * 공용 DEMO/DEV 환경 배지.
+ *
+ * 실제 계정 인증이 아직 연결되지 않은 mock/demo 환경임을 반복되는 안내 문장 대신
+ * 눈에 띄는 배지 하나로 표시한다. `isRealBuilderEnabled()`(실제 Builder 연동 여부)로
+ * 판단하는 호출부에서만 조건부로 렌더링한다 — 이 컴포넌트 자체는 항상 "DEMO"를 뜻한다.
+ */
+import { cn } from "./cn";
+
+export interface DemoBadgeProps {
+  className?: string;
+}
+
+export function DemoBadge({ className }: DemoBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wider text-amber-800 dark:bg-amber-950/50 dark:text-amber-300",
+        className,
+      )}
+    >
+      <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-current" />
+      DEMO
+    </span>
+  );
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -11,6 +11,7 @@ export { PageHeader, type PageHeaderProps } from "./PageHeader";
 export { PlaceholderPage, type PlaceholderPageProps } from "./PlaceholderPage";
 export { EmptyState, type EmptyStateProps } from "./EmptyState";
 export { StatusBadge, type StatusBadgeProps, type StatusValue } from "./StatusBadge";
+export { DemoBadge, type DemoBadgeProps } from "./DemoBadge";
 export { Stepper, type StepperProps, type StepItem, type StepState } from "./Stepper";
 export { FormField, type FormFieldProps, type FormFieldRenderProps } from "./FormField";
 export { TextInput, type TextInputProps } from "./TextInput";


### PR DESCRIPTION
## 목적
원본 PR #314는 base가 브랜치(`fix/ui-audit-hardening`)로 지정되어 main에 반영되지 않았습니다. 동일 작업(eaf2b00)을 base main으로 재머지합니다. #313은 이미 main에 있어 diff는 #314분(+829/-321)만 됩니다.

## 내용
- Home Kubi 자연어 질문 Hero · Dataset Detail **Data Passport** · Bronze/Silver/Gold pipeline 설명
- Login/Signup ADR 0015 정책 정렬 + 공용 DemoBadge · Kubi BuildSpec patch 제안 라벨

## 검증
- 로컬 조합 실측(#314+#313+#main): typecheck 0, vitest 983 통과, E2E 33 통과