### PR TITLE
feat(kubi): polish contextual assistant UX

### DIFF
--- a/src/features/kubi/KubiContent.test.tsx
+++ b/src/features/kubi/KubiContent.test.tsx
@@ -5,7 +5,8 @@
  * 내용이 보이는지 확인한다. null/primitive는 기존 표시 방식을 그대로 유지해야 한다.
  */
 import { describe, expect, it } from "vitest";
-import { formatQueryValue } from "./KubiContent";
+import { evidenceDetail, evidenceDetailEntries, formatQueryValue } from "./KubiContent";
+import type { KubiTurn } from "./types";
 
 describe("formatQueryValue (#256 리뷰 §1)", () => {
   it("shows a dash for null/undefined, matching the previous behavior", () => {
@@ -40,5 +41,42 @@ describe("formatQueryValue (#256 리뷰 §1)", () => {
   it("renders an empty array/object distinctly from null", () => {
     expect(formatQueryValue([])).toBe("[]");
     expect(formatQueryValue({})).toBe("{}");
+  });
+});
+
+describe("stage evidence detail", () => {
+  it("resolves only the exact canonical stage ref to frozen evidence", () => {
+    const refId = "run-1::provider.dataset::gold";
+    const turn = {
+      id: "turn-1",
+      question: "Gold 컬럼",
+      context: { page: "quality", runId: "run-1", source: "provider.dataset", stage: "gold" },
+      createdAt: "2026-08-30T00:00:00Z",
+      status: "ok",
+      query: { status: "idle" },
+      actionStates: {},
+      evidence: {
+        fetchedAt: "2026-08-30T00:00:00Z",
+        context: { page: "quality", runId: "run-1", source: "provider.dataset", stage: "gold" },
+        stage: { refId, stage: "gold", source: "provider.dataset", status: "completed", available: true, rowCount: 40, columns: Array.from({ length: 23 }, (_, index) => `column_${index}`) },
+        deepLinks: {},
+        partial: false,
+        unavailable: [],
+      },
+    } satisfies KubiTurn;
+    expect(evidenceDetail(turn, { kind: "stage", id: refId, label: "Gold" })).toMatchObject({
+      stage: "gold",
+      source: "provider.dataset",
+      status: "completed",
+      rowCount: 40,
+    });
+    expect(evidenceDetail(turn, { kind: "stage", id: "run-1::provider.dataset::silver", label: "wrong" })).toBeNull();
+    expect(evidenceDetailEntries(turn, { kind: "stage", id: refId, label: "Gold" })).toEqual([
+      ["Stage", "Gold"],
+      ["Source", "provider.dataset"],
+      ["Status", "completed"],
+      ["Rows", "40"],
+      ["Columns", "23"],
+    ]);
   });
 });

--- a/src/features/kubi/KubiContent.test.tsx
+++ b/src/features/kubi/KubiContent.test.tsx
@@ -5,7 +5,7 @@
  * 내용이 보이는지 확인한다. null/primitive는 기존 표시 방식을 그대로 유지해야 한다.
  */
 import { describe, expect, it } from "vitest";
-import { evidenceDetail, evidenceDetailEntries, formatQueryValue } from "./KubiContent";
+import { evidenceDetail, evidenceDetailEntries, evidenceHref, formatQueryValue } from "./KubiContent";
 import type { KubiTurn } from "./types";
 
 describe("formatQueryValue (#256 리뷰 §1)", () => {
@@ -78,5 +78,47 @@ describe("stage evidence detail", () => {
       ["Rows", "40"],
       ["Columns", "23"],
     ]);
+  });
+});
+
+describe("evidenceHref run navigation", () => {
+  const turn = {
+    id: "turn-links",
+    question: "근거 링크",
+    context: { page: "quality", datasetId: "dataset-1", runId: "run-current", source: "provider.dataset", stage: "gold" },
+    createdAt: "2026-08-30T00:00:00Z",
+    status: "ok",
+    query: { status: "idle" },
+    actionStates: {},
+    evidence: {
+      fetchedAt: "2026-08-30T00:00:00Z",
+      context: { page: "quality", datasetId: "dataset-1", runId: "run-current", source: "provider.dataset", stage: "gold" },
+      recentRuns: [
+        { runId: "run-current", status: "completed", startedAt: null, finishedAt: null },
+        { runId: "run-previous", status: "completed", startedAt: null, finishedAt: null },
+      ],
+      stage: { refId: "run-current::provider.dataset::gold", stage: "gold", source: "provider.dataset", status: "completed", available: true, rowCount: 40 },
+      deepLinks: {},
+      partial: false,
+      unavailable: [],
+    },
+  } satisfies KubiTurn;
+
+  it("uses the verified current run detail and retains its source/stage context", () => {
+    expect(evidenceHref(turn, { kind: "run", id: "run-current", label: "현재 Run" })).toBe(
+      "/builds?run=run-current&dataset=dataset-1&source=provider.dataset&stage=gold",
+    );
+  });
+
+  it("uses a verified different recent run and does not carry current source/stage", () => {
+    expect(evidenceHref(turn, { kind: "run", id: "run-previous", label: "이전 Run" })).toBe(
+      "/builds?run=run-previous&dataset=dataset-1",
+    );
+  });
+
+  it("keeps the verified stage ref navigation on its current run/source/stage", () => {
+    expect(evidenceHref(turn, { kind: "stage", id: "run-current::provider.dataset::gold", label: "Gold" })).toBe(
+      "/builds?run=run-current&dataset=dataset-1&source=provider.dataset&stage=gold",
+    );
   });
 });

--- a/src/features/kubi/KubiContent.tsx
+++ b/src/features/kubi/KubiContent.tsx
@@ -363,11 +363,24 @@ export function evidenceDetailEntries(turn: KubiTurn, ref: KubiEvidenceRef): [st
     .map(([key, value]) => [key, String(value ?? "—")]);
 }
 
-function evidenceHref(turn: KubiTurn, ref: KubiEvidenceRef): string | null {
+export function evidenceHref(turn: KubiTurn, ref: KubiEvidenceRef): string | null {
   const detail = evidenceDetail(turn, ref);
   if (!detail) return null;
   if (ref.kind === "dataset") return turn.evidence?.deepLinks.datasetDetail ?? null;
-  if (ref.kind === "run" || ref.kind === "stage") {
+  if (ref.kind === "run") {
+    if (!("runId" in detail) || typeof detail.runId !== "string") return null;
+    const targetRunId = detail.runId;
+    const params = new URLSearchParams({ run: targetRunId });
+    if (turn.context.datasetId) params.set("dataset", turn.context.datasetId);
+    // source/stage는 해당 run에서 검증된 문맥일 때만 유효하다. 다른 recent run으로 이동할
+    // 때 현재 run의 선택을 carry하면 존재하지 않는 조합이 되므로 함께 넘기지 않는다.
+    if (targetRunId === turn.context.runId) {
+      if (turn.context.source) params.set("source", turn.context.source);
+      if (turn.context.stage) params.set("stage", turn.context.stage);
+    }
+    return `/builds?${params}`;
+  }
+  if (ref.kind === "stage") {
     if (!turn.context.runId) return null;
     const params = new URLSearchParams({ run: turn.context.runId });
     if (turn.context.datasetId) params.set("dataset", turn.context.datasetId);
@@ -427,6 +440,7 @@ function TurnCard({ turn, session, collapsed = false, onToggle }: { turn: KubiTu
 
   return (
     <div className="space-y-2">
+      {onToggle ? <div className="flex justify-end"><button type="button" aria-expanded="true" onClick={onToggle} className="text-[11px] font-medium text-muted-foreground hover:text-foreground">대화 접기</button></div> : null}
       <div className="ml-auto max-w-[88%] rounded-lg bg-accent px-3 py-2 text-xs text-accent-foreground">
         {turn.question}
       </div>

--- a/src/features/kubi/KubiContent.tsx
+++ b/src/features/kubi/KubiContent.tsx
@@ -5,11 +5,11 @@
  * Kubi 시스템을 만들지 않는다. `compact`는 drawer(좁은 폭)와 페이지(넓은 폭) 레이아웃만
  * 다르게 하고, 상태 로직은 전부 `useKubiSession`에 있다.
  */
-import { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { SpecDiff } from "@/features/build-spec/components/SpecDiff";
 import { useAssistConfig } from "@/features/assistant/config";
-import { Button, Card } from "@/shared/ui";
+import { Button, Card, Disclosure, Textarea } from "@/shared/ui";
 import { describeAction } from "./actions";
 import { relatedCatalogDatasets } from "./relatedDatasets";
 import type { KubiAction } from "./schema";
@@ -17,6 +17,9 @@ import { SUGGESTED_QUESTIONS } from "./suggestedQuestions";
 import { summarizeKubiQuality } from "./types";
 import type { KubiActionRunState, KubiContext, KubiErrorState, KubiQueryState, KubiTurn } from "./types";
 import { useKubiSession } from "./useKubiSession";
+import { MarkdownContent } from "./MarkdownContent";
+import type { KubiEvidenceRef } from "./types";
+import { formatSqlForDisplay } from "./formatSqlForDisplay";
 
 /** 데모 CTA와 onboarding 예시 질문이 함께 쓰는 기본 질문(mock evidence만으로도 답이 나온다). */
 const DEMO_QUESTION = "이 데이터셋 품질 어때?";
@@ -26,11 +29,10 @@ const DEMO_QUESTION = "이 데이터셋 품질 어때?";
  * PAGE는 프로토타입에서도 별도 grid cell이 아니라 drawer 헤더의 보조 캡션이었으므로, 여기서도
  * 작은 캡션 한 줄로만 표시한다 — 4칸을 차지하지 않는다.
  */
-function ContextBar({ context, pageLabel, qualityLabel }: { context: KubiContext; pageLabel: string; qualityLabel: string }) {
+function ContextBar({ context, pageLabel, qualityLabel, sources, onContextChange }: { context: KubiContext; pageLabel: string; qualityLabel: string; sources: string[]; onContextChange: (key: "stage" | "source", value?: string) => void }) {
   const cells: { label: string; value: string }[] = [
     { label: "DATASET", value: context.datasetId ?? "—" },
     { label: "RUN", value: context.runId ?? "—" },
-    { label: "STAGE", value: context.stage ?? "—" },
     { label: "QUALITY", value: qualityLabel },
   ];
   return (
@@ -45,7 +47,10 @@ function ContextBar({ context, pageLabel, qualityLabel }: { context: KubiContext
             </p>
           </div>
         ))}
+        <label className="rounded-lg border border-border bg-muted/40 px-2.5 py-2"><span className="block text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">STAGE</span><select aria-label="Kubi 분석 Stage" className="mt-0.5 w-full bg-transparent text-xs font-medium" value={context.stage ?? ""} onChange={(event) => onContextChange("stage", event.target.value || undefined)} disabled={!context.runId}><option value="">{context.runId ? "Run 전체" : "사용 불가"}</option><option value="bronze">Bronze</option><option value="silver">Silver</option><option value="gold">Gold</option></select></label>
       </div>
+      {context.runId && sources.length > 1 ? <label className="mt-2 block text-xs text-muted-foreground">분석 Source<select aria-label="Kubi 분석 Source" className="ml-2 rounded border border-input bg-card px-2 py-1 text-foreground" value={context.source ?? ""} onChange={(event) => onContextChange("source", event.target.value || undefined)}><option value="">먼저 선택하세요</option>{sources.map((source) => <option key={source} value={source}>{source}</option>)}</select></label> : null}
+      <p className="mt-2 text-[11px] text-muted-foreground">{!context.runId ? "Run을 선택하면 Run 및 Stage 근거를 분석할 수 있습니다." : sources.length > 1 && !context.source ? "이 Run에는 source가 여러 개 있습니다. 분석할 source를 먼저 선택하세요." : !context.stage ? "Run 전체를 분석 중입니다. SQL을 생성하려면 Silver 또는 Gold를 선택하세요." : context.stage === "bronze" ? "Bronze에서는 Generated SQL을 실행할 수 없습니다. Silver 또는 Gold를 선택하세요." : `${context.stage === "gold" ? "Gold" : "Silver"} schema 기반 질문 및 SQL 생성 가능`}</p>
     </div>
   );
 }
@@ -241,9 +246,11 @@ function ActionCard({
   session: ReturnType<typeof useKubiSession>;
 }) {
   const state: KubiActionRunState = turn.actionStates[index] ?? { status: "pending_approval" };
+  const isNavigation = action.type === "OPEN_BUILD" || action.type === "OPEN_QUALITY" || action.type === "OPEN_PROVIDER";
 
   return (
-    <div className="rounded-lg border border-border bg-card px-3 py-2 text-xs">
+    <div className={isNavigation ? "flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border bg-muted/20 px-3 py-2 text-xs" : "rounded-lg border border-border bg-card px-3 py-2 text-xs"}>
+      <div className={isNavigation ? "min-w-0" : undefined}>
       {action.type === "PATCH_BUILDSPEC" ? (
         <span className="mb-1 inline-flex items-center gap-1 rounded-full bg-violet-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-violet-800 dark:bg-violet-950/50 dark:text-violet-300">
           BuildSpec 변경 제안
@@ -251,6 +258,8 @@ function ActionCard({
       ) : null}
       <p className="font-medium text-foreground">{describeAction(action)}</p>
       <p className="mt-0.5 text-muted-foreground">{action.reason}</p>
+
+      </div>
 
       {action.type === "ADD_REPORT_BLOCK" ? (
         <div className="mt-2 rounded-lg border border-border bg-muted/30 p-2">
@@ -296,13 +305,13 @@ function ActionCard({
         </pre>
       ) : null}
 
-      <div className="mt-2 flex flex-wrap items-center gap-2">
+      <div className={`${isNavigation ? "" : "mt-2"} flex flex-wrap items-center gap-2`}>
         {state.status === "pending_approval" ? (
           <>
-            <Button size="sm" disabled={isStale} onClick={() => session.approveAction(turn.id, index)}>
-              승인
+            <Button size="sm" aria-label={isNavigation ? "승인" : undefined} disabled={isStale} onClick={() => session.approveAction(turn.id, index)}>
+              {isNavigation ? "열기" : "승인"}
             </Button>
-            <Button size="sm" variant="ghost" onClick={() => session.rejectAction(turn.id, index)}>
+            <Button className={isNavigation ? "sr-only" : undefined} size="sm" variant="ghost" onClick={() => session.rejectAction(turn.id, index)}>
               거부
             </Button>
           </>
@@ -324,8 +333,97 @@ function ActionCard({
   );
 }
 
-function TurnCard({ turn, session }: { turn: KubiTurn; session: ReturnType<typeof useKubiSession> }) {
+export function evidenceDetail(turn: KubiTurn, ref: KubiEvidenceRef) {
+  const evidence = turn.evidence;
+  if (!evidence) return null;
+  if (ref.kind === "quality") return evidence.quality?.results.find((item) => item.id === ref.id) ?? null;
+  if (ref.kind === "schema_drift") return evidence.quality?.schemaDrift.find((item) => `${item.kind}::${item.column ?? "_"}` === ref.id) ?? null;
+  if (ref.kind === "dataset" && evidence.dataset?.datasetId === ref.id) return evidence.dataset;
+  if (ref.kind === "run") return evidence.recentRuns?.find((item) => item.runId === ref.id) ?? (turn.context.runId === ref.id ? { runId: ref.id } : null);
+  if (ref.kind === "stage" && evidence.stage?.refId === ref.id) return evidence.stage;
+  if (ref.kind === "catalog" && evidence.catalog) return evidence.catalog;
+  return null;
+}
+
+export function evidenceDetailEntries(turn: KubiTurn, ref: KubiEvidenceRef): [string, string][] {
+  const detail = evidenceDetail(turn, ref);
+  if (!detail) return [];
+  if (ref.kind === "stage" && turn.evidence?.stage) {
+    const stage = turn.evidence.stage;
+    return [
+      ["Stage", stage.stage[0].toUpperCase() + stage.stage.slice(1)],
+      ["Source", stage.source],
+      ["Status", stage.status],
+      ["Rows", stage.rowCount === null ? "—" : String(stage.rowCount)],
+      ...(stage.columns ? [["Columns", String(stage.columns.length)] as [string, string]] : []),
+    ];
+  }
+  return Object.entries(detail)
+    .filter(([, value]) => value !== undefined && typeof value !== "object")
+    .map(([key, value]) => [key, String(value ?? "—")]);
+}
+
+function evidenceHref(turn: KubiTurn, ref: KubiEvidenceRef): string | null {
+  const detail = evidenceDetail(turn, ref);
+  if (!detail) return null;
+  if (ref.kind === "dataset") return turn.evidence?.deepLinks.datasetDetail ?? null;
+  if (ref.kind === "run" || ref.kind === "stage") {
+    if (!turn.context.runId) return null;
+    const params = new URLSearchParams({ run: turn.context.runId });
+    if (turn.context.datasetId) params.set("dataset", turn.context.datasetId);
+    if (turn.context.source) params.set("source", turn.context.source);
+    if (turn.context.stage) params.set("stage", turn.context.stage);
+    return `/builds?${params}`;
+  }
+  if (ref.kind === "quality" || ref.kind === "schema_drift") {
+    if (!turn.context.runId && !turn.context.datasetId) return null;
+    const params = new URLSearchParams();
+    if (turn.context.datasetId) params.set("dataset", turn.context.datasetId);
+    if (turn.context.runId) params.set("run", turn.context.runId);
+    if ("source" in detail && typeof detail.source === "string") params.set("source", detail.source);
+    else if (turn.context.source) params.set("source", turn.context.source);
+    if (turn.context.stage) params.set("stage", turn.context.stage);
+    return `/quality?${params}`;
+  }
+  return null;
+}
+
+function EvidenceSection({ turn }: { turn: KubiTurn }) {
+  const [selected, setSelected] = useState<KubiEvidenceRef | null>(null);
+  const refs = turn.response?.evidenceRefs ?? [];
+  const rejected = turn.error?.kind === "hallucinated_refs" ? turn.error.rejectedRefs : [];
+  if (!refs.length && !rejected.length && !turn.evidence?.partial) return null;
+  const detail = selected ? evidenceDetail(turn, selected) : null;
+  const detailEntries = selected ? evidenceDetailEntries(turn, selected) : [];
+  const href = selected ? evidenceHref(turn, selected) : null;
+  return <Disclosure title={`근거 ${refs.length}개${rejected.length ? ` · 제외된 근거 ${rejected.length}개` : ""}`}>
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-1.5">{refs.map((ref) => <button key={`${ref.kind}:${ref.id}`} type="button" aria-pressed={selected?.kind === ref.kind && selected.id === ref.id} onClick={() => setSelected(ref)} className="rounded-full border border-border bg-muted/40 px-2 py-1 text-[10px] hover:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">{ref.label}</button>)}</div>
+      {selected ? <div className="rounded-lg border border-border bg-muted/30 p-3 text-xs">
+        <p className="font-semibold">{selected.label}</p>
+        {detail ? <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">{detailEntries.map(([key, value]) => <div className="contents" key={key}><dt className="text-muted-foreground">{key}</dt><dd className="break-all">{value}</dd></div>)}</dl> : <p className="mt-1 text-muted-foreground">상세 근거를 현재 evidence에서 확인할 수 없습니다.</p>}
+        {href ? <Link className="mt-2 inline-block font-medium underline" to={href}>원본 화면 열기</Link> : null}
+      </div> : null}
+      {rejected.length ? <Disclosure title={`⚠ 제외된 근거 ${rejected.length}개`}>{<ul className="list-disc space-y-1 pl-5 text-xs text-muted-foreground">{rejected.map((item) => <li key={item}>{item}</li>)}</ul>}</Disclosure> : null}
+      {turn.evidence?.partial ? <p className="text-[11px] text-muted-foreground">확인하지 못한 근거: {turn.evidence.unavailable.join(", ")}</p> : null}
+    </div>
+  </Disclosure>;
+}
+
+function LoadingPhase({ turn }: { turn: KubiTurn }) {
+  const steps = [
+    ["collecting_evidence", "Evidence 확인"],
+    ["generating", "답변 생성"],
+    ["validating", "근거 검증"],
+  ] as const;
+  const current = steps.findIndex(([phase]) => phase === turn.phase);
+  return <div aria-live="polite" className="space-y-1 text-muted-foreground">{steps.map(([phase, label], index) => <p key={phase}>{index < current ? "✓" : index === current ? "●" : "○"} {label}{index === current ? " 중" : ""}</p>)}</div>;
+}
+
+function TurnCard({ turn, session, collapsed = false, onToggle }: { turn: KubiTurn; session: ReturnType<typeof useKubiSession>; collapsed?: boolean; onToggle?: () => void }) {
   const stale = session.isStale(turn);
+
+  if (collapsed) return <button type="button" aria-expanded="false" onClick={onToggle} className="flex w-full items-center gap-2 rounded-lg border border-border px-3 py-2 text-left text-xs hover:bg-muted"><span>{turn.status === "ok" ? "성공" : turn.status === "error" ? "실패" : "진행 중"}</span><span className="truncate font-medium">{turn.question}</span>{stale ? <span className="ml-auto shrink-0 text-amber-700">이전 화면</span> : null}</button>;
 
   return (
     <div className="space-y-2">
@@ -347,8 +445,7 @@ function TurnCard({ turn, session }: { turn: KubiTurn; session: ReturnType<typeo
 
         {turn.status === "loading" ? (
           <div className="flex items-center gap-2 text-muted-foreground">
-            <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-            생각 중…
+            <LoadingPhase turn={turn} />
             <Button size="sm" variant="ghost" onClick={() => session.cancel(turn.id)}>
               취소
             </Button>
@@ -359,7 +456,7 @@ function TurnCard({ turn, session }: { turn: KubiTurn; session: ReturnType<typeo
 
         {turn.response ? (
           <div className="space-y-2.5">
-            <p className="whitespace-pre-wrap leading-6 text-foreground">{turn.response.answer}</p>
+            <MarkdownContent>{turn.response.answer}</MarkdownContent>
 
             {turn.error?.kind === "hallucinated_refs" ? (
               <p role="alert" className="text-[11px] text-amber-700 dark:text-amber-400">
@@ -367,31 +464,12 @@ function TurnCard({ turn, session }: { turn: KubiTurn; session: ReturnType<typeo
               </p>
             ) : null}
 
-            {turn.evidence?.partial ? (
-              <p className="text-[11px] text-muted-foreground">
-                일부 evidence를 확인하지 못했습니다: {turn.evidence.unavailable.join(", ")}
-              </p>
-            ) : null}
-
-            {turn.response.evidenceRefs.length > 0 ? (
-              <div>
-                <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Evidence</p>
-                <ul className="mt-1 flex flex-wrap gap-1.5">
-                  {turn.response.evidenceRefs.map((ref) => (
-                    <li key={`${ref.kind}:${ref.id}`} className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[10px]">
-                      {ref.label}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
+            <EvidenceSection turn={turn} />
 
             {turn.response.generatedSql ? (
-              <div>
-                <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                  Generated SQL · {turn.response.generatedSql.stage}
-                </p>
-                <pre className="mt-1 overflow-x-auto rounded-lg bg-muted/70 p-2 text-[11px]">{turn.response.generatedSql.sql}</pre>
+              <div className="min-w-0">
+                <div className="flex items-center justify-between gap-2"><p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Generated SQL · {turn.response.generatedSql.stage}</p><Button size="sm" variant="ghost" aria-label="Generated SQL 복사" onClick={() => void navigator.clipboard.writeText(turn.response!.generatedSql!.sql)}>복사</Button></div>
+                <pre className="mt-1 max-w-full overflow-x-auto whitespace-pre rounded-lg bg-muted/70 p-2 font-mono text-[11px]">{formatSqlForDisplay(turn.response.generatedSql.sql)}</pre>
                 <Button
                   size="sm"
                   className="mt-1.5"
@@ -428,8 +506,15 @@ export interface KubiContentProps {
 /** Kubi 대화 화면. drawer/페이지 공용. */
 export function KubiContent({ compact = false }: KubiContentProps) {
   const session = useKubiSession();
+  const navigate = useNavigate();
+  const location = useLocation();
   const { isConfigured } = useAssistConfig();
   const [input, setInput] = useState("");
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [openPastTurns, setOpenPastTurns] = useState<Set<string>>(new Set());
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const latestRef = useRef<HTMLDivElement>(null);
+  const composingRef = useRef(false);
 
   // BYOK가 없어도 mock 모드에서는 데모로 질문을 보낼 수 있다(#256 데모, real mode는 항상 BYOK 필요).
   const canSubmit = isConfigured || session.isDemoAvailable;
@@ -455,6 +540,42 @@ export function KubiContent({ compact = false }: KubiContentProps) {
     return [];
   }, [session.turns, session.isStale]);
 
+  const contextSources = useMemo(() => {
+    const values = new Set<string>();
+    for (let i = session.turns.length - 1; i >= 0; i -= 1) {
+      const turn = session.turns[i];
+      if (!turn.evidence || session.isStale(turn)) continue;
+      turn.evidence.quality?.results.forEach((item) => values.add(item.source));
+      if (turn.evidence.stage?.source) values.add(turn.evidence.stage.source);
+      break;
+    }
+    return [...values];
+  }, [session.turns, session.isStale]);
+
+  const suggestedQuestions = useMemo(() => {
+    if (session.liveContext.stage === "gold" || session.liveContext.stage === "silver") return ["사용할 수 있는 컬럼을 알려줘.", "이 데이터를 집계하는 SQL을 만들어줘."];
+    if (session.liveContext.page === "quality") return ["Quality 결과를 요약해줘.", "FAIL/WARN의 원인을 알려줘."];
+    if (session.liveContext.runId) return ["이 Run 상태를 요약해줘.", "실패 원인이 있으면 알려줘."];
+    if (session.liveContext.datasetId) return ["이 Dataset의 특징을 알려줘."];
+    return SUGGESTED_QUESTIONS;
+  }, [session.liveContext]);
+
+  function changeContext(key: "stage" | "source", value?: string) {
+    const params = new URLSearchParams(location.search);
+    if (value) params.set(key, value); else params.delete(key);
+    if (key === "source") params.delete("stage");
+    navigate(`${location.pathname}${params.size ? `?${params}` : ""}`);
+  }
+
+  useEffect(() => { latestRef.current?.scrollIntoView?.({ block: "start" }); }, [session.turns.length]);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.style.height = "auto";
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 144)}px`;
+  }, [input]);
+
   function submit(question: string) {
     setInput("");
     if (!isConfigured && session.isDemoAvailable) {
@@ -465,9 +586,11 @@ export function KubiContent({ compact = false }: KubiContentProps) {
   }
 
   return (
-    <div className={compact ? "flex flex-col gap-4" : "grid gap-4 lg:grid-cols-[1fr_280px]"}>
-      <div className="flex min-w-0 flex-col gap-4">
-        <ContextBar context={session.liveContext} pageLabel={session.pageLabel} qualityLabel={qualityLabel} />
+    <div className={compact ? "flex h-full min-h-0 flex-col" : "grid gap-4 lg:grid-cols-[1fr_280px]"}>
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <div className={compact ? "shrink-0 border-b border-border px-5 py-3" : "mb-4"}><ContextBar context={session.liveContext} pageLabel={session.pageLabel} qualityLabel={qualityLabel} sources={contextSources} onContextChange={changeContext} /></div>
+
+        <div className={compact ? "min-h-0 flex-1 overflow-y-auto px-5 py-4" : "space-y-4"} data-testid="kubi-conversation">
 
         {!isConfigured ? (
           <div className="space-y-3">
@@ -491,7 +614,7 @@ export function KubiContent({ compact = false }: KubiContentProps) {
             <p className="text-sm font-semibold">처음이신가요?</p>
             <p className="text-xs text-muted-foreground">예시 질문으로 시작하거나 직접 질문할 수 있습니다.</p>
             <div className="flex flex-wrap gap-1.5">
-              {SUGGESTED_QUESTIONS.map((question) => (
+              {suggestedQuestions.map((question) => (
                 <button
                   key={question}
                   type="button"
@@ -506,26 +629,29 @@ export function KubiContent({ compact = false }: KubiContentProps) {
           </Card>
         ) : null}
 
-        <div className="flex flex-col gap-3">
-          {session.turns.map((turn) => (
-            <TurnCard key={turn.id} turn={turn} session={session} />
-          ))}
+        {session.turns.length > 1 ? <div className="mb-3"><button type="button" aria-expanded={historyOpen} onClick={() => setHistoryOpen((value) => !value)} className="text-xs font-semibold text-muted-foreground">{historyOpen ? "▼" : "▶"} 이전 대화 {session.turns.length - 1}개</button>{historyOpen ? <div className="mt-2 space-y-2">{session.turns.slice(0, -1).map((turn) => <TurnCard key={turn.id} turn={turn} session={session} collapsed={!openPastTurns.has(turn.id)} onToggle={() => setOpenPastTurns((current) => { const next = new Set(current); if (next.has(turn.id)) next.delete(turn.id); else next.add(turn.id); return next; })} />)}</div> : null}</div> : null}
+        {session.turns.length ? <div ref={latestRef}><TurnCard turn={session.turns[session.turns.length - 1]} session={session} /></div> : null}
         </div>
 
         <form
-          className="flex gap-2"
+          className={compact ? "flex shrink-0 items-end gap-2 border-t border-border bg-card px-5 py-3" : "mt-4 flex items-end gap-2"}
           onSubmit={(event) => {
             event.preventDefault();
             if (input.trim()) submit(input);
           }}
         >
-          <input
+          <Textarea
+            ref={textareaRef}
+            rows={2}
             aria-label="Kubi에게 질문하기"
-            className="h-9 flex-1 rounded-lg border border-input bg-card px-3 text-sm text-foreground"
+            className="max-h-36 min-h-[4.25rem] flex-1 resize-none overflow-y-auto"
             disabled={!canSubmit}
             onChange={(event) => setInput(event.target.value)}
             placeholder={isConfigured ? "질문을 입력하세요…" : canSubmit ? "질문을 입력하세요… (데모 · mock 데이터)" : "먼저 API Key를 설정하세요"}
             value={input}
+            onCompositionStart={() => { composingRef.current = true; }}
+            onCompositionEnd={() => { composingRef.current = false; }}
+            onKeyDown={(event) => { if (event.key === "Enter" && !event.shiftKey && !composingRef.current && !event.nativeEvent.isComposing) { event.preventDefault(); if (input.trim()) submit(input); } }}
           />
           <Button type="submit" disabled={!canSubmit || !input.trim()}>
             전송
@@ -538,7 +664,7 @@ export function KubiContent({ compact = false }: KubiContentProps) {
           <div>
             <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">추천 질문</p>
             <div className="mt-2 flex flex-wrap gap-1.5">
-              {SUGGESTED_QUESTIONS.map((question) => (
+              {suggestedQuestions.map((question) => (
                 <button
                   key={question}
                   type="button"

--- a/src/features/kubi/KubiContent.tsx
+++ b/src/features/kubi/KubiContent.tsx
@@ -20,6 +20,7 @@ import { useKubiSession } from "./useKubiSession";
 import { MarkdownContent } from "./MarkdownContent";
 import type { KubiEvidenceRef } from "./types";
 import { formatSqlForDisplay } from "./formatSqlForDisplay";
+import { useLiveRunSources } from "./useLiveRunSources";
 
 /** 데모 CTA와 onboarding 예시 질문이 함께 쓰는 기본 질문(mock evidence만으로도 답이 나온다). */
 const DEMO_QUESTION = "이 데이터셋 품질 어때?";
@@ -554,17 +555,9 @@ export function KubiContent({ compact = false }: KubiContentProps) {
     return [];
   }, [session.turns, session.isStale]);
 
-  const contextSources = useMemo(() => {
-    const values = new Set<string>();
-    for (let i = session.turns.length - 1; i >= 0; i -= 1) {
-      const turn = session.turns[i];
-      if (!turn.evidence || session.isStale(turn)) continue;
-      turn.evidence.quality?.results.forEach((item) => values.add(item.source));
-      if (turn.evidence.stage?.source) values.add(turn.evidence.stage.source);
-      break;
-    }
-    return [...values];
-  }, [session.turns, session.isStale]);
+  // 첫 질문 전에도 현재 Run의 Builder-confirmed stage source 목록을 authoritative하게 쓴다.
+  // 과거 turn/LLM/quality 결과는 live source 후보를 만들 근거로 사용하지 않는다.
+  const contextSources = useLiveRunSources(session.liveContext.runId);
 
   const suggestedQuestions = useMemo(() => {
     if (session.liveContext.stage === "gold" || session.liveContext.stage === "silver") return ["사용할 수 있는 컬럼을 알려줘.", "이 데이터를 집계하는 SQL을 만들어줘."];

--- a/src/features/kubi/KubiDrawer.tsx
+++ b/src/features/kubi/KubiDrawer.tsx
@@ -5,7 +5,7 @@
  * 렌더 금지). 실제 LLM 연동, Evidence/Generated SQL, Suggested Action은 `KubiContent`
  * (`useKubiSession` 공유)가 담당하고, 이 컴포넌트는 drawer 자체의 열림/닫힘·포커스 트랩만 맡는다.
  */
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useUIStore } from "@/shared/hooks/useUIStore";
 import { KubiContent } from "./KubiContent";
 
@@ -20,6 +20,7 @@ export function KubiDrawer() {
   const dialogRef = useRef<HTMLElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const returnFocusRef = useRef<HTMLElement | null>(null);
+  const [expanded, setExpanded] = useState(false);
 
   // 열리는 순간 닫기 버튼으로 포커스를 옮기고, 모달 안에서 포커스를 순환시킨다.
   // 닫히면 drawer를 열었던 요소로 포커스를 되돌린다(접근성).
@@ -80,24 +81,21 @@ export function KubiDrawer() {
         aria-label="Kubi AI Assistant"
         aria-modal="true"
         role="dialog"
-        className="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col overflow-y-auto border-l border-border bg-card px-5 py-5 shadow-xl sm:w-96"
+        className={`fixed inset-y-0 right-0 z-50 flex w-full flex-col overflow-hidden border-l border-border bg-card shadow-xl transition-[width] sm:w-[min(34rem,100vw)] ${expanded ? "lg:w-[min(60vw,60rem)]" : ""}`}
       >
-        <div className="flex items-start justify-between gap-3">
+        <div className="flex shrink-0 items-start justify-between gap-3 border-b border-border px-5 py-4">
           <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             ✨ Kubi AI Assistant
           </p>
-          <button
-            ref={closeButtonRef}
-            aria-label="Kubi 닫기"
-            className="rounded-lg border border-border p-1.5 text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-            onClick={closeKubiDrawer}
-            type="button"
-          >
-            ✕
-          </button>
+          <div className="flex gap-1.5">
+            <button aria-label={expanded ? "Kubi 기본 너비로 보기" : "Kubi 확장하기"} aria-pressed={expanded} className="hidden rounded-lg border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-muted lg:block" onClick={() => setExpanded((value) => !value)} type="button">
+              {expanded ? "기본" : "확장"}
+            </button>
+            <button ref={closeButtonRef} aria-label="Kubi 닫기" className="rounded-lg border border-border p-1.5 text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" onClick={closeKubiDrawer} type="button">✕</button>
+          </div>
         </div>
 
-        <div className="mt-4 flex-1">
+        <div className="min-h-0 flex-1">
           <KubiContent compact />
         </div>
       </aside>

--- a/src/features/kubi/KubiLiveSources.test.tsx
+++ b/src/features/kubi/KubiLiveSources.test.tsx
@@ -1,0 +1,102 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, useLocation, useNavigate } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as datasetsApi from "@/features/datasets/api";
+import { KubiPage } from "@/pages/KubiPage";
+import { useKubiStore } from "./useKubiSession";
+import type { RunStagesResponse } from "@/shared/lib/builderApi";
+
+function stages(runId: string, sourceKeys: string[]): RunStagesResponse {
+  return {
+    run_id: runId,
+    sources: sourceKeys.map((source_key) => ({
+      source_key,
+      bronze: { status: "completed", available: true },
+      silver: { status: "completed", available: true },
+      gold: { status: "completed", available: true },
+    })),
+  };
+}
+
+function Harness({ initialPath = "/kubi?run=run-a" }: { initialPath?: string }) {
+  return (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <KubiPage />
+      <LocationHarness />
+    </MemoryRouter>
+  );
+}
+
+function LocationHarness() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return (
+    <>
+      <output data-testid="location">{location.pathname}{location.search}</output>
+      <button type="button" onClick={() => navigate("/kubi?run=run-b")}>Run B로 이동</button>
+    </>
+  );
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  useKubiStore.setState({ turns: [], onboarded: false, pendingSeed: null });
+  vi.restoreAllMocks();
+});
+
+describe("Kubi live Builder-confirmed source picker", () => {
+  it("shows a multi-source picker before the first question, without quality evidence", async () => {
+    vi.spyOn(datasetsApi, "listBuildStages").mockResolvedValue(stages("run-a", ["provider.a", "provider.b"]));
+    render(<Harness />);
+    const picker = await screen.findByLabelText("Kubi 분석 Source");
+    expect(useKubiStore.getState().turns).toHaveLength(0);
+    expect(picker).toHaveTextContent("provider.a");
+    expect(picker).toHaveTextContent("provider.b");
+  });
+
+  it("does not expose stale Run A sources after changing to Run B", async () => {
+    const runA = deferred<RunStagesResponse>();
+    const runB = deferred<RunStagesResponse>();
+    vi.spyOn(datasetsApi, "listBuildStages").mockImplementation((runId) => runId === "run-a" ? runA.promise : runB.promise);
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "Run B로 이동" }));
+    await act(async () => { runB.resolve(stages("run-b", ["provider.b1", "provider.b2"])); });
+    expect(await screen.findByText("provider.b1", { selector: "option" })).toBeInTheDocument();
+    await act(async () => { runA.resolve(stages("run-a", ["provider.a1", "provider.a2"])); });
+    expect(screen.queryByText("provider.a1", { selector: "option" })).not.toBeInTheDocument();
+  });
+
+  it("shows no fake source option when the Builder source fetch fails", async () => {
+    vi.spyOn(datasetsApi, "listBuildStages").mockRejectedValue(new Error("network"));
+    render(<Harness />);
+    await waitFor(() => expect(datasetsApi.listBuildStages).toHaveBeenCalled());
+    expect(screen.queryByLabelText("Kubi 분석 Source")).not.toBeInTheDocument();
+  });
+
+  it("keeps single-source behavior without presenting an unnecessary picker", async () => {
+    vi.spyOn(datasetsApi, "listBuildStages").mockResolvedValue(stages("run-a", ["provider.only"]));
+    render(<Harness />);
+    await waitFor(() => expect(datasetsApi.listBuildStages).toHaveBeenCalled());
+    expect(screen.queryByLabelText("Kubi 분석 Source")).not.toBeInTheDocument();
+  });
+
+  it("writes a selected confirmed source into URL context", async () => {
+    vi.spyOn(datasetsApi, "listBuildStages").mockResolvedValue(stages("run-a", ["provider.a", "provider.b"]));
+    render(<Harness initialPath="/kubi?run=run-a&stage=gold" />);
+    fireEvent.change(await screen.findByLabelText("Kubi 분석 Source"), { target: { value: "provider.b" } });
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent("/kubi?run=run-a&source=provider.b"));
+  });
+
+  it("remains fail-closed when a multi-source Run has no selected source", async () => {
+    vi.spyOn(datasetsApi, "listBuildStages").mockResolvedValue(stages("run-a", ["provider.a", "provider.b"]));
+    render(<Harness initialPath="/kubi?run=run-a&stage=gold" />);
+    expect(await screen.findByText("이 Run에는 source가 여러 개 있습니다. 분석할 source를 먼저 선택하세요.")).toBeInTheDocument();
+    expect(screen.getByLabelText("Kubi 분석 Source")).toHaveValue("");
+  });
+});

--- a/src/features/kubi/MarkdownContent.test.tsx
+++ b/src/features/kubi/MarkdownContent.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MarkdownContent } from "./MarkdownContent";
+
+describe("MarkdownContent", () => {
+  it("renders common Markdown without exposing syntax markers", () => {
+    const { container } = render(<MarkdownContent>{"Run X의 상태는 **성공(ok)**입니다.\n\n- 항목\n\n`pm10Value`\n\n```sql\nSELECT 1\n```"}</MarkdownContent>);
+    expect(screen.getByText("성공(ok)").tagName).toBe("STRONG");
+    expect(screen.getByText("항목").tagName).toBe("LI");
+    expect(screen.getByText("pm10Value").tagName).toBe("CODE");
+    expect(screen.getByText("SELECT 1").tagName).toBe("CODE");
+    expect(container.textContent).not.toContain("**");
+  });
+
+  it("keeps raw HTML inert and blocks unsafe link protocols", () => {
+    const { container } = render(<MarkdownContent>{'<img src=x onerror="alert(1)"> [bad](javascript:alert(1))'}</MarkdownContent>);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toContain("<img");
+  });
+});

--- a/src/features/kubi/MarkdownContent.tsx
+++ b/src/features/kubi/MarkdownContent.tsx
@@ -1,0 +1,72 @@
+import { Fragment, type ReactNode } from "react";
+
+const SAFE_LINK = /^(https?:\/\/|\/|\.\/|\.\.\/|#)/i;
+
+function inline(text: string): ReactNode[] {
+  const parts: ReactNode[] = [];
+  const pattern = /(\*\*[^*]+\*\*|\*[^*]+\*|`[^`]+`|\[[^\]]+\]\([^)]+\))/g;
+  let last = 0;
+  for (const match of text.matchAll(pattern)) {
+    const index = match.index ?? 0;
+    if (index > last) parts.push(text.slice(last, index));
+    const token = match[0];
+    if (token.startsWith("**")) parts.push(<strong key={index}>{token.slice(2, -2)}</strong>);
+    else if (token.startsWith("*")) parts.push(<em key={index}>{token.slice(1, -1)}</em>);
+    else if (token.startsWith("`")) parts.push(<code key={index} className="rounded bg-muted px-1 py-0.5 font-mono text-[0.92em]">{token.slice(1, -1)}</code>);
+    else {
+      const link = token.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+      const href = link?.[2] ?? "";
+      parts.push(SAFE_LINK.test(href) ? <a key={index} href={href} rel="noopener noreferrer" className="underline">{link?.[1]}</a> : <span key={index}>{link?.[1]}</span>);
+    }
+    last = index + token.length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts;
+}
+
+/** raw HTML을 해석하지 않는 작은 Markdown renderer. LLM 문자열은 항상 React text node로 남는다. */
+export function MarkdownContent({ children }: { children: string }) {
+  const lines = children.replace(/\r\n/g, "\n").split("\n");
+  const nodes: ReactNode[] = [];
+  for (let i = 0; i < lines.length;) {
+    const line = lines[i];
+    if (line.startsWith("```")) {
+      const language = line.slice(3).trim();
+      const code: string[] = [];
+      i += 1;
+      while (i < lines.length && !lines[i].startsWith("```")) code.push(lines[i++]);
+      if (i < lines.length) i += 1;
+      nodes.push(<pre key={`code-${i}`} className="overflow-x-auto rounded-lg bg-muted/70 p-3 font-mono text-xs"><code data-language={language || undefined}>{code.join("\n")}</code></pre>);
+      continue;
+    }
+    if (line.includes("|") && i + 1 < lines.length && /^\s*\|?\s*:?-+/.test(lines[i + 1])) {
+      const split = (value: string) => value.replace(/^\s*\||\|\s*$/g, "").split("|").map((cell) => cell.trim());
+      const headers = split(line);
+      i += 2;
+      const rows: string[][] = [];
+      while (i < lines.length && lines[i].includes("|")) rows.push(split(lines[i++]));
+      nodes.push(<div key={`table-${i}`} className="overflow-x-auto"><table className="min-w-full border-collapse text-left text-xs"><thead><tr>{headers.map((cell, index) => <th key={index} className="border border-border bg-muted/50 px-2 py-1.5">{inline(cell)}</th>)}</tr></thead><tbody>{rows.map((row, rowIndex) => <tr key={rowIndex}>{headers.map((_, cellIndex) => <td key={cellIndex} className="border border-border px-2 py-1.5">{inline(row[cellIndex] ?? "")}</td>)}</tr>)}</tbody></table></div>);
+      continue;
+    }
+    const unordered = line.match(/^[-*] (.+)$/);
+    const ordered = line.match(/^\d+\. (.+)$/);
+    if (unordered || ordered) {
+      const orderedList = Boolean(ordered);
+      const items: string[] = [];
+      while (i < lines.length) {
+        const item = lines[i].match(orderedList ? /^\d+\. (.+)$/ : /^[-*] (.+)$/);
+        if (!item) break;
+        items.push(item[1]); i += 1;
+      }
+      const List = orderedList ? "ol" : "ul";
+      nodes.push(<List key={`list-${i}`} className={`${orderedList ? "list-decimal" : "list-disc"} space-y-1 pl-5`}>{items.map((item, index) => <li key={index}>{inline(item)}</li>)}</List>);
+      continue;
+    }
+    if (line.startsWith("> ")) { nodes.push(<blockquote key={`quote-${i}`} className="border-l-2 border-border pl-3 text-muted-foreground">{inline(line.slice(2))}</blockquote>); i += 1; continue; }
+    if (!line.trim()) { i += 1; continue; }
+    const paragraph: string[] = [line]; i += 1;
+    while (i < lines.length && lines[i].trim() && !/^(```|[-*] |\d+\. |> )/.test(lines[i])) paragraph.push(lines[i++]);
+    nodes.push(<p key={`p-${i}`} className="break-words leading-6">{paragraph.map((value, index) => <Fragment key={index}>{index ? <br /> : null}{inline(value)}</Fragment>)}</p>);
+  }
+  return <div className="space-y-3 text-foreground">{nodes}</div>;
+}

--- a/src/features/kubi/crossCheck.test.ts
+++ b/src/features/kubi/crossCheck.test.ts
@@ -20,6 +20,7 @@ function makeKnownRefs(overrides: Partial<KubiKnownRefs> = {}): KubiKnownRefs {
     providers: new Set(["datago"]),
     qualityResultIds: new Set(["src::missing::max_null_ratio::price"]),
     schemaDriftIds: new Set(["column_added::region"]),
+    stageIds: new Set(),
     sourceKeys: new Set(["datago.air_quality"]),
     ...overrides,
   };
@@ -63,6 +64,35 @@ describe("crossCheckKubiResponse (#256 hallucination gate)", () => {
       makeKnownRefs(),
     );
     expect(result.response.evidenceRefs).toHaveLength(0);
+  });
+
+  it("retains only the exact Builder-confirmed canonical stage ref", () => {
+    const refId = "run-1::provider.dataset::gold";
+    const evidence = makeEvidence({
+      context: { page: "quality", runId: "run-1", source: "provider.dataset", stage: "gold" },
+      stage: { refId, stage: "gold", source: "provider.dataset", status: "completed", available: true, rowCount: 40 },
+    });
+    const known = makeKnownRefs({ stageIds: new Set([refId]), sourceKeys: new Set(["provider.dataset"]) });
+
+    const valid = crossCheckKubiResponse(
+      makeResponse({ evidenceRefs: [{ kind: "stage", id: refId, label: "Gold" }] }),
+      evidence,
+      known,
+    );
+    expect(valid.response.evidenceRefs).toHaveLength(1);
+
+    for (const wrong of [
+      "wrong-run::provider.dataset::gold",
+      "run-1::wrong.source::gold",
+      "run-1::provider.dataset::silver",
+    ]) {
+      const checked = crossCheckKubiResponse(
+        makeResponse({ evidenceRefs: [{ kind: "stage", id: wrong, label: "unknown" }] }),
+        evidence,
+        known,
+      );
+      expect(checked.response.evidenceRefs).toHaveLength(0);
+    }
   });
 
   it("rejects OPEN_BUILD referencing an unknown run", () => {

--- a/src/features/kubi/crossCheck.ts
+++ b/src/features/kubi/crossCheck.ts
@@ -32,7 +32,7 @@ function isKnownEvidenceRef(ref: KubiEvidenceRef, known: KubiKnownRefs, evidence
     case "schema_drift":
       return known.schemaDriftIds.has(ref.id);
     case "stage":
-      return Boolean(evidence.stage) && ref.id === `${evidence.stage!.source}:${evidence.stage!.stage}`;
+      return known.stageIds.has(ref.id) && evidence.stage?.refId === ref.id;
     default:
       return false;
   }

--- a/src/features/kubi/demo.test.ts
+++ b/src/features/kubi/demo.test.ts
@@ -103,7 +103,7 @@ describe("buildKubiDemoResponse (#256 데모)", () => {
     const withStage = baseEvidence({
       ...datasetOnly,
       context: { page: "dataset-detail", datasetId: "air-quality", stage: "silver" },
-      stage: { stage: "silver", source: "datago__air", status: "completed", available: true, rowCount: 1000 },
+      stage: { refId: "run-1::datago__air::silver", stage: "silver", source: "datago__air", status: "completed", available: true, rowCount: 1000 },
     });
     const response = buildKubiDemoResponse(withStage);
     expect(response.generatedSql).toEqual({
@@ -111,13 +111,13 @@ describe("buildKubiDemoResponse (#256 데모)", () => {
       stage: "silver",
       source: "datago__air",
     });
-    expect(response.evidenceRefs).toContainEqual({ kind: "stage", id: "datago__air:silver", label: "datago__air · silver" });
+    expect(response.evidenceRefs).toContainEqual({ kind: "stage", id: "run-1::datago__air::silver", label: "datago__air · silver" });
   });
 
   it("demo SQL never uses the source_key as a FROM table name — only the logical relation \"dataset\"", () => {
     const evidence = baseEvidence({
       context: { page: "dataset-detail", datasetId: "air-quality", stage: "gold" },
-      stage: { stage: "gold", source: "datago__air", status: "completed", available: true, rowCount: 1000 },
+      stage: { refId: "run-1::datago__air::gold", stage: "gold", source: "datago__air", status: "completed", available: true, rowCount: 1000 },
     });
     const response = buildKubiDemoResponse(evidence);
     expect(response.generatedSql?.sql).toMatch(/FROM dataset\b/);

--- a/src/features/kubi/demo.ts
+++ b/src/features/kubi/demo.ts
@@ -79,7 +79,7 @@ export function buildKubiDemoResponse(evidence: KubiEvidence): KubiStructuredRes
     };
     evidenceRefs.push({
       kind: "stage",
-      id: `${evidence.stage.source}:${evidence.stage.stage}`,
+      id: evidence.stage.refId,
       label: `${evidence.stage.source} · ${evidence.stage.stage}`,
     });
     lines.push("Generated SQL은 데모용 미리보기 조회입니다 — 실행하면 mock 결과가 표시됩니다(실제 Builder 호출 없음).");

--- a/src/features/kubi/evidence.test.ts
+++ b/src/features/kubi/evidence.test.ts
@@ -57,9 +57,12 @@ describe("loadKubiEvidence (#256)", () => {
       stage: "silver",
       source: "datago__air",
     };
-    const { evidence } = await loadKubiEvidence(context);
+    const { evidence, knownRefs, safeEvidenceIds } = await loadKubiEvidence(context);
     expect(evidence.stage?.stage).toBe("silver");
     expect(evidence.stage?.source).toBe("datago__air");
+    expect(evidence.stage?.refId).toBe("air-2026-08-14::datago__air::silver");
+    expect(knownRefs.stageIds.has(evidence.stage!.refId)).toBe(true);
+    expect(safeEvidenceIds.has(evidence.stage!.refId)).toBe(true);
     // 원본 sample row는 evidence 타입 자체에 존재하지 않는다 — 최소 데이터 원칙(#256 리뷰 §3).
     expect(evidence.stage).not.toHaveProperty("sample");
   });

--- a/src/features/kubi/evidence.ts
+++ b/src/features/kubi/evidence.ts
@@ -19,7 +19,7 @@ import { loadBuildSpec } from "@/features/build-spec/specStore";
 import { redactSecrets } from "@/features/assistant/scrub";
 import { builderApi } from "@/shared/lib/builderApi";
 import type { KubiContext, KubiEvidence, KubiEvidenceSource, KubiKnownRefs } from "./types";
-import { qualityResultRefId } from "./types";
+import { qualityResultRefId, stageEvidenceRefId } from "./types";
 
 async function settle<T>(promise: Promise<T>): Promise<{ ok: true; value: T } | { ok: false }> {
   try {
@@ -60,6 +60,7 @@ export async function loadKubiEvidence(
     providers: new Set(),
     qualityResultIds: new Set(),
     schemaDriftIds: new Set(),
+    stageIds: new Set(),
     sourceKeys: new Set(),
   };
 
@@ -235,8 +236,11 @@ export async function loadKubiEvidence(
           );
           if (detailResult.ok) {
             const detail = detailResult.value;
+            const refId = stageEvidenceRefId(runId, chosenSource.source_key, detail.stage);
             const rowCount = detail.stage === "bronze" ? detail.record_count : detail.row_count;
             knownRefs.sourceKeys.add(chosenSource.source_key);
+            knownRefs.stageIds.add(refId);
+            safeEvidenceIds.add(refId);
             // Generated SQL이 컬럼명/타입을 추측하지 않도록, Builder가 이미 반환한 stage
             // schema만 canonical하게 노출한다. silver는 {name,dtype}까지, gold는 이름만
             // (contract상 dtype이 없다), bronze는 없다. sample row는 여전히 읽지 않는다.
@@ -249,6 +253,7 @@ export async function loadKubiEvidence(
               columns = [...detail.columns];
             }
             evidence.stage = {
+              refId,
               stage: context.stage,
               source: chosenSource.source_key,
               status: detail.status,

--- a/src/features/kubi/formatSqlForDisplay.test.ts
+++ b/src/features/kubi/formatSqlForDisplay.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { formatSqlForDisplay } from "./formatSqlForDisplay";
+
+describe("formatSqlForDisplay", () => {
+  it("breaks major top-level clauses while keeping a short projection together", () => {
+    const raw = "SELECT a, b FROM dataset WHERE a > 0 ORDER BY b DESC";
+    expect(formatSqlForDisplay(raw)).toBe("SELECT a, b\nFROM dataset\nWHERE a > 0\nORDER BY b DESC");
+    expect(raw).toBe("SELECT a, b FROM dataset WHERE a > 0 ORDER BY b DESC");
+  });
+
+  it("does not treat clause words inside quoted strings as syntax", () => {
+    expect(formatSqlForDisplay("SELECT 'FROM WHERE' AS note FROM dataset")).toBe(
+      "SELECT 'FROM WHERE' AS note\nFROM dataset",
+    );
+  });
+
+  it("only breaks top-level clauses around a nested subquery", () => {
+    const raw = "SELECT x FROM (SELECT x FROM source WHERE x > 0) nested WHERE x < 10";
+    expect(formatSqlForDisplay(raw)).toBe(
+      "SELECT x\nFROM (SELECT x FROM source WHERE x > 0) nested\nWHERE x < 10",
+    );
+  });
+
+  it("falls back to raw SQL when the input is incomplete", () => {
+    const raw = "SELECT x FROM (SELECT 'WHERE' FROM dataset";
+    expect(formatSqlForDisplay(raw)).toBe(raw);
+  });
+});

--- a/src/features/kubi/formatSqlForDisplay.ts
+++ b/src/features/kubi/formatSqlForDisplay.ts
@@ -1,0 +1,109 @@
+/**
+ * SQL 실행 원본과 분리된, Drawer 표시 전용 최소 formatter.
+ * 문자열/주석/괄호 깊이를 추적해 top-level clause 앞에서만 줄을 나눈다.
+ */
+const SINGLE_CLAUSES = new Set(["FROM", "WHERE", "HAVING", "LIMIT", "OFFSET", "UNION"]);
+const JOIN_MODIFIERS = new Set(["LEFT", "RIGHT", "FULL", "INNER", "CROSS", "NATURAL"]);
+
+interface WordToken {
+  value: string;
+  start: number;
+  depth: number;
+}
+
+function topLevelWords(sql: string): WordToken[] {
+  const words: WordToken[] = [];
+  let depth = 0;
+  let quote: "'" | '"' | "`" | null = null;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let index = 0; index < sql.length; index += 1) {
+    const char = sql[index];
+    const next = sql[index + 1];
+    if (lineComment) {
+      if (char === "\n") lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        if (next === quote) index += 1;
+        else quote = null;
+      } else if (char === "\\" && next) index += 1;
+      continue;
+    }
+    if (char === "-" && next === "-") {
+      lineComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      blockComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "(") {
+      depth += 1;
+      continue;
+    }
+    if (char === ")") {
+      depth -= 1;
+      if (depth < 0) throw new Error("Unbalanced SQL parentheses");
+      continue;
+    }
+    if (/[A-Za-z_]/.test(char)) {
+      const start = index;
+      while (index + 1 < sql.length && /[A-Za-z0-9_$]/.test(sql[index + 1])) index += 1;
+      words.push({ value: sql.slice(start, index + 1).toUpperCase(), start, depth });
+    }
+  }
+  if (quote || blockComment || depth !== 0) throw new Error("Incomplete SQL");
+  return words;
+}
+
+function formatSql(rawSql: string): string {
+  const words = topLevelWords(rawSql);
+  const breaks = new Set<number>();
+  for (let index = 0; index < words.length; index += 1) {
+    const word = words[index];
+    if (word.depth !== 0 || word.start === 0) continue;
+    const next = words[index + 1];
+    if (SINGLE_CLAUSES.has(word.value)) breaks.add(word.start);
+    else if ((word.value === "GROUP" || word.value === "ORDER") && next?.depth === 0 && next.value === "BY") {
+      breaks.add(word.start);
+    } else if (word.value === "JOIN") {
+      const previous = words[index - 1];
+      breaks.add(previous?.depth === 0 && JOIN_MODIFIERS.has(previous.value) ? previous.start : word.start);
+    }
+  }
+  if (!breaks.size) return rawSql;
+
+  let formatted = rawSql;
+  for (const position of [...breaks].sort((a, b) => b - a)) {
+    let whitespaceStart = position;
+    while (whitespaceStart > 0 && /[ \t]/.test(formatted[whitespaceStart - 1])) whitespaceStart -= 1;
+    if (formatted[whitespaceStart - 1] === "\n" || formatted[whitespaceStart - 1] === "\r") continue;
+    formatted = `${formatted.slice(0, whitespaceStart)}\n${formatted.slice(position)}`;
+  }
+  return formatted;
+}
+
+/** Formatter 실패 시 raw SQL을 그대로 보여 주며 원본 문자열은 수정하지 않는다. */
+export function formatSqlForDisplay(rawSql: string): string {
+  try {
+    return formatSql(rawSql);
+  } catch {
+    return rawSql;
+  }
+}

--- a/src/features/kubi/prompt.test.ts
+++ b/src/features/kubi/prompt.test.ts
@@ -51,6 +51,7 @@ describe("buildKubiMessages (#256 프롬프트)", () => {
     const evidence = baseEvidence({
       context: { page: "quality", datasetId: "air-quality", runId: "r1", stage: "gold", source: "datago__air_quality" },
       stage: {
+        refId: "r1::datago__air_quality::gold",
         stage: "gold",
         source: "datago__air_quality",
         status: "completed",
@@ -68,7 +69,7 @@ describe("buildKubiMessages (#256 프롬프트)", () => {
 
   it("keeps evidence and user question isolated as separate untrusted-data messages", () => {
     const evidence = baseEvidence({
-      stage: { stage: "silver", source: "datago__air", status: "completed", available: true, rowCount: 10 },
+      stage: { refId: "r1::datago__air::silver", stage: "silver", source: "datago__air", status: "completed", available: true, rowCount: 10 },
     });
     const messages = buildKubiMessages("서울 데이터 보여줘", evidence);
     expect(messages).toHaveLength(3);

--- a/src/features/kubi/prompt.ts
+++ b/src/features/kubi/prompt.ts
@@ -31,6 +31,7 @@ const RESPONSE_CONTRACT = `다음 JSON 형태로만 응답하세요. 다른 텍�
 
 규칙:
 - evidenceRefs, generatedSql, suggestedActions에 등장하는 모든 id(dataset/run/provider/quality 결과 등)는 반드시 아래 evidence 블록에 실제로 존재하는 값이어야 합니다. evidence에 없는 값을 만들어내지 마세요.
+- stage 근거를 인용할 때는 evidence.stage.refId의 문자열을 변형하지 말고 evidenceRefs의 id로 그대로 사용하세요.
 - evidence가 부분적으로만 제공된 경우(partial=true, unavailable 목록 참고) 확인하지 못한 부분은 모른다고 답하세요. 전체를 확인한 것처럼 말하지 마세요.
 - generatedSql은 evidence.context.stage가 "silver" 또는 "gold"일 때만, 그리고 실제로 조회가 필요한 질문일 때만 제안하세요. 그 외에는 null로 두세요. generatedSql은 절대 자동 실행되지 않으며 사용자가 직접 실행 버튼을 눌러야 Builder /query로 전달됩니다.
 - generatedSql.sql의 FROM 절은 반드시 logical relation "dataset" 하나만 조회해야 합니다(Builder #504 contract). evidence에 있는 실제 source_key(Builder canonical 형식은 "provider.dataset", 예: "datago.air_quality")를 FROM의 테이블명으로 쓰지 마세요 — source_key는 오직 generatedSql.source 필드로만 전달하고, Builder가 이를 이용해 실제 소스를 해석합니다. generatedSql.source에는 evidence에 그대로 등장한 source_key 문자열만 쓰고, 형식을 임의로 바꾸지 마세요. 확실하지 않으면 source를 생략하세요(단일 소스 run이면 Builder가 자동으로 선택합니다). multi-source 질문이라도 SQL 본문에는 개별 소스 테이블명을 등장시키지 말고, source 필드로만 어떤 소스를 조회할지 표현하세요.

--- a/src/features/kubi/types.ts
+++ b/src/features/kubi/types.ts
@@ -43,6 +43,11 @@ export function qualityResultRefId(result: {
   return `${result.source_key}::${result.category}::${result.rule}::${result.column ?? "_"}`;
 }
 
+/** Builder가 확인한 stage detail을 가리키는 canonical evidence ID. */
+export function stageEvidenceRefId(runId: string, source: string, stage: KubiStage): string {
+  return `${runId}::${source}::${stage}`;
+}
+
 /** evidence 조회 중 실패한 개별 evidence 종류. */
 export type KubiEvidenceSource = "dataset" | "runs" | "stage" | "quality" | "catalog" | "spec";
 
@@ -77,6 +82,8 @@ export interface KubiEvidence {
   };
   recentRuns?: { runId: string; status: string; startedAt: string | null; finishedAt: string | null }[];
   stage?: {
+    /** run/source/stage exact identity로 만든 canonical evidence ref. */
+    refId: string;
     stage: KubiStage;
     /** Builder canonical source_key. 필드명이 `sourceKey`면 redactSecrets가 `[REDACTED]`한다(`*key$`). */
     source: string;
@@ -133,6 +140,8 @@ export interface KubiKnownRefs {
   providers: Set<string>;
   qualityResultIds: Set<string>;
   schemaDriftIds: Set<string>;
+  /** 이번 evidence load에서 Builder stage detail로 실제 존재가 확인된 canonical ref만 포함. */
+  stageIds: Set<string>;
   /**
    * evidence에 실제로 등장한 Builder canonical source_key("provider.dataset") 집합.
    * quality 결과·stage evidence에서 모은다. Generated SQL의 `source`가 이 집합에 없으면
@@ -205,6 +214,9 @@ export type KubiActionRunState =
   | { status: "rejected"; reason: string }
   | { status: "error"; message: string };
 
+/** 실제 요청 파이프라인에서 현재 수행 중인 단계. 가짜 timer 없이 await 경계에서만 전환한다. */
+export type KubiTurnPhase = "collecting_evidence" | "generating" | "validating";
+
 /** 하나의 질문에서 시작된 전체 turn. context는 요청 시작 시점 값을 그대로 고정한다(stale guard). */
 export interface KubiTurn {
   id: string;
@@ -213,6 +225,7 @@ export interface KubiTurn {
   context: KubiContext;
   createdAt: string;
   status: "loading" | "ok" | "error";
+  phase?: KubiTurnPhase;
   evidence?: KubiEvidence;
   response?: KubiStructuredResponse;
   error?: KubiErrorState;

--- a/src/features/kubi/useKubiSession.ts
+++ b/src/features/kubi/useKubiSession.ts
@@ -140,6 +140,7 @@ export function useKubiSession(): UseKubiSessionResult {
         context,
         createdAt: new Date().toISOString(),
         status: "loading",
+        phase: "collecting_evidence",
         query: { status: "idle" },
         actionStates: {},
       };
@@ -168,6 +169,8 @@ export function useKubiSession(): UseKubiSessionResult {
         );
         updateTurn(turnId, (t) => ({ ...t, evidence }));
 
+        updateTurn(turnId, (t) => ({ ...t, phase: "generating" }));
+
         const provider = createProvider({ apiKey, model, baseUrl });
         const messages = buildKubiMessages(trimmed, evidence);
         let rawOutput = "";
@@ -182,6 +185,7 @@ export function useKubiSession(): UseKubiSessionResult {
           rawOutput += chunk;
         }
 
+        updateTurn(turnId, (t) => ({ ...t, phase: "validating" }));
         const parsed = parseKubiResponse(rawOutput);
         if (!parsed.ok) {
           updateTurn(turnId, (t) => ({
@@ -212,6 +216,7 @@ export function useKubiSession(): UseKubiSessionResult {
         updateTurn(turnId, (t) => ({
           ...t,
           status: "ok",
+          phase: undefined,
           rawOutput,
           response: checked.response,
           actionStates,
@@ -262,6 +267,7 @@ export function useKubiSession(): UseKubiSessionResult {
         context,
         createdAt: new Date().toISOString(),
         status: "loading",
+        phase: "collecting_evidence",
         query: { status: "idle" },
         actionStates: {},
         isDemo: true,
@@ -272,8 +278,9 @@ export function useKubiSession(): UseKubiSessionResult {
       controllersRef.current.set(turnId, controller);
       try {
         const { evidence } = await loadKubiEvidence(context, controller.signal);
+        updateTurn(turnId, (t) => ({ ...t, evidence, phase: "validating" }));
         const response = buildKubiDemoResponse(evidence);
-        updateTurn(turnId, (t) => ({ ...t, status: "ok", evidence, response }));
+        updateTurn(turnId, (t) => ({ ...t, status: "ok", phase: undefined, evidence, response }));
       } catch (cause) {
         if (controller.signal.aborted) {
           updateTurn(turnId, (t) => ({ ...t, status: "error", error: { kind: "cancelled" } }));

--- a/src/features/kubi/useLiveRunSources.ts
+++ b/src/features/kubi/useLiveRunSources.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { listBuildStages } from "@/features/datasets/api";
+
+/** 현재 live Run에서 Builder가 확인한 source_key만 제공한다. */
+export function useLiveRunSources(runId?: string): string[] {
+  const [sources, setSources] = useState<string[]>([]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let current = true;
+    // 이전 Run의 source가 새 Run의 조회 동안 잠시 노출되지 않게 즉시 비운다.
+    setSources([]);
+    if (!runId) return () => controller.abort();
+
+    void listBuildStages(runId, controller.signal)
+      .then((response) => {
+        if (!current || controller.signal.aborted || response.run_id !== runId) return;
+        setSources([...new Set(response.sources.map((source) => source.source_key))]);
+      })
+      .catch(() => {
+        // 조회 실패는 source 부재/후보 추측으로 바꾸지 않는다. picker 후보를 비워 둔다.
+        if (current && !controller.signal.aborted) setSources([]);
+      });
+
+    return () => {
+      current = false;
+      controller.abort();
+    };
+  }, [runId]);
+
+  return sources;
+}

--- a/src/pages/BuildsPage.context.test.ts
+++ b/src/pages/BuildsPage.context.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { normalizeBuildContextSearch, type AsyncState } from "./BuildsPage";
+import type { BuildSpecSnapshotResponse, RunStagesResponse } from "@/shared/lib/builderApi";
+
+const loadingSpec: AsyncState<BuildSpecSnapshotResponse> = { status: "loading" };
+const loadingStages: AsyncState<RunStagesResponse> = { status: "loading" };
+const loadedSpec: AsyncState<BuildSpecSnapshotResponse> = {
+  status: "loaded",
+  data: { run_id: "run-1", spec: "dataset_id: dataset-1\n", spec_digest: "sha256:test" },
+};
+
+function source(source_key: string, gold: "completed" | "failed" | "not_run" = "completed") {
+  return {
+    source_key,
+    bronze: { status: "completed" as const, available: true },
+    silver: { status: "completed" as const, available: true },
+    gold: { status: gold, available: gold === "completed" },
+  };
+}
+
+function loadedStages(sources: RunStagesResponse["sources"]): AsyncState<RunStagesResponse> {
+  return { status: "loaded", data: { run_id: "run-1", sources } };
+}
+
+function normalize(query: string, spec = loadingSpec, stages = loadingStages): URLSearchParams {
+  return normalizeBuildContextSearch(new URLSearchParams(query), spec, stages);
+}
+
+describe("Builds Kubi context URL normalization", () => {
+  it("preserves valid-looking source/stage while stages are loading", () => {
+    expect(normalize("source=B&stage=gold").toString()).toBe("source=B&stage=gold");
+  });
+
+  it("preserves dataset while the spec is loading", () => {
+    expect(normalize("dataset=dataset-1").get("dataset")).toBe("dataset-1");
+  });
+
+  it("retains loaded valid dataset/source/stage", () => {
+    const result = normalize("dataset=dataset-1&source=A&stage=gold", loadedSpec, loadedStages([source("A"), source("B")]));
+    expect(result.toString()).toBe("dataset=dataset-1&source=A&stage=gold");
+  });
+
+  it("removes an invalid source after stages load", () => {
+    const result = normalize("source=ghost&stage=gold", loadedSpec, loadedStages([source("A"), source("B")]));
+    expect(result.has("source")).toBe(false);
+    expect(result.has("stage")).toBe(false);
+  });
+
+  it("rejects a stage that is not_run for the selected source even when another source completed it", () => {
+    const result = normalize("source=B&stage=gold", loadedSpec, loadedStages([source("A"), source("B", "not_run")]));
+    expect(result.get("source")).toBe("B");
+    expect(result.has("stage")).toBe(false);
+  });
+
+  it("keeps single-source auto source behavior", () => {
+    const result = normalize("stage=gold", loadedSpec, loadedStages([source("only.source")]));
+    expect(result.get("source")).toBe("only.source");
+    expect(result.get("stage")).toBe("gold");
+  });
+
+  it("keeps the unique failedStage fallback", () => {
+    const result = normalize("", loadedSpec, loadedStages([source("A"), source("B", "failed")]));
+    expect(result.get("stage")).toBe("gold");
+  });
+});

--- a/src/pages/BuildsPage.tsx
+++ b/src/pages/BuildsPage.tsx
@@ -70,7 +70,7 @@ import {
 /** `/builds` 요청 scope. Builder에 전체 count가 없으므로 KPI는 반드시 이 값 안에서만 계산한다. */
 const LIST_LIMIT = 100;
 
-type AsyncState<T> =
+export type AsyncState<T> =
   | { status: "idle" }
   | { status: "loading" }
   | { status: "loaded"; data: T }
@@ -113,6 +113,50 @@ function useAsync<T>(
   }, deps);
 
   return state;
+}
+
+/** Builder 응답이 loaded인 surface만 사용해 Builds의 Kubi context query를 정규화한다. */
+export function normalizeBuildContextSearch(
+  searchParams: URLSearchParams,
+  specState: AsyncState<BuildSpecSnapshotResponse>,
+  stagesState: AsyncState<RunStagesResponse>,
+): URLSearchParams {
+  const next = new URLSearchParams(searchParams);
+
+  if (specState.status === "loaded") {
+    const datasetId = extractDatasetId(specState.data.spec);
+    if (datasetId) next.set("dataset", datasetId);
+    else next.delete("dataset");
+  }
+
+  if (stagesState.status === "loaded") {
+    const sources = stagesState.data.sources;
+    const failureEvidence = collectFailureEvidence(sources);
+    const requestedStage = next.get("stage");
+    const selectedSource = next.get("source");
+    const selectedSourceEntry = selectedSource
+      ? sources.find((source) => source.source_key === selectedSource)
+      : sources.length === 1
+        ? sources[0]
+        : undefined;
+    const requestedStageAvailable =
+      (requestedStage === "bronze" || requestedStage === "silver" || requestedStage === "gold") &&
+      Boolean(selectedSourceEntry && selectedSourceEntry[requestedStage].status !== "not_run");
+    const stage = requestedStageAvailable
+      ? requestedStage
+      : failureEvidence.length === 1
+        ? failureEvidence[0].failedStage
+        : null;
+
+    if (stage) next.set("stage", stage);
+    else next.delete("stage");
+
+    const sourceKeys = sources.map((source) => source.source_key);
+    if (stage && sourceKeys.length === 1) next.set("source", sourceKeys[0]);
+    else if (selectedSource && !sourceKeys.includes(selectedSource)) next.delete("source");
+  }
+
+  return next;
 }
 
 export function BuildsPage() {
@@ -223,53 +267,8 @@ export function BuildsPage() {
   // 정확히 하나의 source만 실패했을 때만 그 failedStage를 안전한 문맥으로 취급한다(#255 §2).
   useEffect(() => {
     if (!selectedRunId) return;
-    const datasetId = specState.status === "loaded" ? extractDatasetId(specState.data.spec) : null;
-    const failureEvidence =
-      stagesState.status === "loaded" ? collectFailureEvidence(stagesState.data.sources) : [];
-    const sources = stagesState.status === "loaded" ? stagesState.data.sources : [];
-    const requestedStage = searchParams.get("stage");
-    const selectedSource = searchParams.get("source");
-    const requestedStageAvailable =
-      requestedStage === "bronze" || requestedStage === "silver" || requestedStage === "gold"
-        ? sources.some((source) => source[requestedStage].status !== "not_run")
-        : false;
-    const stage = requestedStageAvailable
-      ? requestedStage
-      : failureEvidence.length === 1
-        ? failureEvidence[0].failedStage
-        : null;
-
-    const next = new URLSearchParams(searchParams);
-    let changed = false;
-    if (datasetId) {
-      if (next.get("dataset") !== datasetId) {
-        next.set("dataset", datasetId);
-        changed = true;
-      }
-    } else if (next.has("dataset")) {
-      next.delete("dataset");
-      changed = true;
-    }
-    if (stage) {
-      if (next.get("stage") !== stage) {
-        next.set("stage", stage);
-        changed = true;
-      }
-    } else if (next.has("stage")) {
-      next.delete("stage");
-      changed = true;
-    }
-    const sourceKeys = sources.map((source) => source.source_key);
-    if (stage && sourceKeys.length === 1) {
-      if (next.get("source") !== sourceKeys[0]) {
-        next.set("source", sourceKeys[0]);
-        changed = true;
-      }
-    } else if (selectedSource && !sourceKeys.includes(selectedSource)) {
-      next.delete("source");
-      changed = true;
-    }
-    if (changed) setSearchParams(next, { replace: true });
+    const next = normalizeBuildContextSearch(searchParams, specState, stagesState);
+    if (next.toString() !== searchParams.toString()) setSearchParams(next, { replace: true });
   }, [selectedRunId, specState, stagesState, searchParams, setSearchParams]);
 
   // Run 자체가 존재하지 않는다고 판정하는 기준: 목록 scope 밖이고, stage 조회도 404다.

--- a/src/pages/BuildsPage.tsx
+++ b/src/pages/BuildsPage.tsx
@@ -161,6 +161,7 @@ export function BuildsPage() {
     // 지우면 함께 지워 다음 화면에 이전 run의 문맥이 남지 않게 한다.
     next.delete("dataset");
     next.delete("stage");
+    next.delete("source");
     setSearchParams(next);
   }, [searchParams, setSearchParams]);
 
@@ -225,7 +226,18 @@ export function BuildsPage() {
     const datasetId = specState.status === "loaded" ? extractDatasetId(specState.data.spec) : null;
     const failureEvidence =
       stagesState.status === "loaded" ? collectFailureEvidence(stagesState.data.sources) : [];
-    const stage = failureEvidence.length === 1 ? failureEvidence[0].failedStage : null;
+    const sources = stagesState.status === "loaded" ? stagesState.data.sources : [];
+    const requestedStage = searchParams.get("stage");
+    const selectedSource = searchParams.get("source");
+    const requestedStageAvailable =
+      requestedStage === "bronze" || requestedStage === "silver" || requestedStage === "gold"
+        ? sources.some((source) => source[requestedStage].status !== "not_run")
+        : false;
+    const stage = requestedStageAvailable
+      ? requestedStage
+      : failureEvidence.length === 1
+        ? failureEvidence[0].failedStage
+        : null;
 
     const next = new URLSearchParams(searchParams);
     let changed = false;
@@ -245,6 +257,16 @@ export function BuildsPage() {
       }
     } else if (next.has("stage")) {
       next.delete("stage");
+      changed = true;
+    }
+    const sourceKeys = sources.map((source) => source.source_key);
+    if (stage && sourceKeys.length === 1) {
+      if (next.get("source") !== sourceKeys[0]) {
+        next.set("source", sourceKeys[0]);
+        changed = true;
+      }
+    } else if (selectedSource && !sourceKeys.includes(selectedSource)) {
+      next.delete("source");
       changed = true;
     }
     if (changed) setSearchParams(next, { replace: true });


### PR DESCRIPTION
## Summary

PR #319의 Real E2E Kubi 안정화 위에서, 실제 사용 중 확인된 Kubi UX 문제를 개선합니다.

이번 PR은 grounding / SQL correctness를 다시 설계하지 않고,
기존 `KubiContent` / `useKubiSession` / URL 기반 `KubiContext` 구조를 유지하면서
다음 사용성 문제를 해결합니다.

- 좁은 AI Drawer와 긴 답변 가독성
- 한 줄 입력창과 긴 conversation scroll
- Markdown 미렌더링
- Evidence가 실제로 탐색되지 않던 문제
- Builds / Runs에서 Stage context를 선택하기 어려운 문제
- 과거 답변이 계속 누적되는 문제
- Generated SQL 가독성
- 응답 대기 중 진행 상태 부재

Depends on #319.
<img width="1648" height="1100" alt="image" src="https://github.com/user-attachments/assets/61a7faa6-3075-47fa-97cb-aa7a33cc24bf" />
<img width="1660" height="1339" alt="image" src="https://github.com/user-attachments/assets/1e65d985-7f0d-41f9-aed7-a8eccbf67381" />

---

## Changes

### Context-aware UX

- Run이 있지만 Stage가 선택되지 않은 상태를 `—` 대신 `Run 전체`로 표시
- Kubi context bar에서 Stage 선택 가능
- 성공 Run을 무조건 Gold로 선택하지 않음
- Silver / Gold 선택 시 schema-aware SQL capability 활성화
- single-source Run은 Builder-confirmed source만 자동 확정
- multi-source Run은 임의 첫 source를 선택하지 않고 fail-closed
- Run 변경 시 이전 source / stage context 제거
- 현재 context에서 가능한 AI 기능을 짧은 capability hint로 안내

### Drawer / Composer

- desktop Kubi Drawer 폭 확대
- 기본 / 확장 모드 추가
- mobile full-width 유지
- Drawer 전체가 아닌 conversation 영역만 scroll
- composer는 항상 하단에 유지
- single-line input을 multiline Textarea로 변경
- auto-grow 적용
- Enter 전송 / Shift+Enter 줄바꿈
- 한글 IME composition 중 잘못된 전송 방지
- 기존 focus trap / Escape / focus restore 유지

### Conversation history

- 가장 최근 turn만 기본 expanded
- 이전 turn은 `이전 대화 N개` 아래에 collapse
- 과거 turn 개별 재열기 지원
- query / action / evidence / stale 상태는 그대로 보존
- 새 질문 시 최신 turn 중심으로 이동

### Markdown rendering

Kubi answer를 plain text `<p>`가 아니라 안전한 Markdown renderer로 표시합니다.

지원:

- bold / italic
- paragraph
- bullet / numbered list
- inline / fenced code
- blockquote
- table
- safe links

보안:

- `dangerouslySetInnerHTML` 미사용
- raw HTML 미실행
- unsafe link scheme 차단
- external link에 `noopener noreferrer`

실제:

```text
Run X의 상태는 **성공(ok)**입니다.
````

가 `<strong>성공(ok)</strong>`으로 렌더링됩니다.

### Evidence interaction

* Evidence pill을 실제 keyboard-accessible button으로 변경
* frozen turn evidence에서 상세 정보 표시
* Quality / Run / Stage / Dataset 등 verified evidence 상세 제공
* 안전한 경우에만 `원본 화면 열기` 제공
* rejected / unavailable evidence는 progressive disclosure로 접음
* fake deep link 생성 금지

Stage evidence identity도 통일했습니다.

```text
runId::source::stage
```

형태의 canonical ID를 Builder stage evidence가 실제 확인된 경우에만 생성하고:

* `evidence.stage.refId`
* `knownRefs.stageIds`
* `safeEvidenceIds`

에 exact value로 등록합니다.

prefix / regex shape만으로는 trust하지 않습니다.

### Suggested Actions

* navigation action은 compact하게 표시
* state-changing action의 승인 / diff / preview semantics는 그대로 유지
* 자동 실행은 추가하지 않음

### Loading UX

실제 async 경계와 일치하는 phase를 표시합니다.

1. Evidence 확인 중
2. 답변 생성 중
3. 응답 검증 중

가짜 timer나 검증 전 raw LLM streaming은 사용하지 않습니다.

### Generated SQL readability

Generated SQL은 실행용 raw SQL을 변경하지 않고 **표시만** clause 단위로 정리합니다.

예:

```sql
SELECT stationName, pm10Grade, AVG(TRY_CAST(pm10Value AS DOUBLE)) AS avg_pm10_value
FROM dataset
GROUP BY stationName, pm10Grade
ORDER BY avg_pm10_value DESC
```

표시용 formatter는:

* quote
* SQL comment
* parenthesis depth

를 추적해 top-level clause만 줄바꿈합니다.

* 문자열 내부 keyword 변경 금지
* nested subquery 내부 clause 변경 금지
* formatter 실패 시 raw SQL fallback
* Copy와 Builder `/query`는 원본 `generatedSql.sql` 사용
* horizontal overflow는 code/table 내부에서만 발생

---

## Verification

### Automated

* Targeted: **67 tests PASS**
* Full Vitest: **1,063 tests PASS**
* Typecheck: **PASS**
* Lint: **0 errors** (기존 warning 9개)
* Production build: **PASS**
* `git diff --check`: **PASS**

기존 다음 동작도 회귀 없이 유지됩니다.

* Quality state-aware seed
* malformed evidence ref tolerant parsing
* canonical source validation
* Builder-confirmed Run / Evidence trust
* `safeRunIds` / `safeEvidenceIds`
* schema-grounded SQL
* `TRY_CAST` guidance
* stale context guard
* BYOK security
* explicit query execution
* action approval

---

## Manual Real E2E

실제 Builder + BYOK + AirKorea Run에서 수동 검증했습니다.

Run:

```text
datago-air-quality-1788017784829
```

### Builds / Runs → Gold

* Kubi Stage `Gold` 선택 정상
* source `datago.air_quality`
* Gold 23개 column 인식
* context capability hint 정상

### Markdown

* answer의 bold Markdown이 실제 굵은 글씨로 렌더링됨

### Evidence

`Gold 컬럼 알려줘`:

* Stage evidence가 더 이상 rejected되지 않음
* `근거 1개` verified
* Evidence chip 클릭 정상
* 실제 frozen detail 확인:

  * Stage: Gold
  * Source: datago.air_quality
  * Status: completed
  * Rows: 40
  * Columns: 23
* `원본 화면 열기` 노출 확인

### Generated SQL

`PM10 SQL 만들어줘`:

* actual `pm10Value` 사용
* `TRY_CAST(pm10Value AS DOUBLE)` 사용
* `SELECT / FROM / GROUP BY / ORDER BY` clause formatting 정상
* SQL 영역 내부 horizontal scroll 정상

### Query

* 사용자 `실행` 후 Builder `/query` 성공
* Result Preview 정상 표시
* display-only formatting이 실제 query 실행 SQL을 변경하지 않음

### Conversation UX

* 이전 대화 collapse 정상
* composer 하단 고정 정상
* Drawer 기본 / 확장 레이아웃 정상

---

## Scope / Safety

변경하지 않은 것:

* Builder
* LLM provider/BYOK security model
* SQL generation semantics
* Generated SQL 자동 실행 정책
* action approval policy
* 별도 conversation store
* 별도 page별 Kubi state
* multi-source fail-closed 정책

## Dependency

This PR is stacked on:

* #319 — Kubi Real E2E grounding / response stabilization

#319가 main에 merge된 뒤 이 PR의 base를 `main`으로 변경할 예정입니다.