### PR TITLE
fix: harden Kubi real E2E grounding and response flows

### DIFF
--- a/__tests__/datasetDetail.test.tsx
+++ b/__tests__/datasetDetail.test.tsx
@@ -174,7 +174,9 @@ describe("Dataset Detail P0 (#253)", () => {
   });
 
   it("AI tab demo (no API key, mock mode): Generated SQL and Result Preview render deterministically, clearly labeled as demo (#256 review)", async () => {
-    renderDetail("/datasets/air-quality?tab=ai&stage=silver");
+    // air-2026-08-14는 multi-source run이라 어느 소스인지 URL에 있어야 stage evidence가
+    // fail-closed로 빠지지 않는다(#319 후속) — Dataset Detail의 goToTab("ai")가 실제로 하는 동기화.
+    renderDetail("/datasets/air-quality?tab=ai&source=datago__air&stage=silver");
     const panel = await screen.findByRole("tabpanel", { name: "AI" });
 
     fireEvent.click(within(panel).getByRole("button", { name: "데모 질문 보내보기" }));

--- a/__tests__/kubiSession.test.tsx
+++ b/__tests__/kubiSession.test.tsx
@@ -367,7 +367,7 @@ describe("useKubiSession — askDemo (#256 review, mock mode Kubi 데모)", () =
   it("works without any API key configured and never calls the LLM provider", async () => {
     vi.mocked(createProvider).mockClear();
     const { result } = renderHook(() => useKubiSession(), {
-      wrapper: makeWrapper("/datasets/air-quality?run=air-2026-08-14&stage=silver"),
+      wrapper: makeWrapper("/datasets/air-quality?run=air-2026-08-14&source=datago__air&stage=silver"),
     });
     expect(result.current.isConfigured).toBe(false);
     expect(result.current.isDemoAvailable).toBe(true);
@@ -400,7 +400,7 @@ describe("useKubiSession — askDemo (#256 review, mock mode Kubi 데모)", () =
     const fetchMock = vi.fn(async (_input: unknown) => new Response(null, { status: 500 }));
     vi.stubGlobal("fetch", fetchMock);
     const { result } = renderHook(() => useKubiSession(), {
-      wrapper: makeWrapper("/datasets/air-quality?run=air-2026-08-14&stage=silver"),
+      wrapper: makeWrapper("/datasets/air-quality?run=air-2026-08-14&source=datago__air&stage=silver"),
     });
     await act(async () => {
       await result.current.askDemo("지역별 분포 보여줘");

--- a/src/features/assistant/provider.test.ts
+++ b/src/features/assistant/provider.test.ts
@@ -120,6 +120,63 @@ describe("assistant safe egress (#273)", () => {
     expect(requestBody).toContain("__SCRUBBED_");
   });
 
+  it("safeRunIds 옵션: 확인된 run id 는 egress 에 보존하고 인접 시크릿은 스크럽한다", async () => {
+    const runId = "datago-air-quality-1788004513062";
+    const adjacentSecret = "xJ7kL9mN2pQ4rT6vW8yB3cD5eF7gH9j";
+    let requestBody = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        requestBody = String(init?.body);
+        return new Response('data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n', {
+          status: 200,
+        });
+      }),
+    );
+
+    const provider = createProvider({
+      apiKey: "byok-key",
+      model: "test-model",
+      baseUrl: "https://llm.example.com/v1",
+    });
+    const output = await drain(
+      provider.stream(
+        [{ role: "user", content: `run ${runId} 그리고 ${adjacentSecret}/${runId} 확인` }],
+        undefined,
+        { safeRunIds: new Set([runId]) },
+      ),
+    );
+
+    expect(output).toBe("ok");
+    expect(requestBody).toContain(runId);
+    expect(requestBody).not.toContain(adjacentSecret);
+    expect(requestBody).toContain("__SCRUBBED_");
+  });
+
+  it("safeRunIds 옵션 없이는 run-id 처럼 생긴 고엔트로피 값도 egress 에서 스크럽한다", async () => {
+    const runId = "datago-air-quality-1788004513062";
+    let requestBody = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        requestBody = String(init?.body);
+        return new Response('data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n', {
+          status: 200,
+        });
+      }),
+    );
+
+    const provider = createProvider({
+      apiKey: "byok-key",
+      model: "test-model",
+      baseUrl: "https://llm.example.com/v1",
+    });
+    await drain(provider.stream([{ role: "user", content: `run ${runId} 확인` }]));
+
+    expect(requestBody).not.toContain(runId);
+    expect(requestBody).toContain("__SCRUBBED_");
+  });
+
   it("일반 응답에는 시크릿이나 플레이스홀더를 노출하지 않는다", async () => {
     const secret = "low-entropy-key";
     vi.stubGlobal(

--- a/src/features/assistant/provider.ts
+++ b/src/features/assistant/provider.ts
@@ -10,6 +10,15 @@ import { createSecretScrubber, type SecretScrubber } from "./scrub";
 
 import { checkLlmBaseUrl, redactApiKey, DEFAULT_LLM_BASE_URL } from "./baseUrl";
 
+export interface AssistExchangeOptions {
+  /**
+   * generic 엔트로피 오탐에서만 면제할 exact 값 집합(현재는 Kubi가 evidence에서 확인한
+   * run id). LLM egress 스크러버(prepareMessages → scrubText/scrub)까지 그대로 전달돼
+   * canonical run id가 `[REDACTED]`되지 않게 한다. 넘기지 않으면 기존과 동일 동작.
+   */
+  safeRunIds?: ReadonlySet<string>;
+}
+
 export interface AssistMessage {
   role: "system" | "user" | "assistant";
   content: string;
@@ -27,8 +36,8 @@ const SAFE_PROVIDER: unique symbol = Symbol("safe-assist-provider");
 
 export interface AssistProvider {
   readonly [SAFE_PROVIDER]: true;
-  exchange(messages: AssistMessage[], signal?: AbortSignal): AssistExchange;
-  stream(messages: AssistMessage[], signal?: AbortSignal): AsyncIterable<string>;
+  exchange(messages: AssistMessage[], signal?: AbortSignal, options?: AssistExchangeOptions): AssistExchange;
+  stream(messages: AssistMessage[], signal?: AbortSignal, options?: AssistExchangeOptions): AsyncIterable<string>;
   readonly isConfigured: boolean;
 }
 
@@ -192,8 +201,8 @@ class SafeAssistProvider implements AssistProvider {
     return this.transport.isConfigured;
   }
 
-  exchange(messages: AssistMessage[], signal?: AbortSignal): AssistExchange {
-    const scrubber = createSecretScrubber();
+  exchange(messages: AssistMessage[], signal?: AbortSignal, options?: AssistExchangeOptions): AssistExchange {
+    const scrubber = createSecretScrubber(undefined, { safeRunIds: options?.safeRunIds });
     const safeMessages = prepareMessages(messages, scrubber);
     const output = this.transport.stream(safeMessages, signal);
     return {
@@ -204,8 +213,8 @@ class SafeAssistProvider implements AssistProvider {
     };
   }
 
-  async *stream(messages: AssistMessage[], signal?: AbortSignal): AsyncIterable<string> {
-    yield* this.exchange(messages, signal).displayOutput;
+  async *stream(messages: AssistMessage[], signal?: AbortSignal, options?: AssistExchangeOptions): AsyncIterable<string> {
+    yield* this.exchange(messages, signal, options).displayOutput;
   }
 }
 

--- a/src/features/assistant/scrub.test.ts
+++ b/src/features/assistant/scrub.test.ts
@@ -249,6 +249,61 @@ describe("P6 safeRunIds — provenance 기반 exact-value 면제 (#284)", () => 
 });
 
 /**
+ * safe evidence id — deterministic quality evidence identifier 도 exact-value 면제 대상 (#319 후속).
+ *
+ * `qualityResultRefId` 가 만드는 canonical id(`provider.dataset::category::rule::column`)는
+ * Shannon 엔트로피가 4.0 을 넘어(길이·문자 다양성) safe set 없이는 `[REDACTED]` 로 오탐된다.
+ * run id 와 provenance 계약이 같으므로(이번 로딩에서 실제 생성된 exact 문자열) 같은 인자로
+ * 면제하되, secret-named field / 명시적 credential 대입 / lookalike 는 여전히 스크럽해야 한다.
+ */
+describe("safe evidence id — canonical quality identifier 면제 (#319)", () => {
+  const QUALITY_ID = "datago.air_quality::completeness::min_rows::_";
+  const safeValues = new Set([QUALITY_ID]);
+
+  it("safe set 없이는 canonical quality id 도 엔트로피 오탐으로 스크럽된다(기존 동작)", () => {
+    expect(looksLikeSecret(QUALITY_ID)).toBe(true);
+    expect(redactSecrets({ evidenceRefs: [{ kind: "quality", id: QUALITY_ID }] })).toEqual({
+      evidenceRefs: [{ kind: "quality", id: "[REDACTED]" }],
+    });
+  });
+
+  it("safe set 에 exact 로 들어간 quality id 는 evidence/자유 텍스트에서 보존된다", () => {
+    expect(looksLikeSecret(QUALITY_ID, safeValues)).toBe(false);
+
+    const redacted = redactSecrets(
+      {
+        quality: { results: [{ id: QUALITY_ID, rule: "min_rows", actual: 40, threshold: 1000 }] },
+        evidenceRefs: [{ kind: "quality", id: QUALITY_ID, label: "행 수 검사" }],
+      },
+      safeValues,
+    );
+    expect(JSON.stringify(redacted)).not.toContain("[REDACTED]");
+    expect(JSON.stringify(redacted)).toContain(QUALITY_ID);
+
+    const scrubber = createSecretScrubber("safe-ev-a", { safeRunIds: safeValues });
+    expect(scrubber.scrubText(`quality:${QUALITY_ID} 근거를 확인했습니다`)).toContain(QUALITY_ID);
+  });
+
+  it("secret-named field 는 값이 safe quality id 여도 무조건 스크럽한다", () => {
+    for (const key of ["serviceKey", "apiKey", "token", "secret"]) {
+      expect(redactSecrets({ [key]: QUALITY_ID }, safeValues)).toEqual({ [key]: "[REDACTED]" });
+    }
+    const scrubber = createSecretScrubber("safe-ev-b", { safeRunIds: safeValues });
+    const out = scrubber.scrubText(`serviceKey=${QUALITY_ID}`);
+    expect(out).not.toContain(QUALITY_ID);
+    expect(hasSecretPlaceholder(out)).toBe(true);
+  });
+
+  it("safe set 밖의 비슷한 canonical id 는 면제하지 않는다(exact match 만)", () => {
+    const lookalike = "datago.air_quality::completeness::not_null::stationName";
+    expect(looksLikeSecret(lookalike, safeValues)).toBe(true);
+    expect(redactSecrets({ evidenceRefs: [{ kind: "quality", id: lookalike }] }, safeValues)).toEqual({
+      evidenceRefs: [{ kind: "quality", id: "[REDACTED]" }],
+    });
+  });
+});
+
+/**
  * P6 보완 — safe run id 에 인접(adjacency)한 시크릿 조각 스크럽 (#284).
  *
  * `<secret>/<safeRunId>` 처럼 safe id 앞뒤에 비영숫자 경계가 있으면 safe id 는 보존되지만,

--- a/src/features/assistant/scrub.test.ts
+++ b/src/features/assistant/scrub.test.ts
@@ -134,3 +134,199 @@ describe("redactSecrets — 화면용 비가역 마스킹 (#277)", () => {
     expect(JSON.stringify(redacted)).not.toContain("__SCRUBBED_");
   });
 });
+
+/**
+ * P6: exact-value allowlist 로 canonical run id false-positive 만 면제 (#284).
+ *
+ * 원칙 — 형태가 아니라 provenance 로 판단한다. 실제 Builder/evidence 에서 확인된 exact
+ * run id 만 generic 엔트로피 휴리스틱에서 면제하고, 똑같이 생긴 임의 문자열/crafted
+ * 시크릿은 그대로 스크럽한다. secret-named field / 명시적 credential 대입은 allowlist
+ * 보다 항상 우선한다.
+ */
+describe("P6 safeRunIds — provenance 기반 exact-value 면제 (#284)", () => {
+  const RUN_ID = "datago-air-quality-1788004513062";
+  // safeRunIds 에는 "실제 확인된" run id 만 들어간다(사용자 자유 텍스트에서 추론하지 않음).
+  const safeRunIds = new Set([RUN_ID]);
+
+  it("A. known run id: 자유 텍스트에서 exact run id 를 보존한다", () => {
+    const scrubber = createSecretScrubber("p6-a", { safeRunIds });
+    expect(scrubber.scrubText(`Run ${RUN_ID}의 상태를 분석해줘`)).toContain(RUN_ID);
+    // `runId=<id>` 처럼 붙어 있어도(prompt context line 형태) 보존.
+    expect(scrubber.scrubText(`현재 문맥: page=quality, runId=${RUN_ID}, stage=silver`)).toContain(
+      `runId=${RUN_ID}`,
+    );
+  });
+
+  it("A. known run id: structured evidence / suggestedAction 에서 보존한다", () => {
+    const redacted = redactSecrets(
+      {
+        context: { runId: RUN_ID },
+        deepLinks: { buildDetail: RUN_ID },
+        recentRuns: [{ runId: RUN_ID, status: "succeeded" }],
+        suggestedActions: [{ type: "OPEN_BUILD", runId: RUN_ID, reason: "실패 원인" }],
+      },
+      safeRunIds,
+    );
+    expect(JSON.stringify(redacted)).not.toContain("[REDACTED]");
+    expect(JSON.stringify(redacted)).toContain(RUN_ID);
+  });
+
+  it("B. 똑같은 모양의 unknown secret(crafted timestamp tail)은 여전히 스크럽한다", () => {
+    const crafted = "service-secret-production-abcdef-1788004513062";
+    expect(looksLikeSecret(crafted, safeRunIds)).toBe(true);
+
+    const scrubber = createSecretScrubber("p6-b", { safeRunIds });
+    const out = scrubber.scrubText(`토큰은 ${crafted} 입니다`);
+    expect(out).not.toContain(crafted);
+    expect(hasSecretPlaceholder(out)).toBe(true);
+
+    const redacted = redactSecrets({ note: crafted }, safeRunIds);
+    expect(redacted).toEqual({ note: "[REDACTED]" });
+  });
+
+  it("C. secret-named field 는 값이 safe run id 여도 무조건 스크럽한다", () => {
+    for (const key of ["serviceKey", "apiKey", "api_key", "accessToken", "clientSecret"]) {
+      const redacted = redactSecrets({ [key]: RUN_ID }, safeRunIds);
+      expect(redacted).toEqual({ [key]: "[REDACTED]" });
+    }
+  });
+
+  it("D. 명시적 free-text credential 대입은 값이 safe run id 여도 스크럽한다", () => {
+    const scrubber = createSecretScrubber("p6-d", { safeRunIds });
+    for (const text of [
+      `serviceKey=${RUN_ID}`,
+      `apiKey: ${RUN_ID}`,
+      `token=${RUN_ID}`,
+      `secret=${RUN_ID}`,
+    ]) {
+      const out = scrubber.scrubText(text);
+      expect(out).not.toContain(RUN_ID);
+      expect(hasSecretPlaceholder(out)).toBe(true);
+    }
+  });
+
+  it("E. 기존 시크릿(base64/hex/random/service key/bearer)은 회귀 없이 스크럽한다", () => {
+    const scrubber = createSecretScrubber("p6-e", { safeRunIds });
+    const secrets = [
+      SAMPLE_SERVICE_KEY, // base64-ish service key
+      "xJ7kL9mN2pQ4rT6vW8yB3cD5eF7gH9jZ", // mixed-case random token
+      "sk-live-51H8xKq9Wd0123456789abcdefABCDEF00", // bearer-like
+    ];
+    for (const s of secrets) {
+      expect(looksLikeSecret(s, safeRunIds)).toBe(true);
+      const out = scrubber.scrubText(`value ${s} end`);
+      expect(out).not.toContain(s);
+    }
+  });
+
+  it("F. safe set 에 없는 run-id 처럼 생긴 문자열은 면제하지 않는다(exact match 만)", () => {
+    const lookalike = "other-dataset-private-1788004513063"; // entropy ≥ 4, safe set 밖
+    expect(looksLikeSecret(lookalike, safeRunIds)).toBe(true);
+
+    const scrubber = createSecretScrubber("p6-f", { safeRunIds });
+    expect(scrubber.scrubText(`Run ${lookalike} 분석`)).not.toContain(lookalike);
+  });
+
+  it("G. action round-trip: known run id 는 redaction 후에도 동일, unknown 은 스크럽", () => {
+    const known = redactSecrets(
+      { suggestedActions: [{ type: "OPEN_BUILD", runId: RUN_ID }] },
+      safeRunIds,
+    );
+    expect(known).toEqual({ suggestedActions: [{ type: "OPEN_BUILD", runId: RUN_ID }] });
+
+    const unknown = redactSecrets(
+      { suggestedActions: [{ type: "OPEN_BUILD", runId: "unknown-private-run-1788004513063" }] },
+      safeRunIds,
+    );
+    expect(JSON.stringify(unknown)).toContain("[REDACTED]");
+  });
+
+  it("safeRunIds 를 넘기지 않으면 main 과 동일하게 canonical run id 도 스크럽한다", () => {
+    // 기존 non-Kubi consumer(paramsRedaction/urlRedaction/savedSpecs)의 동작 보존 확인.
+    expect(looksLikeSecret(RUN_ID)).toBe(true);
+    expect(redactSecrets({ note: RUN_ID })).toEqual({ note: "[REDACTED]" });
+  });
+});
+
+/**
+ * P6 보완 — safe run id 에 인접(adjacency)한 시크릿 조각 스크럽 (#284).
+ *
+ * `<secret>/<safeRunId>` 처럼 safe id 앞뒤에 비영숫자 경계가 있으면 safe id 는 보존되지만,
+ * 그 과정에서 safe id 를 잘라내며 남은 시크릿 조각이 24자 미만이 되어 엔트로피 검사를
+ * 빠져나가면 안 된다. safe id 만 보존하고, 주변 비-safe 조각은 전부 기존 스크럽 로직을 받는다.
+ */
+describe("P6 adjacency — safe run id 옆에 붙은 시크릿 조각도 스크럽 (#284)", () => {
+  const RUN_ID = "datago-air-quality-1788004513062";
+  const safeRunIds = new Set([RUN_ID]);
+  const HIGH_ENTROPY = "xJ7kL9mN2pQ4rT6vW8yB3cD5eF7gH9j"; // 31자, entropy ≥ 4
+
+  const SEPARATORS: [name: string, char: string][] = [
+    ["slash", "/"],
+    ["colon", ":"],
+    ["equals", "="],
+    ["comma", ","],
+  ];
+
+  it.each(SEPARATORS)(
+    "`<secret>%s<safeRunId>` (%s) — 시크릿은 스크럽하고 run id 는 보존한다",
+    (name, sep) => {
+      const scrubber = createSecretScrubber(`p6-adj-${name}`, { safeRunIds });
+      const out = scrubber.scrubText(`${HIGH_ENTROPY}${sep}${RUN_ID}`);
+      expect(out).not.toContain(HIGH_ENTROPY);
+      expect(out).toContain(RUN_ID);
+      expect(hasSecretPlaceholder(out)).toBe(true);
+    },
+  );
+
+  it.each(SEPARATORS.filter(([, char]) => char !== "="))(
+    "`<safeRunId>%s<secret>` (%s) — 뒤에 붙은 시크릿도 스크럽하고 run id 는 보존한다",
+    (name, sep) => {
+      const scrubber = createSecretScrubber(`p6-adj-suffix-${name}`, { safeRunIds });
+      const out = scrubber.scrubText(`${RUN_ID}${sep}${HIGH_ENTROPY}`);
+      expect(out).not.toContain(HIGH_ENTROPY);
+      expect(out).toContain(RUN_ID);
+    },
+  );
+
+  it("safe id 가 긴 고엔트로피 토큰을 둘로 쪼개도 양쪽 조각이 모두 스크럽된다", () => {
+    // safe id 를 빼면 각 조각은 24자 미만이라, 조각 단위 엔트로피 검사만으로는 놓친다.
+    const scrubber = createSecretScrubber("p6-adj-split", { safeRunIds });
+    const head = "xJ7kL9mN2pQ4"; // 12자
+    const tail = "rT6vW8yB3cD5eF7gH9j"; // 19자
+    const out = scrubber.scrubText(`${head}/${RUN_ID}/${tail}`);
+    expect(out).toContain(RUN_ID);
+    expect(out).not.toContain(head);
+    expect(out).not.toContain(tail);
+    expect(hasSecretPlaceholder(out)).toBe(true);
+  });
+
+  it("explicit credential 대입은 adjacency 처리보다 먼저 적용된다(값이 safe run id 여도 스크럽)", () => {
+    const scrubber = createSecretScrubber("p6-adj-assign", { safeRunIds });
+    const out = scrubber.scrubText(`serviceKey=${HIGH_ENTROPY}/${RUN_ID}`);
+    expect(out).not.toContain(HIGH_ENTROPY);
+    // assignment 는 `[^\s,}\]]+` 를 통째로 잡으므로 이 형태에서는 run id 도 함께 마스킹된다(fail-closed).
+    expect(hasSecretPlaceholder(out)).toBe(true);
+  });
+
+  it("경계 없이 이어붙은 `<secret><safeRunId>` 는 토큰 전체를 스크럽한다(fail-closed)", () => {
+    const scrubber = createSecretScrubber("p6-adj-glued", { safeRunIds });
+    const out = scrubber.scrubText(`${HIGH_ENTROPY}${RUN_ID}`);
+    expect(out).not.toContain(HIGH_ENTROPY);
+    expect(hasSecretPlaceholder(out)).toBe(true);
+  });
+
+  it("일반 산문에서 safe run id 는 인접 구두점이 있어도 그대로 보존한다", () => {
+    const scrubber = createSecretScrubber("p6-adj-prose", { safeRunIds });
+    for (const text of [`Run ${RUN_ID}의 상태`, `(${RUN_ID})`, `"${RUN_ID}".`, `${RUN_ID}, 그리고`]) {
+      expect(scrubber.scrubText(text)).toContain(RUN_ID);
+    }
+  });
+
+  it("safe set 밖의 run-id 처럼 생긴 값은 인접 경계가 있어도 스크럽한다", () => {
+    const scrubber = createSecretScrubber("p6-adj-lookalike", { safeRunIds });
+    const lookalike = "other-dataset-private-1788004513063";
+    const out = scrubber.scrubText(`${HIGH_ENTROPY}/${lookalike}`);
+    expect(out).not.toContain(HIGH_ENTROPY);
+    expect(out).not.toContain(lookalike);
+  });
+});

--- a/src/features/assistant/scrub.ts
+++ b/src/features/assistant/scrub.ts
@@ -21,6 +21,24 @@ const SECRET_KEY_PATTERNS = [
 const SHANNON_ENTROPY_THRESHOLD = 4.0;
 const MIN_LENGTH_FOR_ENTROPY = 24;
 
+/**
+ * generic 엔트로피 오탐에서만 면제할 "출처가 검증된 exact 값" 집합의 기본값(빈 집합).
+ *
+ * 이 인자를 넘기지 않는 기존 consumer(paramsRedaction/urlRedaction/savedSpecs/일반
+ * assistant)는 main과 완전히 동일한 스크럽 동작을 유지한다. Kubi 경로만 실제 Builder/
+ * evidence에서 만든 run id 집합을 넘겨, canonical run id가 `[REDACTED]`되는 것을 막는다.
+ *
+ * 중요: 이 면제는 "형태가 run id 같다"가 아니라 "이 실행에서 실제 resource identity로
+ * 확인된 exact 문자열"에만 적용된다. secret-named field masking(isSecretKey)과 명시적
+ * credential 대입 스크럽은 이 면제보다 항상 먼저 적용된다.
+ */
+const NO_SAFE_VALUES: ReadonlySet<string> = new Set();
+
+/** 정규식 리터럴로 안전하게 끼워 넣기 위해 메타문자를 escape 한다. */
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export function isSecretKey(keyName: string): boolean {
   return SECRET_KEY_PATTERNS.some((p) => p.test(keyName));
 }
@@ -42,8 +60,21 @@ function shannonEntropy(value: string): number {
   return h;
 }
 
-export function looksLikeSecret(value: string): boolean {
+/**
+ * 값이 API key/token 같은 고엔트로피 시크릿처럼 보이는지 Shannon 엔트로피로 판정한다.
+ *
+ * @param value - 검사 대상 문자열.
+ * @param safeValues - 이 실행에서 실제 resource identity로 확인된 exact 값 집합. 여기에
+ *   정확히(대소문자·전체 문자열까지) 일치하는 값만 엔트로피 휴리스틱에서 면제한다.
+ *   부분 일치/형태 매칭은 하지 않는다 — crafted `<words>-<timestamp>` 시크릿은 exact
+ *   match가 아니므로 그대로 아래 엔트로피 검사에 걸린다.
+ */
+export function looksLikeSecret(
+  value: string,
+  safeValues: ReadonlySet<string> = NO_SAFE_VALUES,
+): boolean {
   if (value.length < MIN_LENGTH_FOR_ENTROPY) return false;
+  if (safeValues.has(value)) return false;
   return shannonEntropy(value) >= SHANNON_ENTROPY_THRESHOLD;
 }
 
@@ -68,8 +99,21 @@ function requestId(): string {
   return globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
 }
 
-export function createSecretScrubber(id = requestId()): SecretScrubber {
+export interface SecretScrubberOptions {
+  /**
+   * 이 스크러버 인스턴스가 generic 엔트로피 검사에서만 면제할 exact 값 집합.
+   * secret-named field / 명시적 credential 대입 스크럽에는 영향을 주지 않는다.
+   * 넘기지 않으면 빈 집합 — main과 동일 동작.
+   */
+  safeRunIds?: ReadonlySet<string>;
+}
+
+export function createSecretScrubber(
+  id = requestId(),
+  options: SecretScrubberOptions = {},
+): SecretScrubber {
   const placeholders = new Map<string, string>();
+  const safeRunIds = options.safeRunIds ?? NO_SAFE_VALUES;
   let counter = 0;
 
   function replace(value: string): string {
@@ -79,7 +123,9 @@ export function createSecretScrubber(id = requestId()): SecretScrubber {
   }
 
   function scrubValue(key: string, value: unknown): unknown {
-    if (typeof value === "string" && (isSecretKey(key) || looksLikeSecret(value))) {
+    // 우선순위: (1) secret-named field는 값이 known safe run id여도 무조건 스크럽,
+    // (2) 그 외에는 safeRunIds exact match일 때만 엔트로피 오탐에서 면제.
+    if (typeof value === "string" && (isSecretKey(key) || looksLikeSecret(value, safeRunIds))) {
       return replace(value);
     }
     // 배열도 순회한다 (#226 결함 a). BuildSpec.sources 가 배열이라
@@ -99,6 +145,17 @@ export function createSecretScrubber(id = requestId()): SecretScrubber {
     return value;
   }
 
+  /**
+   * safe run id 에 인접한 조각을 마스킹할지 판정한다. safe id 자체는 절대 여기 오지 않는다 —
+   * `nonSafeLooksSecret`은 "이 토큰에서 safe id 를 전부 제거한 나머지"가 시크릿처럼 보이는지로,
+   * 조각을 따로 떼면 24자 미만이 되어 엔트로피 검사를 빠져나가는 경우(`<secret>/<safeId>`)를 막는다.
+   */
+  function maskAdjacentFragment(fragment: string, nonSafeLooksSecret: boolean): string {
+    if (!fragment || fragment.startsWith(SCRUBBED_PREFIX)) return fragment;
+    if (nonSafeLooksSecret || looksLikeSecret(fragment, safeRunIds)) return replace(fragment);
+    return fragment;
+  }
+
   function scrubText(text: string): string {
     const assignmentPattern = /\b([\w-]*(?:servicekey|api[_-]?key|token|secret))([ \t]*[:=][ \t]*)([^\s,}\]]+)/gi;
     const assigned = text.replace(assignmentPattern, (_match, key: string, separator: string, value: string) => {
@@ -107,9 +164,46 @@ export function createSecretScrubber(id = requestId()): SecretScrubber {
       return `${key}${separator}${quote}${replace(raw)}${quote}`;
     });
 
-    return assigned.replace(/\S{24,}/g, (token) => {
-      if (token.startsWith(SCRUBBED_PREFIX) || !looksLikeSecret(token)) return token;
-      return replace(token);
+    const scanForSecrets = (segment: string): string =>
+      segment.replace(/\S{24,}/g, (token) => {
+        if (token.startsWith(SCRUBBED_PREFIX) || !looksLikeSecret(token, safeRunIds)) return token;
+        return replace(token);
+      });
+
+    const alternation = [...safeRunIds]
+      .filter((value): value is string => typeof value === "string" && value.length > 0)
+      .sort((a, b) => b.length - a.length)
+      .map(escapeRegExp);
+    if (alternation.length === 0) return scanForSecrets(assigned);
+
+    // 검증된 safe run id 는 "앞뒤가 영숫자가 아닌" 경계로 등장할 때만 그대로 보존한다
+    // (`runId=<id>`, `/builds/<id>`, `<id>의`, 따옴표/콤마/슬래시 경계). `SECRET<id>`처럼
+    // 영숫자로 직접 이어붙은 형태는 경계 검사에 걸리지 않아 토큰 전체가 스크럽된다.
+    const boundary = `(?<![A-Za-z0-9])(?:${alternation.join("|")})(?![A-Za-z0-9])`;
+    const safeIdTest = new RegExp(boundary);
+    const safeIdSplit = new RegExp(boundary, "g");
+
+    // 공백으로 나뉘는 토큰 단위로 처리한다. safe id 를 포함하지 않는 토큰은 기존 엔트로피
+    // 검사를 그대로 받고, safe id 가 붙어 있는 토큰은 safe id 부분만 보존한 채 그 앞뒤(및
+    // 사이) 비-safe 조각을 검사한다. 조각을 단순히 면제하지 않고, "safe id 를 제거한 나머지
+    // 전체"가 시크릿처럼 보이면 모든 비-safe 조각을 마스킹한다 — `<secret>/<safeId>` 처럼
+    // 짧게 쪼개진 시크릿 조각이 엔트로피 검사를 빠져나가지 못하게 한다.
+    return assigned.replace(/\S+/g, (token) => {
+      if (token.startsWith(SCRUBBED_PREFIX)) return token;
+      if (!safeIdTest.test(token)) {
+        return looksLikeSecret(token, safeRunIds) ? replace(token) : token;
+      }
+      safeIdSplit.lastIndex = 0;
+      const nonSafeLooksSecret = looksLikeSecret(token.replace(safeIdSplit, ""), safeRunIds);
+      safeIdSplit.lastIndex = 0;
+      let out = "";
+      let cursor = 0;
+      for (const match of token.matchAll(safeIdSplit)) {
+        const index = match.index ?? 0;
+        out += maskAdjacentFragment(token.slice(cursor, index), nonSafeLooksSecret) + match[0];
+        cursor = index + match[0].length;
+      }
+      return out + maskAdjacentFragment(token.slice(cursor), nonSafeLooksSecret);
     });
   }
 
@@ -174,8 +268,11 @@ export function hasSecretPlaceholder(data: unknown): boolean {
   return false;
 }
 
-export function redactSecrets(data: unknown): unknown {
-  const scrubber = createSecretScrubber();
+export function redactSecrets(
+  data: unknown,
+  safeRunIds: ReadonlySet<string> = NO_SAFE_VALUES,
+): unknown {
+  const scrubber = createSecretScrubber(undefined, { safeRunIds });
   const scrubbed = scrubber.scrub(data);
 
   function redact(value: unknown): unknown {

--- a/src/features/kubi/context.test.ts
+++ b/src/features/kubi/context.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { contextsMatch, resolveKubiContext } from "./context";
+
+/**
+ * KubiContext SSOT resolver (#256 + #319 후속).
+ *
+ * Kubi 는 route(`?dataset=&run=&source=&stage=`)만 문맥으로 읽는다. QualityPage/Dataset Detail 이
+ * 선택한 source 를 `?source=` 로 실어 보내면 resolver 가 `source` 로 넘겨야 multi-source run 에서
+ * stage evidence 를 올바른 소스로 조회하고, source 를 바꿨을 때 이전 turn 이 stale 처리된다.
+ */
+describe("resolveKubiContext — source_key", () => {
+  it("carries ?source= into context.source on the quality route", () => {
+    const { context } = resolveKubiContext(
+      "/quality",
+      "?dataset=air-quality&run=air-2026-08-14&source=datago__air&stage=silver",
+    );
+    expect(context).toMatchObject({
+      page: "quality",
+      datasetId: "air-quality",
+      runId: "air-2026-08-14",
+      source: "datago__air",
+      stage: "silver",
+    });
+  });
+
+  it("treats an empty ?source= ('전체 소스') as no source_key — not guessed", () => {
+    const { context } = resolveKubiContext("/quality", "?dataset=air-quality&run=r1&source=");
+    expect(context.source).toBeUndefined();
+  });
+
+  it("resolves ?source= on the dataset-detail route too", () => {
+    const { context } = resolveKubiContext("/datasets/air-quality", "?run=r1&source=kma__weather&stage=gold");
+    expect(context.source).toBe("kma__weather");
+  });
+});
+
+describe("contextsMatch — source_key participates in the stale guard", () => {
+  const base = { page: "quality", datasetId: "d", runId: "r", stage: "silver" as const };
+
+  it("same source_key → match", () => {
+    expect(contextsMatch({ ...base, source: "datago__air" }, { ...base, source: "datago__air" })).toBe(true);
+  });
+
+  it("different source_key → no match (turn goes stale)", () => {
+    expect(contextsMatch({ ...base, source: "datago__air" }, { ...base, source: "kma__weather" })).toBe(false);
+  });
+
+  it("source_key present vs absent → no match", () => {
+    expect(contextsMatch({ ...base, source: "datago__air" }, base)).toBe(false);
+  });
+});

--- a/src/features/kubi/context.ts
+++ b/src/features/kubi/context.ts
@@ -80,12 +80,16 @@ export function resolveKubiContext(pathname: string, search = ""): KubiRouteReso
   const runId = buildId ?? (params.get("run") ?? undefined);
   const stageParam = params.get("stage");
   const stage = isKubiStage(stageParam) ? stageParam : undefined;
+  // Dataset Detail/Quality가 선택된 소스를 `?source=`로 실어 보낸다(#253/#254). 빈 문자열
+  // ("전체 소스")은 명시적 선택이므로 context로는 넘기지 않는다.
+  const source = params.get("source") || undefined;
 
   const context: KubiContext = {
     page,
     ...(datasetId ? { datasetId } : {}),
     ...(runId ? { runId } : {}),
     ...(stage ? { stage } : {}),
+    ...(source ? { source } : {}),
   };
 
   return { context, pageLabel, pathname };
@@ -97,6 +101,7 @@ export function contextsMatch(a: KubiContext, b: KubiContext): boolean {
     a.page === b.page &&
     (a.datasetId ?? null) === (b.datasetId ?? null) &&
     (a.runId ?? null) === (b.runId ?? null) &&
-    (a.stage ?? null) === (b.stage ?? null)
+    (a.stage ?? null) === (b.stage ?? null) &&
+    (a.source ?? null) === (b.source ?? null)
   );
 }

--- a/src/features/kubi/crossCheck.test.ts
+++ b/src/features/kubi/crossCheck.test.ts
@@ -20,6 +20,7 @@ function makeKnownRefs(overrides: Partial<KubiKnownRefs> = {}): KubiKnownRefs {
     providers: new Set(["datago"]),
     qualityResultIds: new Set(["src::missing::max_null_ratio::price"]),
     schemaDriftIds: new Set(["column_added::region"]),
+    sourceKeys: new Set(["datago.air_quality"]),
     ...overrides,
   };
 }
@@ -137,6 +138,87 @@ describe("crossCheckKubiResponse (#256 hallucination gate)", () => {
       makeKnownRefs(),
     );
     expect(result.response.generatedSql).not.toBeNull();
+  });
+
+  it("keeps generatedSql.source when it exactly matches a known canonical source_key", () => {
+    const result = crossCheckKubiResponse(
+      makeResponse({ generatedSql: { sql: "SELECT * FROM dataset", stage: "silver", source: "datago.air_quality" } }),
+      makeEvidence(),
+      makeKnownRefs({ sourceKeys: new Set(["datago.air_quality"]) }),
+    );
+    expect(result.response.generatedSql).toEqual({
+      sql: "SELECT * FROM dataset",
+      stage: "silver",
+      source: "datago.air_quality",
+    });
+    expect(result.rejectedSqlReason).toBeUndefined();
+  });
+
+  it("validates generatedSql.source even when stage evidence is unavailable (uses knownRefs.sourceKeys)", () => {
+    const result = crossCheckKubiResponse(
+      makeResponse({ generatedSql: { sql: "SELECT * FROM dataset", stage: "silver", source: "datago__air" } }),
+      makeEvidence({ stage: undefined, dataset: undefined }),
+      makeKnownRefs({ sourceKeys: new Set(["datago.air_quality", "kma.weather"]) }),
+    );
+    // multi-source + 미검증 source → fail-closed (SQL 통째로 제외)
+    expect(result.response.generatedSql).toBeNull();
+    expect(result.rejectedSqlReason).toContain("datago__air");
+  });
+
+  it("drops only the source (keeps SQL) for a single-source run with an unverifiable source", () => {
+    const result = crossCheckKubiResponse(
+      makeResponse({ generatedSql: { sql: "SELECT * FROM dataset", stage: "silver", source: "datago__air" } }),
+      makeEvidence({ stage: undefined }),
+      makeKnownRefs({ sourceKeys: new Set(["datago.air_quality"]) }),
+    );
+    expect(result.response.generatedSql).toEqual({ sql: "SELECT * FROM dataset", stage: "silver", source: undefined });
+    expect(result.rejectedSqlReason).toContain("Builder가 자동");
+  });
+
+  it("uses dataset.sources length as the single-source signal when no sourceKeys were collected", () => {
+    const result = crossCheckKubiResponse(
+      makeResponse({ generatedSql: { sql: "SELECT * FROM dataset", stage: "silver", source: "guessed.source" } }),
+      makeEvidence({
+        stage: undefined,
+        dataset: {
+          datasetId: "ds-1",
+          title: "t",
+          providers: ["datago"],
+          sources: [{ provider: "datago", dataset: "air_quality" }],
+          latestRunId: "run-1",
+          status: "ready",
+          updatedAt: null,
+          totalRowCount: 0,
+        },
+      }),
+      makeKnownRefs({ sourceKeys: new Set() }),
+    );
+    expect(result.response.generatedSql?.sql).toBe("SELECT * FROM dataset");
+    expect(result.response.generatedSql?.source).toBeUndefined();
+  });
+
+  it("fail-closes (drops whole SQL) for a multi-source run when nothing verifies the source", () => {
+    const result = crossCheckKubiResponse(
+      makeResponse({ generatedSql: { sql: "SELECT * FROM dataset", stage: "silver", source: "guessed.source" } }),
+      makeEvidence({
+        stage: undefined,
+        dataset: {
+          datasetId: "ds-1",
+          title: "t",
+          providers: ["datago", "kma"],
+          sources: [
+            { provider: "datago", dataset: "air_quality" },
+            { provider: "kma", dataset: "weather" },
+          ],
+          latestRunId: "run-1",
+          status: "ready",
+          updatedAt: null,
+          totalRowCount: 0,
+        },
+      }),
+      makeKnownRefs({ sourceKeys: new Set() }),
+    );
+    expect(result.response.generatedSql).toBeNull();
   });
 
   it("does not discard the whole answer when some refs/actions are rejected", () => {

--- a/src/features/kubi/crossCheck.ts
+++ b/src/features/kubi/crossCheck.ts
@@ -123,9 +123,21 @@ export function crossCheckKubiResponse(
     if (evidence.context.stage !== generatedSql.stage) {
       rejectedSqlReason = `현재 화면 stage(${evidence.context.stage ?? "없음"})와 제안된 SQL의 stage(${generatedSql.stage})가 일치하지 않아 실행 대상에서 제외했습니다.`;
       generatedSql = null;
-    } else if (generatedSql.source && evidence.stage && generatedSql.source !== evidence.stage.sourceKey) {
-      rejectedSqlReason = `evidence에 없는 source "${generatedSql.source}"를 참조해 실행 대상에서 제외했습니다.`;
-      generatedSql = null;
+    } else if (generatedSql.source && !knownRefs.sourceKeys.has(generatedSql.source)) {
+      // 모델이 만든 source 문자열이 evidence의 canonical source_key와 정확히 일치하지 않는다.
+      // "__"→"." 같은 추측성 정규화는 하지 않는다 — canonical evidence와 대조만 한다.
+      // (evidence.stage가 없어도 quality 결과·stage 목록에서 모은 knownRefs.sourceKeys로 검증한다.)
+      const singleSource = knownRefs.sourceKeys.size === 1 || evidence.dataset?.sources.length === 1;
+      if (singleSource) {
+        // 단일 소스 run이고 다른 ambiguity가 없으므로, 미검증 source는 버리고 Builder가
+        // 유일 source를 자동 선택하게 한다(SQL 본문 자체는 살린다).
+        rejectedSqlReason = `제안된 source "${generatedSql.source}"를 evidence에서 확인할 수 없어 제거했습니다. 단일 소스 run이라 Builder가 자동으로 소스를 선택합니다.`;
+        generatedSql = { ...generatedSql, source: undefined };
+      } else {
+        // multi-source에서 미검증 source는 어떤 소스를 조회할지 결정할 수 없다 — fail-closed.
+        rejectedSqlReason = `evidence에 없는 source "${generatedSql.source}"를 참조해 실행 대상에서 제외했습니다.`;
+        generatedSql = null;
+      }
     }
   }
 

--- a/src/features/kubi/crossCheck.ts
+++ b/src/features/kubi/crossCheck.ts
@@ -32,7 +32,7 @@ function isKnownEvidenceRef(ref: KubiEvidenceRef, known: KubiKnownRefs, evidence
     case "schema_drift":
       return known.schemaDriftIds.has(ref.id);
     case "stage":
-      return Boolean(evidence.stage) && ref.id === `${evidence.stage!.sourceKey}:${evidence.stage!.stage}`;
+      return Boolean(evidence.stage) && ref.id === `${evidence.stage!.source}:${evidence.stage!.stage}`;
     default:
       return false;
   }

--- a/src/features/kubi/demo.test.ts
+++ b/src/features/kubi/demo.test.ts
@@ -59,7 +59,7 @@ describe("buildKubiDemoResponse (#256 데모)", () => {
         results: [
           {
             id: "datago__air::missing::max_null_ratio::pm10",
-            sourceKey: "datago__air",
+            source: "datago__air",
             category: "missing",
             rule: "max_null_ratio",
             column: "pm10",
@@ -103,7 +103,7 @@ describe("buildKubiDemoResponse (#256 데모)", () => {
     const withStage = baseEvidence({
       ...datasetOnly,
       context: { page: "dataset-detail", datasetId: "air-quality", stage: "silver" },
-      stage: { stage: "silver", sourceKey: "datago__air", status: "completed", available: true, rowCount: 1000 },
+      stage: { stage: "silver", source: "datago__air", status: "completed", available: true, rowCount: 1000 },
     });
     const response = buildKubiDemoResponse(withStage);
     expect(response.generatedSql).toEqual({
@@ -117,11 +117,11 @@ describe("buildKubiDemoResponse (#256 데모)", () => {
   it("demo SQL never uses the source_key as a FROM table name — only the logical relation \"dataset\"", () => {
     const evidence = baseEvidence({
       context: { page: "dataset-detail", datasetId: "air-quality", stage: "gold" },
-      stage: { stage: "gold", sourceKey: "datago__air", status: "completed", available: true, rowCount: 1000 },
+      stage: { stage: "gold", source: "datago__air", status: "completed", available: true, rowCount: 1000 },
     });
     const response = buildKubiDemoResponse(evidence);
     expect(response.generatedSql?.sql).toMatch(/FROM dataset\b/);
-    expect(response.generatedSql?.sql).not.toContain(evidence.stage!.sourceKey);
+    expect(response.generatedSql?.sql).not.toContain(evidence.stage!.source);
     expect(response.generatedSql?.source).toBe("datago__air");
   });
 });

--- a/src/features/kubi/demo.ts
+++ b/src/features/kubi/demo.ts
@@ -75,12 +75,12 @@ export function buildKubiDemoResponse(evidence: KubiEvidence): KubiStructuredRes
       // FROM 테이블명이 아니라 아래 source 필드로 별도 전달한다(query.ts가 /query 요청에 얹는다).
       sql: `SELECT region, COUNT(*) AS count FROM dataset GROUP BY region`,
       stage: evidence.context.stage,
-      source: evidence.stage.sourceKey,
+      source: evidence.stage.source,
     };
     evidenceRefs.push({
       kind: "stage",
-      id: `${evidence.stage.sourceKey}:${evidence.stage.stage}`,
-      label: `${evidence.stage.sourceKey} · ${evidence.stage.stage}`,
+      id: `${evidence.stage.source}:${evidence.stage.stage}`,
+      label: `${evidence.stage.source} · ${evidence.stage.stage}`,
     });
     lines.push("Generated SQL은 데모용 미리보기 조회입니다 — 실행하면 mock 결과가 표시됩니다(실제 Builder 호출 없음).");
   } else if (evidence.dataset) {

--- a/src/features/kubi/evidence.test.ts
+++ b/src/features/kubi/evidence.test.ts
@@ -95,3 +95,72 @@ describe("loadKubiEvidence (#256)", () => {
     expect(knownRefs.runIds.size).toBe(0);
   });
 });
+
+/**
+ * Run provenance — knownRefs.runIds 와 safeRunIds 는 역할이 다르지만 provenance 계약은 같다
+ * (#284 + 독립 리뷰 blocker).
+ *
+ * 두 Set 모두 "이번 evidence 로딩에서 Builder 응답으로 실제 존재가 확인된 run id" 만 담는다.
+ * route/context.runId 는 evidence.context / deepLink 에는 남을 수 있어도, 존재가 확인되기
+ * 전에는 knownRefs.runIds / safeRunIds 어디에도 들어가지 않는다.
+ */
+describe("loadKubiEvidence — run provenance (knownRefs.runIds / safeRunIds)", () => {
+  it("Builder 응답(getDataset.latest_run_id / listDatasetRuns)이 확인한 run id 는 safeRunIds 에 들어간다", async () => {
+    const context: KubiContext = { page: "dataset-detail", datasetId: "air-quality", runId: "air-2026-08-14" };
+    const { knownRefs, safeRunIds } = await loadKubiEvidence(context);
+
+    expect(safeRunIds.has("air-2026-08-14")).toBe(true);
+    // listDatasetRuns 로 확인된 과거 run 도 포함.
+    expect(safeRunIds.has("air-2026-08-13")).toBe(true);
+    // safeRunIds ⊆ knownRefs.runIds (분리했지만 확인된 값은 양쪽 모두에 있다).
+    for (const id of safeRunIds) expect(knownRefs.runIds.has(id)).toBe(true);
+  });
+
+  it("Builder 어느 응답에서도 확인되지 않은 route runId 는 knownRefs.runIds / safeRunIds 어디에도 없다", async () => {
+    // datasetId 없음 → getDataset/listDatasetRuns 호출 안 함. quality/stage 는 이 run id 로 404.
+    const unverified = "service-secret-production-abcdef-1788004513062";
+    const context: KubiContext = { page: "build-detail", runId: unverified };
+    const { knownRefs, safeRunIds } = await loadKubiEvidence(context);
+
+    expect(safeRunIds.has(unverified)).toBe(false);
+    expect(safeRunIds.size).toBe(0);
+    // 독립 리뷰 blocker: route 값만으로는 knownRefs.runIds 에도 들어가지 않는다.
+    expect(knownRefs.runIds.has(unverified)).toBe(false);
+    expect(knownRefs.runIds.size).toBe(0);
+  });
+
+  it("확인되지 않은 저엔트로피 route runId 는 evidence.context/deepLink 에는 남지만 trust set 에는 안 들어간다", async () => {
+    // 저엔트로피라 redactSecrets 가 마스킹하지 않으므로 context 잔존을 직접 확인할 수 있다.
+    const unverified = "fake-run";
+    const context: KubiContext = { page: "build-detail", runId: unverified };
+    const { evidence, knownRefs, safeRunIds } = await loadKubiEvidence(context);
+
+    expect(evidence.context.runId).toBe("fake-run");
+    expect(evidence.deepLinks.buildDetail).toContain("fake-run");
+    expect(knownRefs.runIds.has(unverified)).toBe(false);
+    expect(safeRunIds.has(unverified)).toBe(false);
+  });
+
+  it("확인되지 않은 고엔트로피 route runId 는 evidence 에서 redact 된다(safeRunIds 로 면제하지 않으므로)", async () => {
+    const unverified = "service-secret-production-abcdef-1788004513062";
+    const context: KubiContext = { page: "build-detail", runId: unverified };
+    const { evidence } = await loadKubiEvidence(context);
+
+    // safeRunIds 가 비어 있으므로 이 고엔트로피 값은 엔트로피 오탐 면제를 받지 못하고 마스킹된다.
+    expect(evidence.context.runId).toBe("[REDACTED]");
+  });
+
+  it("확인된(safe) 저엔트로피 run id 는 evidence 에 그대로 남는다", async () => {
+    const context: KubiContext = { page: "dataset-detail", datasetId: "air-quality", runId: "air-2026-08-14" };
+    const { evidence } = await loadKubiEvidence(context);
+    expect(evidence.context.runId).toBe("air-2026-08-14");
+    expect(evidence.deepLinks.buildDetail).toContain("air-2026-08-14");
+  });
+
+  it("getBuildQuality 가 이 run id 로 정상 응답하면 knownRefs/safeRunIds 양쪽에 추가한다(datasetId 없이도)", async () => {
+    const context: KubiContext = { page: "build-detail", runId: "air-2026-08-14" };
+    const { knownRefs, safeRunIds } = await loadKubiEvidence(context);
+    expect(safeRunIds.has("air-2026-08-14")).toBe(true);
+    expect(knownRefs.runIds.has("air-2026-08-14")).toBe(true);
+  });
+});

--- a/src/features/kubi/evidence.test.ts
+++ b/src/features/kubi/evidence.test.ts
@@ -1,11 +1,13 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { saveBuildSpec } from "@/features/build-spec/specStore";
+import * as datasetsApi from "@/features/datasets/api";
 import type { BuildSpec } from "@/shared/lib/types";
 import { loadKubiEvidence } from "./evidence";
 import type { KubiContext } from "./types";
 
 afterEach(() => {
   localStorage.clear();
+  vi.restoreAllMocks();
 });
 
 describe("loadKubiEvidence (#256)", () => {
@@ -46,18 +48,129 @@ describe("loadKubiEvidence (#256)", () => {
     expect(evidence.stage).toBeUndefined();
   });
 
-  it("includes stage evidence (status/rowCount only, no raw sample rows) when a stage is in context", async () => {
+  it("includes stage evidence (status/rowCount only, no raw sample rows) for the context source_key", async () => {
+    // air-2026-08-14는 multi-source(datago__air + kma__weather)라 어느 소스인지 명시해야 한다.
     const context: KubiContext = {
       page: "dataset-detail",
       datasetId: "air-quality",
       runId: "air-2026-08-14",
       stage: "silver",
+      source: "datago__air",
     };
     const { evidence } = await loadKubiEvidence(context);
     expect(evidence.stage?.stage).toBe("silver");
-    expect(evidence.stage?.sourceKey).toBeTruthy();
+    expect(evidence.stage?.source).toBe("datago__air");
     // 원본 sample row는 evidence 타입 자체에 존재하지 않는다 — 최소 데이터 원칙(#256 리뷰 §3).
     expect(evidence.stage).not.toHaveProperty("sample");
+  });
+
+  it("fails closed (stage unavailable) for a multi-source run when the context has no source_key", async () => {
+    const context: KubiContext = {
+      page: "quality",
+      datasetId: "air-quality",
+      runId: "air-2026-08-14",
+      stage: "silver",
+    };
+    const { evidence } = await loadKubiEvidence(context);
+    // 임의로 첫 source를 고르지 않는다 — 어느 소스인지 모호하면 stage를 unavailable로 둔다.
+    expect(evidence.stage).toBeUndefined();
+    expect(evidence.unavailable).toContain("stage");
+  });
+
+  it("falls back to the sole source_key for a single-source run when the context has no source_key", async () => {
+    const context: KubiContext = {
+      page: "quality",
+      datasetId: "population",
+      runId: "population-2026-08-13",
+      stage: "silver",
+    };
+    const { evidence } = await loadKubiEvidence(context);
+    expect(evidence.stage?.stage).toBe("silver");
+    expect(evidence.stage?.source).toBe("kosis__population");
+  });
+
+  it("requests stage detail with a positive limit (real Builder rejects limit=0 with 400 → stage always unavailable)", async () => {
+    // 실 Builder `/builds/{run}/stages/{stage}` 는 limit 을 "1..1000 양의 정수" 로만 받는다.
+    // limit=0 이면 400 → settle 실패 → stage 가 항상 unavailable 로 빠지던 실 runtime 버그.
+    const spy = vi.spyOn(datasetsApi, "getBuildStageDetail");
+    const context: KubiContext = {
+      page: "quality",
+      datasetId: "population",
+      runId: "population-2026-08-13",
+      stage: "silver",
+    };
+    await loadKubiEvidence(context);
+    expect(spy).toHaveBeenCalled();
+    for (const call of spy.mock.calls) {
+      const limit = call[3];
+      expect(typeof limit).toBe("number");
+      expect(limit as number).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("exposes exact stage column names + dtypes from the Builder silver stage detail (SQL authoring evidence)", async () => {
+    // 실 Builder Gold 시나리오 재현: 실제 컬럼은 `pm10Value`(String)이고 `pm10`은 없다.
+    // LLM이 컬럼명을 추측하지 않도록 Builder가 반환한 schema를 그대로 노출해야 한다.
+    vi.spyOn(datasetsApi, "getBuildStageDetail").mockResolvedValue({
+      run_id: "population-2026-08-13",
+      stage: "silver",
+      source_key: "kosis__population",
+      status: "completed",
+      available: true,
+      row_count: 40,
+      schema: [
+        { name: "stationName", dtype: "String", nullable: false, unique_count: 40 },
+        { name: "pm10Value", dtype: "String", nullable: true, unique_count: 33 },
+      ],
+      statistics: null,
+      validation: null,
+      sample: [{ stationName: "종로구", pm10Value: "-" }],
+    });
+
+    const context: KubiContext = {
+      page: "quality",
+      datasetId: "population",
+      runId: "population-2026-08-13",
+      stage: "silver",
+    };
+    const { evidence } = await loadKubiEvidence(context);
+
+    expect(evidence.stage?.columns).toEqual(["stationName", "pm10Value"]);
+    expect(evidence.stage?.schema).toContainEqual({ name: "pm10Value", dtype: "String" });
+    // 존재하지 않는 축약 컬럼명은 evidence에 등장하지 않는다.
+    expect(evidence.stage?.columns).not.toContain("pm10");
+    // 최소 데이터 원칙: raw sample row는 여전히 evidence에 새어 나가지 않는다.
+    const serialized = JSON.stringify(evidence);
+    expect(serialized).not.toContain("종로구");
+    expect(evidence.stage).not.toHaveProperty("sample");
+  });
+
+  it("exposes gold stage column names (contract has no dtype) without inventing a schema", async () => {
+    vi.spyOn(datasetsApi, "getBuildStageDetail").mockResolvedValue({
+      run_id: "population-2026-08-13",
+      stage: "gold",
+      source_key: "kosis__population",
+      status: "completed",
+      available: true,
+      row_count: 40,
+      columns: ["stationName", "pm10Value"],
+      splits: null,
+      exports: [{ kind: "parquet" }],
+      sample: null,
+      sample_available: false,
+    });
+
+    const context: KubiContext = {
+      page: "quality",
+      datasetId: "population",
+      runId: "population-2026-08-13",
+      stage: "gold",
+    };
+    const { evidence } = await loadKubiEvidence(context);
+
+    expect(evidence.stage?.columns).toEqual(["stationName", "pm10Value"]);
+    // gold stage detail은 dtype을 주지 않는다 — 지어내지 않고 schema는 생략한다.
+    expect(evidence.stage?.schema).toBeUndefined();
   });
 
   it("never includes source param values (only param key names) in the BuildSpec summary", async () => {
@@ -85,6 +198,31 @@ describe("loadKubiEvidence (#256)", () => {
     const context: KubiContext = { page: "dataset-detail", datasetId: "air-quality", runId: "air-2026-08-14" };
     const { evidence } = await loadKubiEvidence(context);
     expect(JSON.stringify(evidence)).not.toContain("__SCRUBBED_");
+  });
+
+  it("keeps deterministic quality/schema-drift evidence ids out of entropy redaction (safeEvidenceIds provenance)", async () => {
+    const context: KubiContext = { page: "quality", datasetId: "air-quality", runId: "air-2026-08-14" };
+    const { evidence, knownRefs, safeEvidenceIds } = await loadKubiEvidence(context);
+
+    const results = evidence.quality?.results ?? [];
+    expect(results.length).toBeGreaterThan(0);
+    // canonical source_key는 secret이 아니다 — 필드명이 `source`라 redactSecrets의 `*key$`
+    // secret-named 휴리스틱에 걸리지 않고, crossCheck의 stage/그룹 대조에 그대로 쓸 수 있어야 한다.
+    for (const result of results) expect(result.source).not.toBe("[REDACTED]");
+    const ids = results.map((result) => result.id);
+    for (const id of ids) {
+      // valid quality id는 secret scrubber의 엔트로피 오탐으로 `[REDACTED]`되면 안 된다.
+      expect(id).not.toBe("[REDACTED]");
+      // 그리고 crossCheck 대조용 knownRefs와 egress 면제용 safeEvidenceIds 양쪽에 동일 값으로 들어간다.
+      expect(knownRefs.qualityResultIds.has(id)).toBe(true);
+      expect(safeEvidenceIds.has(id)).toBe(true);
+    }
+    for (const finding of evidence.quality?.schemaDrift ?? []) {
+      const driftId = `${finding.kind}::${finding.column ?? "_"}`;
+      expect(safeEvidenceIds.has(driftId)).toBe(true);
+    }
+    // safeEvidenceIds는 run id가 아니라 evidence identifier만 담는다 — run id는 safeRunIds 소관.
+    expect(safeEvidenceIds.has("air-2026-08-14")).toBe(false);
   });
 
   it("omits stage/buildSpecSummary/quality when the context has no runId at all", async () => {

--- a/src/features/kubi/evidence.ts
+++ b/src/features/kubi/evidence.ts
@@ -40,7 +40,12 @@ async function settle<T>(promise: Promise<T>): Promise<{ ok: true; value: T } | 
 export async function loadKubiEvidence(
   context: KubiContext,
   signal?: AbortSignal,
-): Promise<{ evidence: KubiEvidence; knownRefs: KubiKnownRefs; safeRunIds: Set<string> }> {
+): Promise<{
+  evidence: KubiEvidence;
+  knownRefs: KubiKnownRefs;
+  safeRunIds: Set<string>;
+  safeEvidenceIds: Set<string>;
+}> {
   const unavailable: KubiEvidenceSource[] = [];
   const evidence: KubiEvidence = {
     fetchedAt: new Date().toISOString(),
@@ -65,6 +70,15 @@ export async function loadKubiEvidence(
   // 확인되기 전에는 어느 trust set 에도 넣지 않는다. 두 Set 이 다시 어긋나지 않도록 확인된
   // run 은 반드시 이 helper 를 통해 등록한다.
   const safeRunIds = new Set<string>();
+
+  // safeRunIds 와 provenance 계약은 같지만(엔트로피 오탐에서만 면제하는 exact 값) 대상이
+  // 다르다: 여기에는 Builder `/quality` 응답 필드로부터 Studio 가 deterministic 하게 만든
+  // evidence identifier(qualityResultRefId / schema drift key)만 담는다. `datago.air_quality::
+  // completeness::min_rows::_` 같은 canonical id 는 Shannon 엔트로피가 4.0 을 넘어(길이·문자
+  // 다양성), safeRunIds 만 넘기면 redactSecrets 가 valid quality id 를 `[REDACTED]` 로
+  // 오탐한다. 형태(`quality:` prefix 등)가 아니라 "이번 로딩에서 실제로 생성한 exact 문자열"
+  // 로만 면제한다. 사용자 질문/모델 출력에서 온 값은 절대 넣지 않는다.
+  const safeEvidenceIds = new Set<string>();
 
   function confirmRunId(id: string | null | undefined): void {
     if (!id) return;
@@ -165,10 +179,11 @@ export async function loadKubiEvidence(
         results: results.map((result) => {
           const id = qualityResultRefId(result);
           knownRefs.qualityResultIds.add(id);
+          safeEvidenceIds.add(id);
           knownRefs.sourceKeys.add(result.source_key);
           return {
             id,
-            sourceKey: result.source_key,
+            source: result.source_key,
             category: result.category,
             rule: result.rule,
             column: result.column,
@@ -179,7 +194,9 @@ export async function loadKubiEvidence(
           };
         }),
         schemaDrift: drift.map((finding) => {
-          knownRefs.schemaDriftIds.add(`${finding.kind}::${finding.column ?? "_"}`);
+          const driftId = `${finding.kind}::${finding.column ?? "_"}`;
+          knownRefs.schemaDriftIds.add(driftId);
+          safeEvidenceIds.add(driftId);
           return { kind: finding.kind, column: finding.column, detail: finding.detail };
         }),
       };
@@ -196,26 +213,55 @@ export async function loadKubiEvidence(
         confirmRunId(runId);
         // stage 목록의 모든 source_key는 이 run의 실제 canonical source다 — Generated SQL의
         // source 검증에 쓸 수 있게 전부 모은다(quality evidence가 없어도 검증 가능).
-        for (const source of stagesResult.value.sources) knownRefs.sourceKeys.add(source.source_key);
-        const firstSource = stagesResult.value.sources[0];
-        if (firstSource) {
+        const sources = stagesResult.value.sources;
+        for (const source of sources) knownRefs.sourceKeys.add(source.source_key);
+        // 어느 소스의 stage를 볼지: (1) 화면에서 선택된 context.source가 이 run의 실제
+        // source면 그것을, (2) 선택이 없고 이 run의 source가 정확히 1개면 그 유일 소스를,
+        // (3) 그 외(복수 source인데 선택 없음/선택이 이 run에 없음)면 임의 선택하지 않고
+        // fail-closed로 stage를 unavailable 처리한다(P5 canonical source policy와 동일).
+        const chosenSource = context.source
+          ? sources.find((source) => source.source_key === context.source)
+          : sources.length === 1
+            ? sources[0]
+            : undefined;
+        if (chosenSource) {
+          // stage evidence 는 status/available/row_count 메타데이터만 쓰고 sample row 는
+          // 읽지 않는다. 하지만 Builder `/builds/{run}/stages/{stage}` 는 limit=0 을
+          // "positive integer up to 1000" 위반으로 400 을 준다(OpenAPI SSOT) — 실
+          // Builder 에서 stage evidence 가 항상 unavailable 로 빠지던 원인. 최소 sample(1)
+          // 로 요청해 메타데이터만 취한다.
           const detailResult = await settle(
-            getBuildStageDetail(runId, context.stage, firstSource.source_key, 0, signal),
+            getBuildStageDetail(runId, context.stage, chosenSource.source_key, 1, signal),
           );
           if (detailResult.ok) {
             const detail = detailResult.value;
             const rowCount = detail.stage === "bronze" ? detail.record_count : detail.row_count;
-            knownRefs.sourceKeys.add(firstSource.source_key);
+            knownRefs.sourceKeys.add(chosenSource.source_key);
+            // Generated SQL이 컬럼명/타입을 추측하지 않도록, Builder가 이미 반환한 stage
+            // schema만 canonical하게 노출한다. silver는 {name,dtype}까지, gold는 이름만
+            // (contract상 dtype이 없다), bronze는 없다. sample row는 여전히 읽지 않는다.
+            let columns: string[] | undefined;
+            let schema: { name: string; dtype: string }[] | undefined;
+            if (detail.stage === "silver" && detail.schema.length > 0) {
+              schema = detail.schema.map((column) => ({ name: column.name, dtype: column.dtype }));
+              columns = schema.map((column) => column.name);
+            } else if (detail.stage === "gold" && detail.columns.length > 0) {
+              columns = [...detail.columns];
+            }
             evidence.stage = {
               stage: context.stage,
-              sourceKey: firstSource.source_key,
+              source: chosenSource.source_key,
               status: detail.status,
               available: detail.available,
               rowCount,
+              ...(columns ? { columns } : {}),
+              ...(schema ? { schema } : {}),
             };
           } else {
             unavailable.push("stage");
           }
+        } else {
+          unavailable.push("stage");
         }
       } else {
         unavailable.push("stage");
@@ -227,9 +273,12 @@ export async function loadKubiEvidence(
   evidence.partial = unavailable.length > 0;
 
   // 방어적 마지막 관문: Builder 응답에 예상치 못한 credential성 필드가 섞여 있어도 여기서 걸러낸다.
-  // 엔트로피 오탐 면제는 safeRunIds(= Builder 가 존재를 확인한 exact run id) 로만 한다. 아직
-  // 확인되지 않은 route context.runId(예: `?run=` / `/builds/:id`)는 여기에도 knownRefs.runIds
-  // 에도 들어 있지 않으므로 evidence 에서 그대로 새어 나가지 않는다.
-  const redacted = redactSecrets(evidence, safeRunIds) as KubiEvidence;
-  return { evidence: redacted, knownRefs, safeRunIds };
+  // 엔트로피 오탐 면제는 provenance 가 확인된 exact 값 — safeRunIds(Builder 가 존재를 확인한
+  // run id) + safeEvidenceIds(Builder `/quality` 응답에서 deterministic 하게 만든 evidence
+  // identifier) — 로만 한다. 아직 확인되지 않은 route context.runId 나 임의 문자열은 어느
+  // 집합에도 없으므로 evidence 에서 그대로 새어 나가지 않는다. secret-named field masking 은
+  // 이 면제보다 항상 먼저 적용된다(scrub.ts).
+  const safeValues = new Set<string>([...safeRunIds, ...safeEvidenceIds]);
+  const redacted = redactSecrets(evidence, safeValues) as KubiEvidence;
+  return { evidence: redacted, knownRefs, safeRunIds, safeEvidenceIds };
 }

--- a/src/features/kubi/evidence.ts
+++ b/src/features/kubi/evidence.ts
@@ -34,12 +34,13 @@ async function settle<T>(promise: Promise<T>): Promise<{ ok: true; value: T } | 
  *
  * @param context - evidence를 구성할 대상 문맥(요청 시작 시점 값으로 고정해서 넘겨야 한다).
  * @param signal - 취소 signal.
- * @returns secret이 제거된 evidence 번들과, 응답 hallucination 검사를 위한 알려진 id 집합.
+ * @returns secret이 제거된 evidence 번들, 응답 hallucination 검사를 위한 알려진 id 집합,
+ *   그리고 LLM egress 엔트로피 오탐에서만 면제할 "Builder가 존재를 확인한" run id 집합.
  */
 export async function loadKubiEvidence(
   context: KubiContext,
   signal?: AbortSignal,
-): Promise<{ evidence: KubiEvidence; knownRefs: KubiKnownRefs }> {
+): Promise<{ evidence: KubiEvidence; knownRefs: KubiKnownRefs; safeRunIds: Set<string> }> {
   const unavailable: KubiEvidenceSource[] = [];
   const evidence: KubiEvidence = {
     fetchedAt: new Date().toISOString(),
@@ -54,7 +55,22 @@ export async function loadKubiEvidence(
     providers: new Set(),
     qualityResultIds: new Set(),
     schemaDriftIds: new Set(),
+    sourceKeys: new Set(),
   };
+
+  // knownRefs.runIds 와 safeRunIds 는 역할이 다르지만(전자는 crossCheck 의 hallucination
+  // 대조, 후자는 LLM egress/redaction 엔트로피 오탐 면제) provenance 계약은 같다: 둘 다
+  // "이번 evidence 로딩에서 Builder 응답으로 실제 존재가 확인된 run id" 만 담는다. route/
+  // context.runId 는 evidence.context / deepLink / Builder 조회 target 으로만 쓰고, 존재가
+  // 확인되기 전에는 어느 trust set 에도 넣지 않는다. 두 Set 이 다시 어긋나지 않도록 확인된
+  // run 은 반드시 이 helper 를 통해 등록한다.
+  const safeRunIds = new Set<string>();
+
+  function confirmRunId(id: string | null | undefined): void {
+    if (!id) return;
+    knownRefs.runIds.add(id);
+    safeRunIds.add(id);
+  }
 
   const catalogResult = await settle(builderApi.catalog(signal));
   if (catalogResult.ok) {
@@ -89,7 +105,9 @@ export async function loadKubiEvidence(
         updatedAt: dataset.updated_at,
         totalRowCount: dataset.total_row_count,
       };
-      knownRefs.runIds.add(dataset.latest_run_id);
+      // getDataset 성공 응답의 latest_run_id — Builder 가 확인한 값이다(schema 상 string 이나
+      // 방어적으로 falsy 를 거른다).
+      confirmRunId(dataset.latest_run_id);
       evidence.deepLinks.datasetDetail = `/datasets/${encodeURIComponent(dataset.dataset_id)}`;
       evidence.deepLinks.qualityCenter = `/quality?dataset=${encodeURIComponent(dataset.dataset_id)}`;
       runId = runId ?? dataset.latest_run_id;
@@ -104,14 +122,18 @@ export async function loadKubiEvidence(
         startedAt: run.started_at,
         finishedAt: run.finished_at,
       }));
-      for (const run of runsResult.value.runs) knownRefs.runIds.add(run.run_id);
+      // listDatasetRuns 성공 응답의 run_id — Builder 가 직접 반환한 실제 run 이다.
+      for (const run of runsResult.value.runs) confirmRunId(run.run_id);
     } else {
       unavailable.push("runs");
     }
   }
 
   if (runId) {
-    knownRefs.runIds.add(runId);
+    // runId 가 route/context 에서 왔다면(dataset.latest_run_id 로 이미 confirm 된 경우가 아니면)
+    // 아직 존재가 확인되지 않았다. deepLink 계산과 Builder 조회 target 으로는 쓰되, knownRefs/
+    // safeRunIds 에는 넣지 않는다 — 아래 getBuildQuality / listBuildStages 는 nonexistent run 에
+    // 404 를 주므로(Builder OpenAPI SSOT), 그 요청이 정상 응답할 때만 confirmRunId 로 등록한다.
     evidence.deepLinks.buildDetail = `/builds/${encodeURIComponent(runId)}`;
 
     const storedSpec = loadBuildSpec(runId);
@@ -132,6 +154,8 @@ export async function loadKubiEvidence(
 
     const qualityResult = await settle(getBuildQuality(runId, signal));
     if (qualityResult.ok) {
+      // GET /builds/{run_id}/quality 는 nonexistent run 에 404 를 준다 — 200 이면 실제 run 이다.
+      confirmRunId(runId);
       const quality = qualityResult.value;
       const results = Object.values(quality.quality_results).flat();
       const drift = Object.values(quality.schema_drift).flat();
@@ -141,6 +165,7 @@ export async function loadKubiEvidence(
         results: results.map((result) => {
           const id = qualityResultRefId(result);
           knownRefs.qualityResultIds.add(id);
+          knownRefs.sourceKeys.add(result.source_key);
           return {
             id,
             sourceKey: result.source_key,
@@ -167,6 +192,11 @@ export async function loadKubiEvidence(
     if (context.stage) {
       const stagesResult = await settle(listBuildStages(runId, signal));
       if (stagesResult.ok) {
+        // GET /builds/{run_id}/stages 도 nonexistent run 에 404 를 준다 — 200 이면 실제 run 이다.
+        confirmRunId(runId);
+        // stage 목록의 모든 source_key는 이 run의 실제 canonical source다 — Generated SQL의
+        // source 검증에 쓸 수 있게 전부 모은다(quality evidence가 없어도 검증 가능).
+        for (const source of stagesResult.value.sources) knownRefs.sourceKeys.add(source.source_key);
         const firstSource = stagesResult.value.sources[0];
         if (firstSource) {
           const detailResult = await settle(
@@ -175,6 +205,7 @@ export async function loadKubiEvidence(
           if (detailResult.ok) {
             const detail = detailResult.value;
             const rowCount = detail.stage === "bronze" ? detail.record_count : detail.row_count;
+            knownRefs.sourceKeys.add(firstSource.source_key);
             evidence.stage = {
               stage: context.stage,
               sourceKey: firstSource.source_key,
@@ -196,6 +227,9 @@ export async function loadKubiEvidence(
   evidence.partial = unavailable.length > 0;
 
   // 방어적 마지막 관문: Builder 응답에 예상치 못한 credential성 필드가 섞여 있어도 여기서 걸러낸다.
-  const redacted = redactSecrets(evidence) as KubiEvidence;
-  return { evidence: redacted, knownRefs };
+  // 엔트로피 오탐 면제는 safeRunIds(= Builder 가 존재를 확인한 exact run id) 로만 한다. 아직
+  // 확인되지 않은 route context.runId(예: `?run=` / `/builds/:id`)는 여기에도 knownRefs.runIds
+  // 에도 들어 있지 않으므로 evidence 에서 그대로 새어 나가지 않는다.
+  const redacted = redactSecrets(evidence, safeRunIds) as KubiEvidence;
+  return { evidence: redacted, knownRefs, safeRunIds };
 }

--- a/src/features/kubi/parseResponse.test.ts
+++ b/src/features/kubi/parseResponse.test.ts
@@ -75,3 +75,85 @@ describe("parseKubiResponse (#256)", () => {
     }
   });
 });
+
+describe("parseKubiResponse — evidenceRefs 부분 복구 (#256 리뷰)", () => {
+  it("잘못된 evidenceRef 항목 하나 때문에 answer 전체를 버리지 않는다", () => {
+    const payload = {
+      answer: "정상 답변",
+      evidenceRefs: [
+        { kind: "dataset", id: "d1", label: "정상 ref" },
+        { kind: "not_a_real_kind", id: "x", label: "잘못된 kind" },
+      ],
+      generatedSql: null,
+      suggestedActions: [],
+    };
+    const result = parseKubiResponse(JSON.stringify(payload));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.response.answer).toBe("정상 답변");
+      expect(result.response.evidenceRefs).toEqual([{ kind: "dataset", id: "d1", label: "정상 ref" }]);
+      expect(result.malformedEvidenceRefs).toHaveLength(1);
+      expect(result.malformedEvidenceRefs[0]).toContain("not_a_real_kind");
+    }
+  });
+
+  it("evidenceRefs가 전부 잘못되면 answer는 유지하고 evidenceRefs는 빈 배열", () => {
+    const payload = {
+      answer: "정상 답변",
+      evidenceRefs: [
+        { kind: "bogus", id: "a", label: "1" },
+        { kind: "run", label: "id 없음" },
+      ],
+    };
+    const result = parseKubiResponse(JSON.stringify(payload));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.response.answer).toBe("정상 답변");
+      expect(result.response.evidenceRefs).toEqual([]);
+      expect(result.malformedEvidenceRefs).toHaveLength(2);
+    }
+  });
+
+  it("evidenceRefs가 배열이 아니면 비우고 answer는 유지한다", () => {
+    const result = parseKubiResponse(JSON.stringify({ answer: "정상 답변", evidenceRefs: "oops" }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.response.evidenceRefs).toEqual([]);
+      expect(result.malformedEvidenceRefs).toHaveLength(1);
+    }
+  });
+
+  it("answer가 없으면 여전히 실패한다(fail-closed 유지)", () => {
+    const result = parseKubiResponse(
+      JSON.stringify({ evidenceRefs: [{ kind: "bogus", id: "x", label: "y" }] }),
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("answer 타입이 잘못되면 여전히 실패한다", () => {
+    const result = parseKubiResponse(
+      JSON.stringify({ answer: 123, evidenceRefs: [{ kind: "dataset", id: "d1", label: "l" }] }),
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("suggestedActions가 malformed면 evidenceRefs가 정상이어도 여전히 실패한다(보안 정책 유지)", () => {
+    const payload = {
+      answer: "정상 답변",
+      evidenceRefs: [{ kind: "dataset", id: "d1", label: "l" }],
+      suggestedActions: [{ type: "RUN_BUILD", reason: "자동 실행" }],
+    };
+    const result = parseKubiResponse(JSON.stringify(payload));
+    expect(result.ok).toBe(false);
+  });
+
+  it("generatedSql이 malformed면 evidenceRefs가 정상이어도 여전히 실패한다(보안 정책 유지)", () => {
+    const payload = {
+      answer: "정상 답변",
+      evidenceRefs: [{ kind: "dataset", id: "d1", label: "l" }],
+      generatedSql: { sql: "", stage: "bronze" },
+    };
+    const result = parseKubiResponse(JSON.stringify(payload));
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/features/kubi/parseResponse.ts
+++ b/src/features/kubi/parseResponse.ts
@@ -4,12 +4,54 @@
  * 4중 게이트의 1단계(zod 파싱)만 담당한다. "모양"은 맞지만 "내용"(실존 dataset/run 등)이
  * 맞는지는 `crossCheck.ts`가 담당한다.
  */
-import { kubiStructuredResponseSchema } from "./schema";
+import { kubiEvidenceRefSchema, kubiStructuredResponseSchema } from "./schema";
 import type { KubiStructuredResponse } from "./types";
 
 export type ParseKubiResponseResult =
-  | { ok: true; response: KubiStructuredResponse }
+  | { ok: true; response: KubiStructuredResponse; malformedEvidenceRefs: string[] }
   | { ok: false; message: string };
+
+/** 잘못된 evidenceRef 항목을 사용자에게 보여줄 짧은 설명으로 바꾼다. */
+function describeMalformedRef(item: unknown): string {
+  if (item && typeof item === "object") {
+    const record = item as Record<string, unknown>;
+    const kind = typeof record.kind === "string" ? record.kind : "?";
+    const id = typeof record.id === "string" ? record.id : "?";
+    return `kind="${kind}" id="${id}"`;
+  }
+  const serialized = JSON.stringify(item);
+  return serialized ? serialized.slice(0, 60) : String(item);
+}
+
+/**
+ * evidenceRefs를 항목 단위로 검증한다(#256 리뷰 — evidenceRefs만 tolerant).
+ *
+ * evidenceRefs는 표시 전용이고 이후 `crossCheck`가 evidence와 대조하므로, 개별 항목 하나가
+ * (예: `kind`가 허용 목록 밖) 잘못돼도 실행 가능한 `answer`/`generatedSql`/`suggestedActions`
+ * 전체를 버리지 않는다. 잘못된 항목만 떼어내고, 나머지는 strict schema가 그대로 검증한다.
+ */
+function sanitizeEvidenceRefs(candidate: unknown): { malformed: string[] } {
+  if (!candidate || typeof candidate !== "object") return { malformed: [] };
+  const record = candidate as Record<string, unknown>;
+  if (!("evidenceRefs" in record)) return { malformed: [] };
+
+  const raw = record.evidenceRefs;
+  if (!Array.isArray(raw)) {
+    // 배열 자체가 아니면 항목 단위 검증이 불가능하다 — evidenceRefs는 표시 전용이므로
+    // 통째로 비우고(실행 안전성에 영향 없음) 나머지 응답은 살린다.
+    record.evidenceRefs = [];
+    return { malformed: [describeMalformedRef(raw)] };
+  }
+
+  const valid: unknown[] = [];
+  const malformed: string[] = [];
+  for (const item of raw) {
+    if (kubiEvidenceRefSchema.safeParse(item).success) valid.push(item);
+    else malformed.push(describeMalformedRef(item));
+  }
+  record.evidenceRefs = valid;
+  return { malformed };
+}
 
 /**
  * LLM 원본 텍스트에서 ```json 블록(또는 텍스트 전체)을 추출해 zod로 검증한다.
@@ -33,6 +75,10 @@ export function parseKubiResponse(rawOutput: string): ParseKubiResponseResult {
     return { ok: false, message: "LLM 응답을 JSON으로 해석할 수 없습니다." };
   }
 
+  // evidenceRefs만 항목 단위로 관대하게 정리한다. answer/generatedSql/suggestedActions는
+  // 아래 strict schema가 그대로 검증한다(fail-closed 유지).
+  const { malformed: malformedEvidenceRefs } = sanitizeEvidenceRefs(candidate);
+
   const result = kubiStructuredResponseSchema.safeParse(candidate);
   if (!result.success) {
     const issues = result.error.issues
@@ -50,5 +96,6 @@ export function parseKubiResponse(rawOutput: string): ParseKubiResponseResult {
       generatedSql: result.data.generatedSql,
       suggestedActions: result.data.suggestedActions,
     },
+    malformedEvidenceRefs,
   };
 }

--- a/src/features/kubi/prompt.test.ts
+++ b/src/features/kubi/prompt.test.ts
@@ -32,9 +32,43 @@ describe("buildKubiMessages (#256 프롬프트)", () => {
     expect(systemMessage.content).toContain("generatedSql.source 필드로만 전달");
   });
 
+  it("states the exact-column-name + TRY_CAST authoring invariants in the response contract", () => {
+    const [systemMessage] = buildKubiMessages("질문", baseEvidence());
+    // 컬럼명 추측 금지 + schema evidence 참조
+    expect(systemMessage.content).toContain("evidence.stage.schema");
+    expect(systemMessage.content).toContain("evidence.stage.columns");
+    expect(systemMessage.content).toContain("추측");
+    // String 컬럼 numeric aggregation은 strict CAST가 아니라 TRY_CAST
+    expect(systemMessage.content).toContain("TRY_CAST");
+    // provider sentinel 때문에 전체 쿼리가 실패하지 않도록
+    expect(systemMessage.content).toContain("sentinel");
+    // 특정 데이터셋/컬럼에 하드코딩되어 있지 않다(AirKorea·pm10Value 전용 프롬프트 금지).
+    expect(systemMessage.content).not.toContain("AirKorea");
+    expect(systemMessage.content).not.toContain("pm10Value");
+  });
+
+  it("passes stage schema evidence through as untrusted structured content, not baked into the prompt text", () => {
+    const evidence = baseEvidence({
+      context: { page: "quality", datasetId: "air-quality", runId: "r1", stage: "gold", source: "datago__air_quality" },
+      stage: {
+        stage: "gold",
+        source: "datago__air_quality",
+        status: "completed",
+        available: true,
+        rowCount: 40,
+        columns: ["stationName", "pm10Value"],
+      },
+    });
+    const messages = buildKubiMessages("측정소별 PM10 평균 SQL 만들어줘", evidence);
+    // schema evidence는 structuredContent로만 전달되고 프롬프트 지시문에 문자열로 박히지 않는다.
+    expect(messages[1].structuredContent).toEqual(evidence);
+    expect(messages[0].content).not.toContain("pm10Value");
+    expect(messages[1].content).not.toContain("pm10Value");
+  });
+
   it("keeps evidence and user question isolated as separate untrusted-data messages", () => {
     const evidence = baseEvidence({
-      stage: { stage: "silver", sourceKey: "datago__air", status: "completed", available: true, rowCount: 10 },
+      stage: { stage: "silver", source: "datago__air", status: "completed", available: true, rowCount: 10 },
     });
     const messages = buildKubiMessages("서울 데이터 보여줘", evidence);
     expect(messages).toHaveLength(3);

--- a/src/features/kubi/prompt.ts
+++ b/src/features/kubi/prompt.ts
@@ -33,7 +33,7 @@ const RESPONSE_CONTRACT = `다음 JSON 형태로만 응답하세요. 다른 텍�
 - evidenceRefs, generatedSql, suggestedActions에 등장하는 모든 id(dataset/run/provider/quality 결과 등)는 반드시 아래 evidence 블록에 실제로 존재하는 값이어야 합니다. evidence에 없는 값을 만들어내지 마세요.
 - evidence가 부분적으로만 제공된 경우(partial=true, unavailable 목록 참고) 확인하지 못한 부분은 모른다고 답하세요. 전체를 확인한 것처럼 말하지 마세요.
 - generatedSql은 evidence.context.stage가 "silver" 또는 "gold"일 때만, 그리고 실제로 조회가 필요한 질문일 때만 제안하세요. 그 외에는 null로 두세요. generatedSql은 절대 자동 실행되지 않으며 사용자가 직접 실행 버튼을 눌러야 Builder /query로 전달됩니다.
-- generatedSql.sql의 FROM 절은 반드시 logical relation "dataset" 하나만 조회해야 합니다(Builder #504 contract). evidence에 있는 실제 source_key(예: "datago__air")를 FROM의 테이블명으로 쓰지 마세요 — source_key는 오직 generatedSql.source 필드로만 전달하고, Builder가 이를 이용해 실제 소스를 해석합니다. multi-source 질문이라도 SQL 본문에는 개별 소스 테이블명을 등장시키지 말고, source 필드로만 어떤 소스를 조회할지 표현하세요.
+- generatedSql.sql의 FROM 절은 반드시 logical relation "dataset" 하나만 조회해야 합니다(Builder #504 contract). evidence에 있는 실제 source_key(Builder canonical 형식은 "provider.dataset", 예: "datago.air_quality")를 FROM의 테이블명으로 쓰지 마세요 — source_key는 오직 generatedSql.source 필드로만 전달하고, Builder가 이를 이용해 실제 소스를 해석합니다. generatedSql.source에는 evidence에 그대로 등장한 source_key 문자열만 쓰고, 형식을 임의로 바꾸지 마세요. 확실하지 않으면 source를 생략하세요(단일 소스 run이면 Builder가 자동으로 선택합니다). multi-source 질문이라도 SQL 본문에는 개별 소스 테이블명을 등장시키지 말고, source 필드로만 어떤 소스를 조회할지 표현하세요.
 - suggestedActions는 issue #256이 정의한 6종(OPEN_PROVIDER/OPEN_BUILD/OPEN_QUALITY/PATCH_BUILDSPEC/CREATE_BUILD_DRAFT/ADD_REPORT_BLOCK) 외에는 절대 만들지 마세요. 다른 종류의 action이나 자유 형식 함수 호출을 제안하지 마세요.
 - Build 실행, Publish, Credential 변경, SQL 자동 실행, 기존 BuildSpec 덮어쓰기는 어떤 action으로도 제안하지 마세요. 이 시스템에는 그런 action이 존재하지 않습니다.`;
 

--- a/src/features/kubi/prompt.ts
+++ b/src/features/kubi/prompt.ts
@@ -34,6 +34,8 @@ const RESPONSE_CONTRACT = `다음 JSON 형태로만 응답하세요. 다른 텍�
 - evidence가 부분적으로만 제공된 경우(partial=true, unavailable 목록 참고) 확인하지 못한 부분은 모른다고 답하세요. 전체를 확인한 것처럼 말하지 마세요.
 - generatedSql은 evidence.context.stage가 "silver" 또는 "gold"일 때만, 그리고 실제로 조회가 필요한 질문일 때만 제안하세요. 그 외에는 null로 두세요. generatedSql은 절대 자동 실행되지 않으며 사용자가 직접 실행 버튼을 눌러야 Builder /query로 전달됩니다.
 - generatedSql.sql의 FROM 절은 반드시 logical relation "dataset" 하나만 조회해야 합니다(Builder #504 contract). evidence에 있는 실제 source_key(Builder canonical 형식은 "provider.dataset", 예: "datago.air_quality")를 FROM의 테이블명으로 쓰지 마세요 — source_key는 오직 generatedSql.source 필드로만 전달하고, Builder가 이를 이용해 실제 소스를 해석합니다. generatedSql.source에는 evidence에 그대로 등장한 source_key 문자열만 쓰고, 형식을 임의로 바꾸지 마세요. 확실하지 않으면 source를 생략하세요(단일 소스 run이면 Builder가 자동으로 선택합니다). multi-source 질문이라도 SQL 본문에는 개별 소스 테이블명을 등장시키지 말고, source 필드로만 어떤 소스를 조회할지 표현하세요.
+- generatedSql.sql의 컬럼 이름은 반드시 evidence.stage.schema[].name 또는 evidence.stage.columns에 그대로 존재하는 exact 문자열만 사용하세요. 사용자 질문에 나온 표현이나 일반적인 관례로 컬럼명을 추측·축약·변형·복수화하지 말고, evidence에 있는 철자를 글자 그대로 쓰세요. 해당 stage의 schema/columns evidence가 없으면(stage evidence 자체가 없거나 columns가 비어 있으면) 특정 컬럼에 기대는 SQL을 자신 있게 만들지 말고, answer에서 "스키마를 확인할 수 없다"고 밝힌 뒤 generatedSql은 null로 두거나 COUNT(*) 수준으로만 제안하세요.
+- 수치 집계(AVG/SUM/MIN/MAX 등)가 필요한 컬럼이 evidence.stage.schema에서 문자열 계열 dtype(String/object/text/utf8 등)이거나, dtype evidence가 없어 수치형인지 확신할 수 없으면, strict CAST 대신 Builder가 지원하는 TRY_CAST(컬럼 AS DOUBLE)을 사용하세요. 공공데이터 공급자 컬럼에는 "-" 같은 결측 sentinel 문자열이 섞여 있어, strict CAST는 그 한 행 때문에 쿼리 전체를 실패시킵니다. 이미 수치형 dtype(float64/int64 등)으로 확인된 컬럼은 그대로 집계해도 됩니다.
 - suggestedActions는 issue #256이 정의한 6종(OPEN_PROVIDER/OPEN_BUILD/OPEN_QUALITY/PATCH_BUILDSPEC/CREATE_BUILD_DRAFT/ADD_REPORT_BLOCK) 외에는 절대 만들지 마세요. 다른 종류의 action이나 자유 형식 함수 호출을 제안하지 마세요.
 - Build 실행, Publish, Credential 변경, SQL 자동 실행, 기존 BuildSpec 덮어쓰기는 어떤 action으로도 제안하지 마세요. 이 시스템에는 그런 action이 존재하지 않습니다.`;
 
@@ -52,6 +54,7 @@ function formatContextLine(context: KubiContext): string {
   if (context.datasetId) parts.push(`datasetId=${context.datasetId}`);
   if (context.runId) parts.push(`runId=${context.runId}`);
   if (context.stage) parts.push(`stage=${context.stage}`);
+  if (context.source) parts.push(`source=${context.source}`);
   if (context.provider) parts.push(`provider=${context.provider}`);
   return parts.join(", ");
 }

--- a/src/features/kubi/runProvenance.integration.test.ts
+++ b/src/features/kubi/runProvenance.integration.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Run provenance 통합 회귀 (독립 리뷰 blocker).
+ *
+ * 단위 테스트 두 개(evidence.test.ts / crossCheck.test.ts)만으로는 실제 흐름
+ *   loadKubiEvidence → 반환된 knownRefs → crossCheckKubiResponse
+ * 에서 "확인되지 않은 route runId 가 known 으로 새는" 회귀를 막지 못한다. 세 케이스를
+ * 결합 흐름으로 고정한다.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { saveBuildSpec } from "@/features/build-spec/specStore";
+import type { BuildSpec } from "@/shared/lib/types";
+import { loadKubiEvidence } from "./evidence";
+import { crossCheckKubiResponse } from "./crossCheck";
+import type { KubiContext, KubiStructuredResponse } from "./types";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+function response(overrides: Partial<KubiStructuredResponse> = {}): KubiStructuredResponse {
+  return {
+    answer: "요약 답변입니다.",
+    evidenceRefs: [],
+    generatedSql: null,
+    suggestedActions: [],
+    ...overrides,
+  };
+}
+
+describe("run provenance — loadKubiEvidence → crossCheckKubiResponse", () => {
+  it("Case A — 확인되지 않은 route run 은 evidenceRef/OPEN_BUILD/OPEN_QUALITY(runId)/PATCH_BUILDSPEC 에서 모두 reject 된다", async () => {
+    const unverified = "unverified-private-run-1788004513063";
+    // dataset 자체는 존재하지만 이 runId 는 dataset/runs 에 없고 quality/stage 요청도 404.
+    const context: KubiContext = { page: "build-detail", datasetId: "air-quality", runId: unverified };
+    const { evidence, knownRefs, safeRunIds } = await loadKubiEvidence(context);
+
+    expect(knownRefs.runIds.has(unverified)).toBe(false);
+    expect(safeRunIds.has(unverified)).toBe(false);
+
+    const checked = crossCheckKubiResponse(
+      response({
+        evidenceRefs: [{ kind: "run", id: unverified, label: "빌드 실행" }],
+        suggestedActions: [
+          { type: "OPEN_BUILD", runId: unverified, reason: "확인해보세요" },
+          { type: "OPEN_QUALITY", datasetId: "air-quality", runId: unverified, reason: "품질을 보세요" },
+          {
+            type: "PATCH_BUILDSPEC",
+            runId: unverified,
+            patch: [{ op: "replace", path: "/title", value: "x" }],
+            reason: "고쳐보세요",
+          },
+        ],
+      }),
+      evidence,
+      knownRefs,
+    );
+
+    expect(checked.response.evidenceRefs).toHaveLength(0);
+    expect(checked.response.suggestedActions).toHaveLength(0);
+    expect(checked.rejectedActions.some((r) => r.startsWith("OPEN_BUILD"))).toBe(true);
+    expect(checked.rejectedActions.some((r) => r.startsWith("OPEN_QUALITY"))).toBe(true);
+    expect(checked.rejectedActions.some((r) => r.startsWith("PATCH_BUILDSPEC"))).toBe(true);
+  });
+
+  it("Case B — Builder 가 확인한 context run 은 evidenceRef/OPEN_BUILD/OPEN_QUALITY/PATCH_BUILDSPEC 가 유지된다", async () => {
+    const actualRunId = "air-2026-08-14";
+    const spec: BuildSpec = {
+      datasetId: "air-quality",
+      title: "대기질",
+      description: "설명",
+      sources: [{ provider: "datago", dataset: "air", params: { region: "서울" } }],
+      exports: [{ format: "jsonl" }],
+      metadata: {},
+    };
+    saveBuildSpec(actualRunId, spec);
+
+    const context: KubiContext = { page: "build-detail", datasetId: "air-quality", runId: actualRunId };
+    const { evidence, knownRefs, safeRunIds } = await loadKubiEvidence(context);
+
+    expect(knownRefs.runIds.has(actualRunId)).toBe(true);
+    expect(safeRunIds.has(actualRunId)).toBe(true);
+
+    const checked = crossCheckKubiResponse(
+      response({
+        evidenceRefs: [{ kind: "run", id: actualRunId, label: "빌드 실행" }],
+        suggestedActions: [
+          { type: "OPEN_BUILD", runId: actualRunId, reason: "확인" },
+          { type: "OPEN_QUALITY", datasetId: "air-quality", runId: actualRunId, reason: "품질" },
+          {
+            type: "PATCH_BUILDSPEC",
+            runId: actualRunId,
+            patch: [{ op: "replace", path: "/title", value: "x" }],
+            reason: "수정",
+          },
+        ],
+      }),
+      evidence,
+      knownRefs,
+    );
+
+    expect(checked.response.evidenceRefs).toHaveLength(1);
+    expect(checked.response.suggestedActions).toHaveLength(3);
+    expect(checked.rejectedActions).toHaveLength(0);
+  });
+
+  it("Case C — context.runId 와 Builder 가 확인한 run 이 다르면, context 쪽만 known/safe 에서 빠진다", async () => {
+    const mismatch = "context-only-run-1788004513099";
+    const context: KubiContext = { page: "build-detail", datasetId: "air-quality", runId: mismatch };
+    const { evidence, knownRefs, safeRunIds } = await loadKubiEvidence(context);
+
+    // Builder 가 확인한 run(air-quality dataset/runs).
+    expect(knownRefs.runIds.has("air-2026-08-14")).toBe(true);
+    expect(safeRunIds.has("air-2026-08-14")).toBe(true);
+    // context 에서만 온 run.
+    expect(knownRefs.runIds.has(mismatch)).toBe(false);
+    expect(safeRunIds.has(mismatch)).toBe(false);
+
+    const rejected = crossCheckKubiResponse(
+      response({ suggestedActions: [{ type: "OPEN_BUILD", runId: mismatch, reason: "context" }] }),
+      evidence,
+      knownRefs,
+    );
+    expect(rejected.response.suggestedActions).toHaveLength(0);
+
+    const accepted = crossCheckKubiResponse(
+      response({ suggestedActions: [{ type: "OPEN_BUILD", runId: "air-2026-08-14", reason: "builder" }] }),
+      evidence,
+      knownRefs,
+    );
+    expect(accepted.response.suggestedActions).toHaveLength(1);
+  });
+});

--- a/src/features/kubi/types.ts
+++ b/src/features/kubi/types.ts
@@ -111,6 +111,12 @@ export interface KubiKnownRefs {
   providers: Set<string>;
   qualityResultIds: Set<string>;
   schemaDriftIds: Set<string>;
+  /**
+   * evidence에 실제로 등장한 Builder canonical source_key("provider.dataset") 집합.
+   * quality 결과·stage evidence에서 모은다. Generated SQL의 `source`가 이 집합에 없으면
+   * 검증되지 않은 값이므로 Builder `/query`로 그대로 보내지 않는다(crossCheck).
+   */
+  sourceKeys: Set<string>;
 }
 
 /** LLM 구조화 응답이 근거로 인용한 evidence 조각. */

--- a/src/features/kubi/types.ts
+++ b/src/features/kubi/types.ts
@@ -22,6 +22,13 @@ export interface KubiContext {
   datasetId?: string;
   runId?: string;
   stage?: KubiStage;
+  /**
+   * 화면에서 선택된 Builder canonical source_key(`?source=` 쿼리 관례, #253/#254).
+   * multi-source run에서 stage evidence를 어느 소스로 조회할지 결정하는 데 쓴다 — route에
+   * 없으면 undefined로 두고 추측하지 않는다(P5 canonical source policy와 동일 identity).
+   * 필드명은 `source` — `redactSecrets`의 secret-named 휴리스틱(`*key$`)에 걸리지 않도록 한다.
+   */
+  source?: string;
   qualityResultIds?: string[];
   provider?: string;
 }
@@ -42,7 +49,8 @@ export type KubiEvidenceSource = "dataset" | "runs" | "stage" | "quality" | "cat
 /** Evidence에 포함하는 quality 결과 요약(원본 QualityCheckResult에 안정적 id만 덧붙임). */
 export interface KubiQualityResultEvidence {
   id: string;
-  sourceKey: string;
+  /** Builder canonical source_key. 필드명이 `sourceKey`면 redactSecrets가 `[REDACTED]`한다(`*key$`). */
+  source: string;
   category: string;
   rule: string;
   column: string | null;
@@ -70,10 +78,24 @@ export interface KubiEvidence {
   recentRuns?: { runId: string; status: string; startedAt: string | null; finishedAt: string | null }[];
   stage?: {
     stage: KubiStage;
-    sourceKey: string;
+    /** Builder canonical source_key. 필드명이 `sourceKey`면 redactSecrets가 `[REDACTED]`한다(`*key$`). */
+    source: string;
     status: string;
     available: boolean;
     rowCount: number | null;
+    /**
+     * 이 stage 산출물의 exact column 이름(Builder stage detail이 반환한 값 그대로).
+     * Generated SQL이 컬럼명을 추측·축약·변형하지 않도록 노출한다 — silver는 schema[].name,
+     * gold는 columns 필드에서 온다. bronze나 available=false면 undefined.
+     * 사용자 질문/모델 출력에서 온 컬럼명은 절대 여기 넣지 않는다(evidence 원칙).
+     */
+    columns?: string[];
+    /**
+     * column별 dtype(Builder silver stage detail의 schema에서만 제공 — gold stage detail은
+     * dtype 없이 이름만 준다). numeric aggregation 대상 컬럼이 String이면 프롬프트가
+     * strict CAST 대신 TRY_CAST를 쓰도록 유도하는 근거로 쓴다. 없으면 undefined.
+     */
+    schema?: { name: string; dtype: string }[];
   };
   quality?: {
     availability: "available" | "partial" | "unavailable";

--- a/src/features/kubi/useKubiSession.ts
+++ b/src/features/kubi/useKubiSession.ts
@@ -162,13 +162,19 @@ export function useKubiSession(): UseKubiSessionResult {
       controllersRef.current.set(turnId, controller);
 
       try {
-        const { evidence, knownRefs } = await loadKubiEvidence(context, controller.signal);
+        const { evidence, knownRefs, safeRunIds } = await loadKubiEvidence(context, controller.signal);
         updateTurn(turnId, (t) => ({ ...t, evidence }));
 
         const provider = createProvider({ apiKey, model, baseUrl });
         const messages = buildKubiMessages(trimmed, evidence);
         let rawOutput = "";
-        for await (const chunk of provider.stream(messages, controller.signal)) {
+        // Builder 응답으로 존재가 확인된 exact run id(safeRunIds)만 LLM egress 스크러버에서
+        // 보존한다 — knownRefs.runIds 가 아니다. 그래야 모델이 실제 run id를 그대로 echo 하고
+        // crossCheck(knownRefs.runIds)·suggestedAction.runId 와 일치해 정상 action 이 제거되지
+        // 않으면서, 아직 확인되지 않은 route runId 는 엔트로피 스크럽 대상으로 남는다.
+        for await (const chunk of provider.stream(messages, controller.signal, {
+          safeRunIds,
+        })) {
           rawOutput += chunk;
         }
 
@@ -189,8 +195,15 @@ export function useKubiSession(): UseKubiSessionResult {
           actionStates[index] = { status: "pending_approval" };
         });
 
+        // parse 단계에서 형식이 잘못돼 떼어낸 evidenceRef(예: 허용 목록 밖 kind)도
+        // cross-check가 제거한 근거와 같은 자리에 함께 보여준다 — answer는 살린다.
+        const malformedRefs = parsed.malformedEvidenceRefs;
+        const rejectedRefs = [
+          ...malformedRefs.map((ref) => `형식 오류로 제외: ${ref}`),
+          ...checked.rejectedRefs,
+        ];
         const hasRejections =
-          checked.rejectedRefs.length > 0 || checked.rejectedActions.length > 0 || Boolean(checked.rejectedSqlReason);
+          rejectedRefs.length > 0 || checked.rejectedActions.length > 0 || Boolean(checked.rejectedSqlReason);
 
         updateTurn(turnId, (t) => ({
           ...t,
@@ -203,12 +216,12 @@ export function useKubiSession(): UseKubiSessionResult {
                 kind: "hallucinated_refs",
                 message: [
                   checked.rejectedSqlReason,
-                  checked.rejectedRefs.length ? `제외된 근거: ${checked.rejectedRefs.join(", ")}` : null,
+                  rejectedRefs.length ? `제외된 근거: ${rejectedRefs.join(", ")}` : null,
                   checked.rejectedActions.length ? `제외된 action: ${checked.rejectedActions.join(", ")}` : null,
                 ]
                   .filter(Boolean)
                   .join(" "),
-                rejectedRefs: checked.rejectedRefs,
+                rejectedRefs,
                 rejectedActions: checked.rejectedActions,
               }
             : undefined,

--- a/src/features/kubi/useKubiSession.ts
+++ b/src/features/kubi/useKubiSession.ts
@@ -162,18 +162,22 @@ export function useKubiSession(): UseKubiSessionResult {
       controllersRef.current.set(turnId, controller);
 
       try {
-        const { evidence, knownRefs, safeRunIds } = await loadKubiEvidence(context, controller.signal);
+        const { evidence, knownRefs, safeRunIds, safeEvidenceIds } = await loadKubiEvidence(
+          context,
+          controller.signal,
+        );
         updateTurn(turnId, (t) => ({ ...t, evidence }));
 
         const provider = createProvider({ apiKey, model, baseUrl });
         const messages = buildKubiMessages(trimmed, evidence);
         let rawOutput = "";
-        // Builder 응답으로 존재가 확인된 exact run id(safeRunIds)만 LLM egress 스크러버에서
-        // 보존한다 — knownRefs.runIds 가 아니다. 그래야 모델이 실제 run id를 그대로 echo 하고
-        // crossCheck(knownRefs.runIds)·suggestedAction.runId 와 일치해 정상 action 이 제거되지
-        // 않으면서, 아직 확인되지 않은 route runId 는 엔트로피 스크럽 대상으로 남는다.
+        // LLM egress 스크러버에서 엔트로피 오탐 면제 대상: Builder 응답으로 존재가 확인된 exact
+        // run id(safeRunIds) + Builder `/quality` 응답에서 deterministic 하게 만든 evidence
+        // identifier(safeEvidenceIds). 그래야 모델이 실제 run id/quality id를 그대로 echo 해도
+        // crossCheck(knownRefs)·suggestedAction 와 일치해 정상 근거·action 이 제거되지 않으면서,
+        // 아직 확인되지 않은 route runId 나 임의 문자열은 엔트로피 스크럽 대상으로 남는다.
         for await (const chunk of provider.stream(messages, controller.signal, {
-          safeRunIds,
+          safeRunIds: new Set<string>([...safeRunIds, ...safeEvidenceIds]),
         })) {
           rawOutput += chunk;
         }

--- a/src/features/quality/model.test.ts
+++ b/src/features/quality/model.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { previewSourceState, summarizePreviewSources } from "./model";
+import {
+  previewSourceState,
+  qualityKubiSeedQuestion,
+  summarizeChecksPassed,
+  summarizePreviewSources,
+} from "./model";
 import type { PreviewSource, QualityCheckResult } from "@/shared/lib/builderApi";
 
 function qualityResult(status: QualityCheckResult["status"]): QualityCheckResult {
@@ -99,5 +104,29 @@ describe("summarizePreviewSources (#250 §3, mixed/partial preview)", () => {
     ];
     const summary = summarizePreviewSources(sources);
     expect(summary.perSource[1].quality.status).toBe("FAIL");
+  });
+});
+
+describe("qualityKubiSeedQuestion (real Builder E2E — 상태별 seed 질문)", () => {
+  it("평가된 check가 없으면(evaluated=0) 규칙 미설정 상태를 묻는다", () => {
+    const q = qualityKubiSeedQuestion(summarizeChecksPassed([]));
+    expect(q).toContain("평가된 Quality check가 없습니다");
+    expect(q).not.toContain("WARN/FAIL의 원인");
+  });
+
+  it("모든 check가 PASS면 WARN/FAIL을 전제하지 않고 PASS 근거를 묻는다", () => {
+    const q = qualityKubiSeedQuestion(summarizeChecksPassed([qualityResult("pass"), qualityResult("pass")]));
+    expect(q).toContain("모든 check가 PASS한 근거");
+    expect(q).not.toContain("WARN/FAIL의 원인");
+  });
+
+  it("WARN이 있으면 원인/조치 질문을 유지한다", () => {
+    const q = qualityKubiSeedQuestion(summarizeChecksPassed([qualityResult("pass"), qualityResult("warn")]));
+    expect(q).toContain("WARN/FAIL의 원인과 우선 조치");
+  });
+
+  it("FAIL이 있으면 원인/조치 질문을 유지한다", () => {
+    const q = qualityKubiSeedQuestion(summarizeChecksPassed([qualityResult("fail")]));
+    expect(q).toContain("WARN/FAIL의 원인과 우선 조치");
   });
 });

--- a/src/features/quality/model.ts
+++ b/src/features/quality/model.ts
@@ -121,6 +121,23 @@ export function summarizeChecksPassed(results: QualityCheckResult[]): ChecksPass
   return { pass, warn, fail, evaluated, status };
 }
 
+/**
+ * Quality Center header의 "Kubi 분석" 버튼이 seed할 질문을 현재 Quality 상태에 맞춰 고른다.
+ *
+ * 이전에는 상태와 무관하게 "WARN/FAIL의 원인과 조치"를 고정 seed해서, 모든 check가 PASS인
+ * Run에서도 존재하지 않는 WARN/FAIL을 전제한 질문이 들어갔다(real Builder E2E에서 확인).
+ * per-issue "Kubi 분석" 버튼은 이미 이슈 문맥을 담으므로 이 함수는 header 버튼에만 쓴다.
+ */
+export function qualityKubiSeedQuestion(summary: ChecksPassedSummary): string {
+  if (summary.evaluated === 0) {
+    return "현재 Run에는 평가된 Quality check가 없습니다. 현재 상태를 설명하고, Quality 규칙을 설정할 때 확인할 사항을 Evidence 기준으로 알려줘.";
+  }
+  if (summary.warn > 0 || summary.fail > 0) {
+    return "현재 Quality WARN/FAIL의 원인과 우선 조치 방법을 Evidence 기준으로 분석해줘.";
+  }
+  return "현재 Quality 결과를 Evidence 기준으로 요약하고, 모든 check가 PASS한 근거와 추가로 확인할 사항을 알려줘.";
+}
+
 export interface CategorySummary extends ChecksPassedSummary {
   /** 표시용으로 고른 가장 심각한 개별 결과(FAIL > WARN > 첫 PASS). 평가된 결과가 없으면 null. */
   worst: QualityCheckResult | null;

--- a/src/pages/DatasetDetailPage.tsx
+++ b/src/pages/DatasetDetailPage.tsx
@@ -157,14 +157,19 @@ export function DatasetDetailPage() {
     setSearchParams(next);
   }
 
-  // AI 탭은 Kubi(KubiContent)가 route의 ?run=&stage=로만 문맥을 판단한다(추측 금지 원칙,
-  // context.ts 참고) — 그래서 여기서 화면에 이미 계산되어 보이는 selectedRunId/selectedStage를
-  // URL에 명시적으로 반영해줘야, 처음 AI 탭을 열었을 때도 Kubi RUN context bar가 실제로는
-  // 알고 있는 latest run을 "—"로 보여주거나 Generated SQL/Result Preview가 비어 보이지
-  // 않는다(UI audit #5). 탭 바(button onClick)와 Overview 탭의 Kubi discoverability CTA 모두
-  // 이 helper 하나를 공유해 같은 규칙을 두 번 구현하지 않는다.
+  // AI 탭은 Kubi(KubiContent)가 route의 ?run=&source=&stage=로만 문맥을 판단한다(추측 금지 원칙,
+  // context.ts 참고) — 그래서 여기서 화면에 이미 계산되어 보이는 selectedRunId/selectedSource/
+  // selectedStage를 URL에 명시적으로 반영해줘야, 처음 AI 탭을 열었을 때도 Kubi RUN context bar가
+  // 실제로는 알고 있는 latest run을 "—"로 보여주거나 Generated SQL/Result Preview가 비어 보이지
+  // 않는다(UI audit #5). source까지 실어야 multi-source run에서 stage evidence가 fail-closed로
+  // 빠지지 않는다(#319 후속). 탭 바(button onClick)와 Overview 탭의 Kubi discoverability CTA
+  // 모두 이 helper 하나를 공유해 같은 규칙을 두 번 구현하지 않는다.
   function goToTab(tab: DetailTab) {
-    updateContext(tab === "ai" ? { tab: "ai", run: selectedRunId, stage: selectedStage } : { tab: tab === "overview" ? null : tab });
+    updateContext(
+      tab === "ai"
+        ? { tab: "ai", run: selectedRunId, source: selectedSource || null, stage: selectedStage }
+        : { tab: tab === "overview" ? null : tab },
+    );
   }
 
   const tabParam = searchParams.get("tab") as DetailTab | null;

--- a/src/pages/QualityPage.tsx
+++ b/src/pages/QualityPage.tsx
@@ -26,6 +26,7 @@ import {
   isMissingCategory,
   isSchemaCategory,
   overallQualityState,
+  qualityKubiSeedQuestion,
   summarizeByCategory,
   summarizeChecksPassed,
   warnOrFailResults,
@@ -286,7 +287,7 @@ export function QualityPage() {
           <Button
             variant="secondary"
             onClick={() => {
-              seedKubiQuestion("현재 Quality WARN/FAIL의 원인과 우선 조치 방법을 분석해줘.");
+              seedKubiQuestion(qualityKubiSeedQuestion(checksPassed));
               openKubiDrawer();
             }}
           >

--- a/src/pages/QualityPage.tsx
+++ b/src/pages/QualityPage.tsx
@@ -134,6 +134,36 @@ export function QualityPage() {
   const selectedRunId = requestedRunId || selectedDataset?.latest_run_id || "";
   const selectedRun = runsState.data?.find((run) => run.run_id === selectedRunId);
 
+  // Kubi(KubiContent)는 route의 `?dataset=&run=&source=&stage=`만 문맥으로 읽는다(context.ts,
+  // 추측 금지 원칙). 화면에는 fallback으로 이미 dataset/run이 계산되어 보이지만 URL에 없으면
+  // KubiContext에는 전달되지 않아 "어떤 dataset/run인지 알려달라"는 답이 나온다(#319 후속).
+  // 그래서 fallback으로 확정된 선택을 URL에 되반영해 UI 선택과 KubiContext SSOT를 일치시킨다.
+  // replace로만 갱신해 history를 더럽히지 않고, 유효하지 않은 dataset/run일 때는 건드리지 않는다.
+  useEffect(() => {
+    if (datasetsState.status !== "loaded" || invalidDataset || invalidRun) return;
+    const next = new URLSearchParams(searchParams);
+    let changed = false;
+    if (!requestedDatasetId && selectedDatasetId) {
+      next.set("dataset", selectedDatasetId);
+      changed = true;
+    }
+    if (!requestedRunId && selectedRunId) {
+      next.set("run", selectedRunId);
+      changed = true;
+    }
+    if (changed) setSearchParams(next, { replace: true });
+  }, [
+    datasetsState.status,
+    invalidDataset,
+    invalidRun,
+    requestedDatasetId,
+    selectedDatasetId,
+    requestedRunId,
+    selectedRunId,
+    searchParams,
+    setSearchParams,
+  ]);
+
   useEffect(() => {
     if (!selectedRunId || invalidRun) {
       setStagesState({ status: "idle" });
@@ -172,6 +202,18 @@ export function QualityPage() {
       else next.delete(key);
     }
     setSearchParams(next);
+  }
+
+  // Kubi를 열기 전에, 화면에 선택되어 보이는 dataset/run/source/stage를 URL에 확정 반영한다 —
+  // KubiContext는 route만 읽으므로(context.ts) 이 동기화가 없으면 drawer가 catalog 수준
+  // evidence만 받는다(#319 후속). 헤더 버튼과 이슈별 "Kubi 분석"이 이 helper를 공유한다.
+  function syncKubiContext() {
+    updateContext({
+      dataset: selectedDatasetId || null,
+      run: selectedRunId || null,
+      source: selectedSource || null,
+      stage: selectedStage ?? null,
+    });
   }
 
   const scopedResults = useMemo(
@@ -287,6 +329,7 @@ export function QualityPage() {
           <Button
             variant="secondary"
             onClick={() => {
+              syncKubiContext();
               seedKubiQuestion(qualityKubiSeedQuestion(checksPassed));
               openKubiDrawer();
             }}
@@ -368,6 +411,7 @@ export function QualityPage() {
             contextLabel={contextLabel}
             selectedRun={selectedRun}
             onKubi={(issue) => {
+              syncKubiContext();
               seedKubiQuestion(`"${issue.category} · ${issue.rule}" 규칙이 ${issue.status.toUpperCase()}인 이유와 조치 방법을 분석해줘.`);
               openKubiDrawer();
             }}


### PR DESCRIPTION
## Summary

Real Builder + 실제 AirKorea + 실제 LLM E2E에서 확인된 Kubi의
context grounding / structured response / evidence identity /
stage evidence / Generated SQL 문제를 수정합니다.

이번 PR은 단순 UI 보완이 아니라 실제 Builder evidence를 기준으로
Kubi가 현재 Dataset / Run / Stage / Quality / Schema를 정확히 인식하고,
검증된 SQL을 사용자 승인 후 실행할 수 있도록 Real E2E 흐름을 안정화합니다.

---

## Changes

### 1. Quality Kubi context

Quality Center의 화면 선택 상태와 KubiContext가 분리되어 있던 문제를 수정했습니다.

기존에는 `/quality` 진입 시 화면에서는 fallback으로 Dataset / Run이 선택되어 있어도
URL query에 반영되지 않아 Kubi는 catalog 수준 context만 받는 경우가 있었습니다.

변경:

- QualityPage의 확정된 `dataset` / `run` / `source` / `stage`를 URL query와 동기화
- `KubiContext`에 `source` 추가
- `resolveKubiContext()`가 `?source=` 파싱
- `contextsMatch()`가 source 변경도 stale context로 판정
- Dataset Detail → AI 진입 시 선택 source 전달
- Quality Kubi 실행 직전 현재 selection을 context에 동기화

결과:

- PASS Quality에서 현재 Run / 4개 Quality check를 즉시 인식
- FAIL Quality에서 `actual 40 / threshold 1000` 등의 실제 evidence를 즉시 인식
- Run/source 변경 후 이전 Kubi action은 stale 처리

---

### 2. Quality 상태 기반 seed question

Quality 상태를 무조건 WARN/FAIL로 가정하던 seed question을 수정했습니다.

상태별로:

- evaluated = 0
- WARN/FAIL 존재
- all PASS

를 구분해 질문을 생성합니다.

PASS 상태에서는 존재하지 않는 실패 원인을 전제하지 않습니다.

---

### 3. Structured response robustness

LLM이 일부 malformed `evidenceRefs`를 반환해도
정상 answer 전체가 사라지지 않도록 수정했습니다.

- valid evidence ref는 유지
- invalid evidence ref만 item-level 제거
- 제외 이유 표시
- `answer`
- `generatedSql`
- `suggestedActions`

의 핵심 structured contract는 기존처럼 strict validation 유지

실제 E2E에서도 invalid `kind`가 반환된 상황에서
answer는 유지되고 잘못된 ref만 제외되는 것을 확인했습니다.

---

### 4. Run ID / evidence ID secret scrub

고엔트로피 canonical identifier가 credential로 오탐되던 문제를 수정했습니다.

#### Run ID

regex/shape 기반 예외가 아니라
Builder가 실제로 확인한 exact Run ID만 `safeRunIds`에 등록합니다.

route의 `context.runId`만으로는 trusted resource로 간주하지 않습니다.

Builder-confirmed Run만:

- `knownRefs.runIds`
- `safeRunIds`

에 등록합니다.

따라서 unverified route Run은:

- evidenceRef
- `OPEN_BUILD`
- `OPEN_QUALITY`
- `PATCH_BUILDSPEC`

에서 fail-closed 처리됩니다.

#### Quality evidence ID

실제 Quality evidence ID 중 일부가 entropy threshold를 넘어
`quality:[REDACTED]`로 변환되던 문제도 확인했습니다.

Builder `/quality` 응답으로부터 이번 evidence loading에서
deterministic하게 생성한 exact identifier만 `safeEvidenceIds`에 등록합니다.

형태 기반 예외는 사용하지 않습니다.

기존 보안 우선순위는 유지합니다.

- `serviceKey`
- `apiKey`
- `token`
- `secret`

등 secret-named field는 safe value와 동일하더라도 항상 scrub합니다.

---

### 5. Stage evidence

Stage evidence가 실제 Builder에서 항상 unavailable이 되던 문제를 수정했습니다.

실제 원인:

```text
GET /builds/{run}/stages/{stage}?source=...&limit=0
→ HTTP 400
→ 'limit' must be a positive integer up to 1000
````

Kubi evidence loader가 stage-detail을 `limit=0`으로 요청하고 있었습니다.

변경:

* stage-detail evidence 요청을 `limit=1`로 변경
* sample row 자체는 Kubi evidence에 포함하지 않음
* 선택된 `context.source`가 있으면 exact source 사용
* source가 정확히 하나면 single-source fallback
* multi-source인데 source가 불명확하면 임의 선택하지 않고 fail-closed

또한 `sourceKey` 필드명이 secret-key heuristic에 걸리던 문제를 피하기 위해
Kubi 내부 evidence DTO에서는 canonical source identity를 `source`로 사용합니다.

---

### 6. Generated SQL source grounding

Generated SQL의 source identity를 실제 evidence와 대조합니다.

* canonical `provider.dataset` source key 사용
* known source exact-match
* single-source에서만 safe fallback
* multi-source ambiguity는 fail-closed
* 임의 `__ -> .` normalization 없음

과거 Real E2E에서 발생했던:

```text
source is not part of the run
```

문제는 재검증에서 재현되지 않았습니다.

---

### 7. Generated SQL schema grounding

실제 SQL 실행 실패를 추적한 결과 Builder query engine은 정상이고,
LLM이 schema를 보지 못한 채 SQL을 추측하던 것이 원인이었습니다.

실제 실패 SQL은:

```sql
SELECT
  stationName,
  AVG(CAST(pm10 AS FLOAT)) AS avg_pm10
FROM dataset
GROUP BY stationName
ORDER BY avg_pm10 DESC
```

이었지만 실제 Gold column은 `pm10Value`이며 `pm10`은 존재하지 않습니다.

또한 `pm10Value`는 String이고 실제 provider data에 `"-"` sentinel이 있어
strict `CAST`는 실행 실패합니다.

실 Builder에서 다음 SQL이 정상 실행되는 것을 확인했습니다.

```sql
SELECT
  stationName,
  AVG(TRY_CAST(pm10Value AS DOUBLE)) AS avg_pm10
FROM dataset
GROUP BY stationName
ORDER BY avg_pm10 DESC
```

변경:

* `KubiEvidence.stage.columns` 추가
* Silver에서는 `schema: { name, dtype }[]`도 전달
* Gold는 contract가 제공하는 column name만 전달하고 dtype은 추측하지 않음
* raw sample / statistics는 LLM evidence에 추가하지 않음

Generated SQL prompt에는 다음 invariant를 추가했습니다.

* evidence에 실제 존재하는 exact column name만 사용
* 사용자 표현을 근거로 column name 추측/축약 금지
* schema/columns evidence가 없으면 column 기반 SQL을 임의 생성하지 않음
* String 또는 dtype unknown numeric aggregation은
  `TRY_CAST(... AS DOUBLE)`을 우선 사용
* provider sentinel 때문에 strict cast가 전체 query를 실패시키지 않도록 함

AirKorea / `pm10Value` 등 dataset-specific hard-code는 없습니다.

---

## Real E2E verification

실제 환경:

* Provider: `datago`
* Dataset: `air_quality`
* Source: `datago.air_quality`
* actual AirKorea API
* actual Builder
* actual LLM

### Normal Run

```text
datago-air-quality-1788017784829
```

확인 결과:

* Bronze completed
* Silver completed
* Gold completed
* 40 rows
* Quality 4/4 PASS
* Run ID redaction 없음
* Stage evidence 정상
* Gold columns 23개를 Kubi가 실제 evidence로 인식
* `stationName`, `pm10Value` exact column 인식
* Generated SQL에서 `pm10Value` 사용
* `TRY_CAST` 사용
* 사용자 실행 후 Result Preview 정상 반환

### Intentional Quality FAIL Run

```text
datago-air-quality-1788018319608
```

Quality:

```yaml
min_rows: 1000
min_rows_severity: fail
```

실제 결과:

* actual = 40
* threshold = 1000
* Bronze completed
* Silver failed
* Gold not_run

Kubi가 실제 evidence를 기준으로:

* `min_rows` 실패
* actual 40
* threshold 1000
* Silver failed

를 정확히 인식했습니다.

---

## Query runtime verification

동일 Normal Run / Gold / `datago.air_quality`에서 직접 검증했습니다.

```sql
SELECT COUNT(*) FROM dataset
```

→ HTTP 200 / 40 rows

따라서:

* run resolution
* stage resolution
* source resolution
* `/query` plumbing
* execution engine

은 정상입니다.

실제 schema를 사용한:

```sql
SELECT
  stationName,
  AVG(TRY_CAST(pm10Value AS DOUBLE)) AS avg_pm10
FROM dataset
GROUP BY stationName
ORDER BY avg_pm10 DESC
```

도 정상 실행되었고, 실제 Kubi Generated SQL에서도 동일한
`pm10Value + TRY_CAST` 계열 SQL 생성 및 Result Preview를 확인했습니다.

---

## Verification

Targeted regression suites:

* Kubi + assistant: PASS
* Quality + reports + integration suites: PASS
* Generated SQL evidence guidance: 142 passed
* typecheck: PASS
* lint: 0 errors
* build: PASS
* `git diff --check`: PASS

Full Vitest:

* 1054 passed
* 1 timeout failure under full-suite parallel load
* 해당 `datasetDetail.test.tsx` isolated run: 25/25 PASS
* 해당 code path는 이번 Generated SQL evidence 변경에서 수정하지 않음

---

## Security / fail-closed properties retained

* Studio BYOK 유지
* Builder에 LLM secret 전달하지 않음
* raw credential evidence 포함 금지
* secret-named field 우선 scrub
* Builder-confirmed exact Run ID만 entropy exception
* deterministic exact evidence ID만 evidence exception
* unverified route resource trust 금지
* unknown evidence/action 제거
* multi-source ambiguity fail-closed
* stale response/action 실행 차단
* Generated SQL 자동 실행 금지
* SQL은 사용자 명시적 실행 후 Builder `/query` 호출

---

## Non-blocking notes

### Builds / Runs stage context

Builds / Runs의 기본 Run 분석은 현재 run-level context이므로
성공 Run에서는 특정 stage가 자동 선택되지 않아 `STAGE --`로 표시됩니다.

실패 Run은 정확히 하나의 failed stage가 확인될 경우 해당 stage를 focus합니다.

Quality / Dataset Detail처럼 명시적인 Silver/Gold context에서는
schema-aware Generated SQL이 정상 동작합니다.

성공 Run의 Builds / Runs 화면에서 특정 Stage를 사용자가 선택해
Kubi context로 전달하는 UX는 별도 후속 개선 대상으로 둘 수 있습니다.

### OPEN_QUALITY ownership relation

`OPEN_QUALITY(datasetId, runId)`는 현재 dataset과 run 각각의 존재를 검증하지만
run이 해당 dataset에 속하는지까지 별도 ownership cross-check하지는 않습니다.

현재 영향은 잘못된 navigation 가능성 수준이며 권한 우회나
unverified resource action 허용은 아닙니다.

---

## Dependency

Builder response body에 잘못 포함되던 `request_id` wire-contract 문제는
별도 Builder PR #569에서 수정합니다.

Studio에는 해당 Builder bug를 우회하기 위한 schema workaround를 추가하지 않았습니다.