### PR TITLE
fix: close remaining Studio integration truthfulness gaps

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -8,7 +8,7 @@ Studio는 Builder HTTP API의 소비자입니다. HTTP wire 계약의 단일 소
 
 - Builder endpoint/status/schema 변경은 Builder OpenAPI SSOT에서 시작합니다.
 - Studio는 `src/shared/lib/builderApi.ts`와 `src/shared/lib/builderApi.schema.ts`에서 OpenAPI wire shape를 런타임 검증합니다.
-- `API_CONTRACT_VERSION`과 지원 operation 집합은 `__tests__/contractConformance.test.ts`가 고정합니다.
+- `MIN_BUILDER_API_VERSION`(SemVer 호환성 판정의 기준)과 지원 operation 집합은 `__tests__/contractConformance.test.ts`가 고정합니다.
 - 사용자 화면은 page에서 직접 HTTP를 호출하지 않고 feature API를 통해 Builder를 사용합니다.
 
 ## 2. Studio 클라이언트 계층
@@ -23,7 +23,7 @@ graph LR
 
 | 계층 | 파일 | 책임 |
 | :--- | :--- | :--- |
-| 저수준 HTTP 클라이언트 | `src/shared/lib/builderApi.ts` | Builder URL, 인증 헤더, timeout/retry, `ApiError`, 계약 버전 |
+| 저수준 HTTP 클라이언트 | `src/shared/lib/builderApi.ts` | Builder URL, 인증 헤더, timeout/retry, `ApiError`, 최소 버전/SemVer 호환성 |
 | wire schema | `src/shared/lib/builderApi.schema.ts` | Builder JSON 응답 Zod parse |
 | BuildSpec 매핑 | `src/features/build-spec/specMapping.ts` | Studio camelCase model ↔ Builder snake_case spec |
 | Preview API | `src/features/preview/api/index.ts` | `/preview` 응답을 UI용 rows/schema/warnings로 변환 |
@@ -33,14 +33,32 @@ graph LR
 
 ## 3. 계약 버전과 정합성
 
-Studio는 `GET /version` 응답의 `api_version`을 `API_CONTRACT_VERSION`과 비교해 설정 화면에 호환성 경고를 표시합니다.
+Studio는 `GET /version` 응답의 `api_version`을 `MIN_BUILDER_API_VERSION`과 **SemVer 호환성**
+규칙(Builder ADR 0013)으로 비교해 설정 화면에 경고를 표시합니다. exact-equality 비교가
+아닙니다.
+
+호환성 규칙 (`isBuilderApiCompatible`):
+
+1. `server major == required major` (major가 다르면 breaking — 비호환).
+2. `server >= required` (같은 major 안에서 minor/patch가 최소값 이상).
+3. 더 높은 additive minor/patch는 호환으로 간주합니다 (예: 최소값 1.18.0에 대해 Builder
+   1.21.0은 호환).
+4. 파싱 불가/형식 오류인 버전 문자열은 fail-closed로 비호환 처리합니다.
+
+`MIN_BUILDER_API_VERSION`은 Studio의 현재 통합 표면(async build job + cooperative
+cancel + manifest status/partial + provider credential + monitoring + publish)이 요구하는
+**최소** Builder API 버전입니다. cancellation과 manifest status/partial이 Builder
+1.18.0에서 도입됐고 Studio가 이 둘을 실제로 사용하므로 최소값은 `1.18.0`입니다.
+1.19~1.21에 추가된 미사용 endpoint는 이 최소값에 반영하지 않으며 Studio에 구현하지도
+않습니다.
 
 정합성 규칙:
 
-1. Builder OpenAPI `info.version`과 Builder service `API_CONTRACT_VERSION`이 먼저 일치해야 합니다.
-2. Studio `API_CONTRACT_VERSION`은 실제로 지원하는 Builder 계약 버전만 가리킵니다.
-3. Builder operation이 추가/삭제되면 Studio 클라이언트 구현과 `contractConformance.test.ts`를 함께 갱신합니다.
-4. 문서만 바꿔서 계약 drift를 덮지 않습니다.
+1. `MIN_BUILDER_API_VERSION`은 Studio가 실제로 호출·검토한 operation이 요구하는 최소
+   버전만 가리킵니다.
+2. Builder operation이 추가/삭제되면 Studio 클라이언트 구현과
+   `contractConformance.test.ts`를 함께 갱신합니다.
+3. 문서만 바꿔서 계약 drift를 덮지 않습니다.
 
 ## 4. BuildSpec 매핑 원칙
 

--- a/__tests__/BuildArtifactsPage.test.tsx
+++ b/__tests__/BuildArtifactsPage.test.tsx
@@ -137,3 +137,48 @@ describe("BuildArtifactsPage - Issue #119: undefined vs empty array", () => {
     expect(screen.getByText("100")).toBeInTheDocument();
   });
 });
+
+describe("BuildArtifactsPage - manifest truthfulness (F05A)", () => {
+  it("full authoritative manifest shows no stale '미연동' warning", async () => {
+    const full: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "run-full",
+      build_environment: null,
+      inputs_fingerprint: null,
+      outputs: ["artifacts/builds/run-full/data.jsonl"],
+      row_counts: { "datago.air-quality": 100 },
+      provenance: [
+        {
+          provider: "datago",
+          dataset: "air-quality",
+          fetched_at: "2026-06-21T00:00:00+00:00",
+          record_count: 100,
+          data_checksum: "sha256:abc",
+          api_version: "1.0",
+          params: {},
+        },
+      ],
+    };
+
+    renderWithManifest(full);
+    await waitFor(() => expect(screen.getByText("Manifest 요약")).toBeInTheDocument());
+    expect(screen.queryByText(/아직 연동되지 않아/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/manifest가 아직 연동/)).not.toBeInTheDocument();
+  });
+
+  it("legacy/partial manifest is described factually (missing metadata, not 'API not integrated')", async () => {
+    const partial: BuildManifest = {
+      schema_version: "1.0.0",
+      build_id: "run-partial",
+      build_environment: null,
+      inputs_fingerprint: null,
+      outputs: ["artifacts/builds/run-partial/data.jsonl"],
+      // row_counts / provenance 없음
+    };
+
+    renderWithManifest(partial);
+    await waitFor(() => expect(screen.getByText("Manifest 요약")).toBeInTheDocument());
+    expect(screen.getByText(/일부 메타데이터 필드/)).toBeInTheDocument();
+    expect(screen.queryByText(/아직 연동되지 않아/)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/asyncBuildJob.test.ts
+++ b/__tests__/asyncBuildJob.test.ts
@@ -60,7 +60,10 @@ function mixedSpec(datasetId: string): BuildSpec {
 beforeEach(() => {
   vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
 });
-afterEach(() => vi.unstubAllEnvs());
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
 
 describe("async build job polling (#245)", () => {
   it("submits, polls through queued/running, and maps terminal success", async () => {
@@ -179,6 +182,148 @@ describe("async build job polling (#245)", () => {
     expect(result.current.interrupted).toBe(true);
     buildSpy.mockRestore();
     cancelSpy.mockRestore();
+  });
+});
+
+describe("async pre-submit cancellation race (F03)", () => {
+  it("deferred submit: Cancel before submit resolves does not hit cancel endpoint, then hits it exactly once with the authoritative run_id", async () => {
+    // POST /builds 응답을 테스트가 직접 제어한다.
+    let resolveSubmit: (v: {
+      run_id: string;
+      status: BuilderJobStatus;
+      created_at: string;
+      updated_at: string;
+    }) => void = () => {};
+    const submitSpy = vi
+      .spyOn(builderApi, "submitBuild")
+      .mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSubmit = resolve;
+          }),
+      );
+
+    // 서버가 준 authoritative run_id는 client가 생성한 값과 다르다.
+    const AUTHORITATIVE = "authoritative-run-xyz";
+    const pollStates: BuilderJobStatus[] = ["cancelling", "cancelled"];
+    let pollIndex = 0;
+    const getJobSpy = vi.spyOn(builderApi, "getBuildJob").mockImplementation(async () => ({
+      run_id: AUTHORITATIVE,
+      status: pollStates[Math.min(pollIndex++, pollStates.length - 1)],
+      created_at: "2026-08-16T09:00:00+00:00",
+      updated_at: "2026-08-16T09:00:05+00:00",
+    }));
+    const cancelSpy = vi
+      .spyOn(builderApi, "cancelBuildJob")
+      .mockResolvedValue({
+        run_id: AUTHORITATIVE,
+        status: "cancelling",
+        created_at: "2026-08-16T09:00:00+00:00",
+        updated_at: "2026-08-16T09:00:05+00:00",
+      });
+
+    const { result } = renderHook(() => useBuildJob());
+
+    let promise: Promise<void> = Promise.resolve();
+    act(() => {
+      promise = result.current.start(specOf("pub"));
+    });
+    await waitFor(() => expect(result.current.status).toBe("running"));
+
+    // submit이 아직 보류 중일 때 Cancel을 여러 번 누른다.
+    act(() => {
+      result.current.cancel();
+      result.current.cancel();
+      result.current.cancel();
+    });
+
+    // 이 시점에는 cancel endpoint가 호출되지 않았고, local 상태도 취소/중단이 아니다.
+    expect(cancelSpy).not.toHaveBeenCalled();
+    expect(result.current.status).toBe("running");
+    expect(result.current.interrupted).toBe(false);
+    // 사용자 Cancel 때문에 submit 요청 자체를 abort하지 않는다.
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+
+    // submit 성공 → authoritative run_id 확보.
+    await act(async () => {
+      resolveSubmit({
+        run_id: AUTHORITATIVE,
+        status: "queued",
+        created_at: "2026-08-16T09:00:00+00:00",
+        updated_at: "2026-08-16T09:00:00+00:00",
+      });
+      await promise.catch(() => undefined);
+    });
+
+    // pending intent가 authoritative run_id로 정확히 1회 협조적 취소를 건다.
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+    expect(cancelSpy).toHaveBeenCalledWith(AUTHORITATIVE);
+    expect(getJobSpy).toHaveBeenCalled();
+
+    // cancelling → cancelled polling을 관찰해 최종 상태를 확정한다.
+    expect(result.current.builderStatus).toBe("cancelled");
+    expect(result.current.status).toBe("cancelled");
+    expect(result.current.run?.status).toBe("cancelled");
+
+    submitSpy.mockRestore();
+    getJobSpy.mockRestore();
+    cancelSpy.mockRestore();
+  });
+
+  it("repeated early Cancel coalesces to a single cancel endpoint call", async () => {
+    let resolveSubmit: (v: {
+      run_id: string;
+      status: BuilderJobStatus;
+      created_at: string;
+      updated_at: string;
+    }) => void = () => {};
+    vi.spyOn(builderApi, "submitBuild").mockImplementation(
+      () => new Promise((resolve) => { resolveSubmit = resolve; }),
+    );
+    let pollIndex = 0;
+    const pollStates: BuilderJobStatus[] = ["cancelling", "cancelled"];
+    vi.spyOn(builderApi, "getBuildJob").mockImplementation(async () => ({
+      run_id: "r1",
+      status: pollStates[Math.min(pollIndex++, pollStates.length - 1)],
+      created_at: "2026-08-16T09:00:00+00:00",
+      updated_at: "2026-08-16T09:00:05+00:00",
+    }));
+    const cancelSpy = vi.spyOn(builderApi, "cancelBuildJob").mockResolvedValue({
+      run_id: "r1",
+      status: "cancelling",
+      created_at: "2026-08-16T09:00:00+00:00",
+      updated_at: "2026-08-16T09:00:05+00:00",
+    });
+
+    const { result } = renderHook(() => useBuildJob());
+    let promise: Promise<void> = Promise.resolve();
+    act(() => {
+      promise = result.current.start(specOf("pub"));
+    });
+    await waitFor(() => expect(result.current.status).toBe("running"));
+
+    act(() => {
+      result.current.cancel();
+      result.current.cancel();
+    });
+
+    await act(async () => {
+      resolveSubmit({
+        run_id: "r1",
+        status: "queued",
+        created_at: "2026-08-16T09:00:00+00:00",
+        updated_at: "2026-08-16T09:00:00+00:00",
+      });
+      await promise.catch(() => undefined);
+    });
+
+    // handle이 온 뒤 한 번 더 눌러도 여전히 1회.
+    act(() => {
+      result.current.cancel();
+    });
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe("cancelled");
   });
 });
 

--- a/__tests__/buildRoutes.test.tsx
+++ b/__tests__/buildRoutes.test.tsx
@@ -47,7 +47,8 @@ describe("build-centric routes", () => {
     // run(dur-pregnancy-taboo-20260621, status: running)으로 canonical 상태를 확인한다.
     renderAt("/builds/dur-pregnancy-taboo-20260621/run", <BuildRunPage />);
     expect(await screen.findByText("실행 중")).toBeInTheDocument();
-    expect(screen.getByText("상세 진행 정보 미지원")).toBeInTheDocument();
+    expect(screen.getByText("상세 진행은 Build 상세에서 확인하세요")).toBeInTheDocument();
+    expect(screen.queryByText(/미지원/)).not.toBeInTheDocument();
   });
 
   it("renders the artifacts page with a manifest section", async () => {

--- a/__tests__/buildRunPage.test.tsx
+++ b/__tests__/buildRunPage.test.tsx
@@ -30,10 +30,26 @@ describe("BuildRunPage (audit #3)", () => {
     expect(screen.queryByText("대기 중")).not.toBeInTheDocument();
   });
 
-  it("does not fabricate stage-by-stage progress it cannot support", async () => {
+  it("does not fabricate stage-by-stage progress, and does not claim the API is unsupported", async () => {
     renderRun("dur-pregnancy-taboo-20260621");
 
     await screen.findByText("실행 중");
-    expect(screen.getByText("상세 진행 정보 미지원")).toBeInTheDocument();
+    // 사실과 다른 "미지원" 문구는 없다.
+    expect(screen.queryByText(/미지원/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/아직 제공하지 않습니다/)).not.toBeInTheDocument();
+    // 대신 canonical Build 상세로 안내한다.
+    expect(screen.getByText("상세 진행은 Build 상세에서 확인하세요")).toBeInTheDocument();
+  });
+
+  it("routes to the canonical Build detail and keeps deep links", async () => {
+    renderRun("dur-pregnancy-taboo-20260621");
+    await screen.findByText("실행 중");
+
+    const detailLinks = screen
+      .getAllByRole("link")
+      .filter((a) => a.getAttribute("href")?.startsWith("/builds?run="));
+    expect(detailLinks.length).toBeGreaterThan(0);
+    // legacy 화면에 항상-disabled 가짜 취소 버튼은 없다.
+    expect(screen.queryByRole("button", { name: "취소" })).not.toBeInTheDocument();
   });
 });

--- a/__tests__/builderApi.test.ts
+++ b/__tests__/builderApi.test.ts
@@ -193,6 +193,24 @@ describe("builderApi client (#29)", () => {
     expect(init.method).toBe("GET");
   });
 
+  it("getProviderCredential() parses the exact Builder GET wire body (no provider field)", async () => {
+    // Builder SSOT: GET /providers/{provider}/credential returns
+    // ProviderCredentialGetResponse = { configured, masked, updated_at } only.
+    // `provider` is never on the GET response; the schema must accept this body
+    // verbatim (it rejected it while `provider` was wrongly required).
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse(200, { configured: false, masked: null, updated_at: null }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await builderApi.getProviderCredential("datago");
+
+    expect(result).toEqual({ configured: false, masked: null, updated_at: null });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/providers/datago/credential");
+    expect(init.method ?? "GET").toBe("GET");
+  });
+
   it("getPublishReadiness() sends only target=huggingface and parses the exact Run", async () => {
     const fetchMock = vi.fn().mockResolvedValue(mockResponse(200, {
       run_id: "run-270",

--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -1,18 +1,22 @@
 /**
  * Builder API 계약 적합성 테스트 (#36).
  *
- * Studio가 실제로 검토·연동한 Builder 계약 버전과 엔드포인트 집합을 고정해, 한쪽이
- * 바뀌면 CI에서 깨지도록 한다. 이 pin은 "Builder main의 최신 API_CONTRACT_VERSION과
- * 항상 exact-equality"를 뜻하지 않는다 — Builder는 additive 변경마다 버전을 계속
- * 올리므로(예: 1.8.0 — per-user provider credentials), Studio가 아직 구현/검토하지
- * 않은 operation까지 지원한다고 오인시키지 않도록 여기서는 마지막으로 검토한 버전만
- * 고정한다(Silver/Gold read-only `/query` 추가 — builder #504, API_CONTRACT_VERSION
- * "1.7.0"). Provider credentials API 연동은 Studio #259 범위이며 아직 여기 없다.
- * exact-equality pin 정책 자체를 versionless capability 협상으로 바꿀지는 builder
- * #521에서 논의 중이며, 이 테스트는 그 결정을 선점하지 않는다.
+ * Studio가 호출하는 Builder operation 집합과, 통합 표면이 요구하는 **최소** Builder
+ * API 버전을 고정한다. 이 값은 "Builder main의 최신 api_version과 exact-equality"가
+ * 아니다 — Builder ADR 0013(#521)에 따라 Studio는 같은 major·server >= 최소값이면
+ * 호환으로 간주하고 더 높은 additive minor/patch(1.19~1.21 등)를 허용한다.
+ *
+ * 현재 최소값은 1.18.0이다: cooperative cancel(POST /builds/{id}/cancel)과 manifest
+ * status/partial 필드가 1.18.0에서 도입됐고 Studio가 둘 다 실제로 사용한다. provider
+ * credential / monitoring / async build job operation은 이미 연동돼 EXPECTED_OPERATIONS에
+ * 포함돼 있다.
  */
 import { describe, expect, it } from "vitest";
-import { API_CONTRACT_VERSION, builderApi } from "@/shared/lib/builderApi";
+import {
+  isBuilderApiCompatible,
+  MIN_BUILDER_API_VERSION,
+  builderApi,
+} from "@/shared/lib/builderApi";
 
 // Studio 클라이언트가 호출하는 Builder service 오퍼레이션(현재 구현 기준).
 const EXPECTED_OPERATIONS = [
@@ -44,14 +48,15 @@ const EXPECTED_OPERATIONS = [
   "listProviders",
   "testProviderConnection",
   "getProviderStatus",
+  "getProviderCredential",
   "putProviderCredential",
   "deleteProviderCredential",
   "uploadFile",
 ] as const;
 
 describe("Builder API contract conformance (#36)", () => {
-  it("pins Builder PR #547's reviewed 1.17.0 contract including publish; unrelated provider/monitoring operations are not implied", () => {
-    expect(API_CONTRACT_VERSION).toBe("1.17.0");
+  it("declares 1.18.0 as the minimum required Builder API version for the integrated surface", () => {
+    expect(MIN_BUILDER_API_VERSION).toBe("1.18.0");
   });
 
   it("exposes exactly the expected client operations", () => {
@@ -62,5 +67,32 @@ describe("Builder API contract conformance (#36)", () => {
     for (const op of EXPECTED_OPERATIONS) {
       expect(typeof builderApi[op]).toBe("function");
     }
+  });
+});
+
+describe("isBuilderApiCompatible — SemVer policy (ADR 0013)", () => {
+  it("accepts the exact minimum version", () => {
+    expect(isBuilderApiCompatible("1.18.0")).toBe(true);
+  });
+
+  it("accepts higher additive minor/patch within the same major", () => {
+    expect(isBuilderApiCompatible("1.18.4")).toBe(true);
+    expect(isBuilderApiCompatible("1.21.0")).toBe(true);
+  });
+
+  it("rejects versions below the minimum within the same major", () => {
+    expect(isBuilderApiCompatible("1.17.0")).toBe(false);
+    expect(isBuilderApiCompatible("1.17.9")).toBe(false);
+  });
+
+  it("rejects a different (higher) major", () => {
+    expect(isBuilderApiCompatible("2.0.0")).toBe(false);
+  });
+
+  it("fails closed on malformed / missing versions", () => {
+    expect(isBuilderApiCompatible("")).toBe(false);
+    expect(isBuilderApiCompatible("1.18")).toBe(false);
+    expect(isBuilderApiCompatible("v1.18.0")).toBe(false);
+    expect(isBuilderApiCompatible(undefined)).toBe(false);
   });
 });

--- a/__tests__/getBuildAuthoritative.test.ts
+++ b/__tests__/getBuildAuthoritative.test.ts
@@ -1,0 +1,163 @@
+/**
+ * getBuild() real-mode authoritative data 회귀 (F02).
+ *
+ * - BuildSpec은 GET /builds/{run_id}/spec snapshot이 정본이다(localStorage 없이도 편집 가능).
+ * - snapshot 404(legacy)일 때만 로컬 specStore로 fallback한다.
+ * - run status를 절대 임의로 succeeded로 합성하지 않는다:
+ *   GET /builds 목록 > authoritative manifest.status > 명시적 오류.
+ * - Builder snapshot의 redaction marker는 복원 시에도 유지된다(S07 fail-closed).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getBuild } from "@/features/runs/api/getBuild";
+import { clearBuildSpecs, saveBuildSpec } from "@/features/build-spec/specStore";
+import { ApiError, builderApi } from "@/shared/lib/builderApi";
+import type { BuildSpec } from "@/shared/lib/types";
+
+const SNAPSHOT_YAML = [
+  "dataset_id: air-quality",
+  "title: 대기오염",
+  "description: 설명",
+  "sources:",
+  "  - provider: datago",
+  "    dataset: air",
+  "    params:",
+  "      sidoName: 서울",
+  "      serviceKey: A7vK2mQ9xP4rT8yW3nC6dF1hJ5sL0zB4uH8",
+  "exports:",
+  "  - kind: jsonl",
+  "    output_path: artifacts/builds/air/data.jsonl",
+  "metadata: {}",
+  "",
+].join("\n");
+
+const LOCAL_SPEC: BuildSpec = {
+  datasetId: "legacy-ds",
+  title: "레거시",
+  description: "로컬 보관 스펙",
+  sources: [{ provider: "datago", dataset: "legacy", params: { region: "부산" } }],
+  exports: [{ format: "jsonl" }],
+  metadata: {},
+};
+
+const SNAPSHOT_DIGEST = `sha256:${"a".repeat(64)}`;
+
+function notFound() {
+  return new ApiError(404, "no snapshot for legacy run");
+}
+
+beforeEach(() => {
+  vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+  clearBuildSpecs();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  clearBuildSpecs();
+});
+
+describe("getBuild real mode — authoritative spec + status (F02)", () => {
+  it("loads the edit spec from the Builder snapshot even with no localStorage spec", async () => {
+    vi.spyOn(builderApi, "getBuildSpecSnapshot").mockResolvedValue({
+      run_id: "remote-run",
+      spec: SNAPSHOT_YAML,
+      spec_digest: SNAPSHOT_DIGEST,
+    });
+    vi.spyOn(builderApi, "listBuilds").mockResolvedValue({
+      builds: [{ run_id: "remote-run", status: "ok", started_at: null, finished_at: null }],
+    });
+
+    const build = await getBuild("remote-run");
+    expect(build.spec.datasetId).toBe("air-quality");
+    expect(build.status).toBe("succeeded");
+  });
+
+  it("keeps the Builder snapshot's redacted credential redacted (S07 fail-closed)", async () => {
+    vi.spyOn(builderApi, "getBuildSpecSnapshot").mockResolvedValue({
+      run_id: "remote-run",
+      spec: SNAPSHOT_YAML,
+      spec_digest: SNAPSHOT_DIGEST,
+    });
+    vi.spyOn(builderApi, "listBuilds").mockResolvedValue({
+      builds: [{ run_id: "remote-run", status: "ok", started_at: null, finished_at: null }],
+    });
+
+    const build = await getBuild("remote-run");
+    const params = build.spec.sources[0].params as Record<string, unknown>;
+    expect(params.serviceKey).toBe("[REDACTED]");
+    expect(JSON.stringify(build.spec)).not.toContain("A7vK2mQ9xP4rT8yW3nC6dF1hJ5sL0zB4uH8");
+  });
+
+  it("falls back to the local specStore only when the snapshot is a 404 (legacy run)", async () => {
+    saveBuildSpec("legacy-run", LOCAL_SPEC);
+    vi.spyOn(builderApi, "getBuildSpecSnapshot").mockRejectedValue(notFound());
+    vi.spyOn(builderApi, "listBuilds").mockResolvedValue({
+      builds: [{ run_id: "legacy-run", status: "failed", started_at: null, finished_at: null }],
+    });
+
+    const build = await getBuild("legacy-run");
+    expect(build.spec.datasetId).toBe("legacy-ds");
+    expect(build.status).toBe("failed");
+  });
+
+  it("uses the GET /builds terminal summary status when the run is in the list (never re-guesses)", async () => {
+    vi.spyOn(builderApi, "getBuildSpecSnapshot").mockResolvedValue({
+      run_id: "r",
+      spec: SNAPSHOT_YAML,
+      spec_digest: SNAPSHOT_DIGEST,
+    });
+    vi.spyOn(builderApi, "listBuilds").mockResolvedValue({
+      builds: [{ run_id: "r", status: "cancelled", started_at: null, finished_at: null }],
+    });
+    const manifestSpy = vi.spyOn(builderApi, "getBuildManifest");
+
+    const build = await getBuild("r");
+    expect(build.status).toBe("cancelled");
+    expect(manifestSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses authoritative manifest.status when the run is outside the GET /builds list", async () => {
+    vi.spyOn(builderApi, "getBuildSpecSnapshot").mockResolvedValue({
+      run_id: "r",
+      spec: SNAPSHOT_YAML,
+      spec_digest: SNAPSHOT_DIGEST,
+    });
+    vi.spyOn(builderApi, "listBuilds").mockResolvedValue({ builds: [] });
+    vi.spyOn(builderApi, "getBuildManifest").mockResolvedValue({
+      build_id: "r",
+      started_at: "2026-08-31T00:00:00Z",
+      finished_at: "2026-08-31T00:01:00Z",
+      schema_version: "1.0.0",
+      status: "cancelled",
+    });
+
+    const build = await getBuild("r");
+    expect(build.status).toBe("cancelled");
+  });
+
+  it("does NOT synthesize succeeded when there is no authoritative status basis", async () => {
+    saveBuildSpec("orphan-run", LOCAL_SPEC);
+    vi.spyOn(builderApi, "getBuildSpecSnapshot").mockRejectedValue(notFound());
+    vi.spyOn(builderApi, "listBuilds").mockResolvedValue({ builds: [] });
+    vi.spyOn(builderApi, "getBuildManifest").mockResolvedValue({
+      build_id: "orphan-run",
+      started_at: "2026-08-31T00:00:00Z",
+      finished_at: "2026-08-31T00:01:00Z",
+      schema_version: "1.0.0",
+      // status 필드 없음 — legacy/partial manifest
+    });
+
+    await expect(getBuild("orphan-run")).rejects.toThrow(/상태를 확인할 수 없습니다/);
+  });
+
+  it("surfaces a non-404 snapshot error instead of silently falling back", async () => {
+    saveBuildSpec("perm-run", LOCAL_SPEC);
+    vi.spyOn(builderApi, "getBuildSpecSnapshot").mockRejectedValue(
+      new ApiError(403, "forbidden"),
+    );
+    const listSpy = vi.spyOn(builderApi, "listBuilds");
+
+    await expect(getBuild("perm-run")).rejects.toThrow(/forbidden/);
+    expect(listSpy).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/legacyDeepLinks.test.tsx
+++ b/__tests__/legacyDeepLinks.test.tsx
@@ -44,7 +44,7 @@ describe("router 딥링크 회귀 (#247)", () => {
     render(<RouterProvider router={router} />);
 
     await navigateTo("/builds/abc/run");
-    expect(await screen.findByText("상세 진행 정보 미지원")).toBeInTheDocument();
+    expect(await screen.findByText("상세 진행은 Build 상세에서 확인하세요")).toBeInTheDocument();
 
     await navigateTo("/builds/abc/artifacts");
     expect(await screen.findByText("Manifest 요약")).toBeInTheDocument();

--- a/__tests__/providerPage.test.tsx
+++ b/__tests__/providerPage.test.tsx
@@ -1,12 +1,16 @@
 /**
- * ProviderPage — real Builder API 연동 + credential/status 계약 회귀 (#S01, #S02).
+ * ProviderPage — real Builder API 연동 + credential 진실성 회귀 (#S01, #S02, F01).
  *
  * - real mode는 GET /providers를 canonical source로 쓰고, 실패를 mock 성공으로
  *   위장하지 않는다(명시적 error + 빈 목록).
  * - 연결 테스트는 GET /providers/{provider}/status(임의 POST /test 아님).
- * - credential 저장/삭제는 singular `/credential` + { credential } body, 그리고
- *   선택된 provider의 canonical id를 URL에 쓴다.
- * - 명시적 mock mode는 기존 mock 목록 동작을 유지한다.
+ * - "사용자 저장 credential" 유무/마스킹은 GET /providers/{provider}/credential
+ *   메타데이터로만 판정한다 — GET /providers 요약의 `configured`(effective provider
+ *   configuration)와 분리한다.
+ * - requires_credential=false → 가짜 masked key / Delete 없음.
+ * - server-default-only(요약 configured=true, 사용자 credential 없음) → Delete 없음, 등록 허용.
+ * - 사용자 credential 존재 → Builder masked 값 표시 + Delete.
+ * - raw secret은 DOM에 노출되지 않는다.
  */
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
@@ -53,7 +57,6 @@ describe("ProviderPage real mode (#S01)", () => {
     expect(await screen.findByText("datago")).toBeInTheDocument();
     expect(screen.getByText("kosis")).toBeInTheDocument();
     expect(spy).toHaveBeenCalledTimes(1);
-    // mock provider 이름이 새어 나오지 않는다.
     expect(screen.queryByText("데이터고")).not.toBeInTheDocument();
   });
 
@@ -72,6 +75,12 @@ describe("ProviderPage real mode (#S01)", () => {
     vi.spyOn(builderApi, "listProviders").mockResolvedValue({
       providers: [{ provider: "datago", requires_credential: true, configured: true }],
     });
+    vi.spyOn(builderApi, "getProviderCredential").mockResolvedValue({
+      provider: "datago",
+      configured: false,
+      masked: null,
+      updated_at: null,
+    });
     const statusSpy = vi
       .spyOn(builderApi, "getProviderStatus")
       .mockResolvedValue(STATUS_OK);
@@ -84,9 +93,77 @@ describe("ProviderPage real mode (#S01)", () => {
     expect((await screen.findAllByText("연결됨")).length).toBeGreaterThan(0);
   });
 
-  it("credential save uses PUT /providers/{provider}/credential with { credential } and the selected provider id", async () => {
+  it("requires_credential=false → no masked key, no Delete, no register form", async () => {
     vi.spyOn(builderApi, "listProviders").mockResolvedValue({
+      providers: [{ provider: "opendata", requires_credential: false, configured: true }],
+    });
+    const credSpy = vi.spyOn(builderApi, "getProviderCredential");
+
+    renderPage();
+    fireEvent.click(await screen.findByText("opendata"));
+
+    expect(
+      await screen.findByText(/자격 증명 없이 사용할 수 있습니다\. 등록하거나 삭제할/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "삭제" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "등록하기" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "사용자 자격 증명 등록" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/마스킹/)).not.toBeInTheDocument();
+    // credential 메타데이터 조회 자체를 하지 않는다.
+    expect(credSpy).not.toHaveBeenCalled();
+  });
+
+  it("server-default-only provider (summary configured=true, no user credential) → no Delete, register allowed", async () => {
+    vi.spyOn(builderApi, "listProviders").mockResolvedValue({
+      providers: [{ provider: "datago", requires_credential: true, configured: true }],
+    });
+    vi.spyOn(builderApi, "getProviderCredential").mockResolvedValue({
+      provider: "datago",
+      configured: false,
+      masked: null,
+      updated_at: null,
+    });
+
+    renderPage();
+    fireEvent.click(await screen.findByText("datago"));
+
+    expect(
+      await screen.findByText(/Builder 기본 자격 증명으로 사용 중/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "삭제" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "사용자 자격 증명 등록" })).toBeInTheDocument();
+  });
+
+  it("user credential present → shows Builder masked value + Delete, never the raw secret", async () => {
+    vi.spyOn(builderApi, "listProviders").mockResolvedValue({
+      providers: [{ provider: "datago", requires_credential: true, configured: true }],
+    });
+    vi.spyOn(builderApi, "getProviderCredential").mockResolvedValue({
+      provider: "datago",
+      configured: true,
+      masked: "AK••••9f",
+      updated_at: "2026-08-30T10:00:00.000Z",
+    });
+
+    renderPage();
+    fireEvent.click(await screen.findByText("datago"));
+
+    expect(await screen.findByText("AK••••9f")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "등록하기" })).not.toBeInTheDocument();
+    // 원문/full key 후보가 DOM에 없다.
+    expect(document.body.textContent).not.toContain("••••••••••••••••");
+  });
+
+  it("credential save uses PUT /credential then re-fetches summary + credential metadata", async () => {
+    const listSpy = vi.spyOn(builderApi, "listProviders").mockResolvedValue({
       providers: [{ provider: "datago", requires_credential: true, configured: false }],
+    });
+    const credSpy = vi.spyOn(builderApi, "getProviderCredential").mockResolvedValue({
+      provider: "datago",
+      configured: false,
+      masked: null,
+      updated_at: null,
     });
     const putSpy = vi
       .spyOn(builderApi, "putProviderCredential")
@@ -94,20 +171,40 @@ describe("ProviderPage real mode (#S01)", () => {
 
     renderPage();
     fireEvent.click(await screen.findByText("datago"));
-    fireEvent.click(screen.getByRole("button", { name: "등록하기" }));
+    fireEvent.click(await screen.findByRole("button", { name: "등록하기" }));
     fireEvent.change(screen.getByPlaceholderText("API Key를 입력하세요"), {
       target: { value: "secret-key-123" },
     });
+
+    // 저장 후 사용자 credential이 생겼다고 응답하도록 바꾼다.
+    credSpy.mockResolvedValue({
+      provider: "datago",
+      configured: true,
+      masked: "se••••23",
+      updated_at: "2026-08-31T00:00:00.000Z",
+    });
+    listSpy.mockClear();
+    credSpy.mockClear();
+
     fireEvent.click(screen.getByRole("button", { name: "저장" }));
 
-    await waitFor(() =>
-      expect(putSpy).toHaveBeenCalledWith("datago", "secret-key-123"),
-    );
+    await waitFor(() => expect(putSpy).toHaveBeenCalledWith("datago", "secret-key-123"));
+    // save 후 두 소스를 다시 authoritative하게 갱신한다.
+    await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(credSpy).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText("se••••23")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
   });
 
-  it("credential delete uses DELETE /providers/{provider}/credential for the selected provider", async () => {
-    vi.spyOn(builderApi, "listProviders").mockResolvedValue({
+  it("credential delete uses DELETE /credential then re-fetches state", async () => {
+    const listSpy = vi.spyOn(builderApi, "listProviders").mockResolvedValue({
       providers: [{ provider: "datago", requires_credential: true, configured: true }],
+    });
+    const credSpy = vi.spyOn(builderApi, "getProviderCredential").mockResolvedValue({
+      provider: "datago",
+      configured: true,
+      masked: "AK••••9f",
+      updated_at: "2026-08-30T10:00:00.000Z",
     });
     const deleteSpy = vi
       .spyOn(builderApi, "deleteProviderCredential")
@@ -115,9 +212,17 @@ describe("ProviderPage real mode (#S01)", () => {
 
     renderPage();
     fireEvent.click(await screen.findByText("datago"));
-    fireEvent.click(screen.getByRole("button", { name: "삭제" }));
+    fireEvent.click(await screen.findByRole("button", { name: "삭제" }));
+
+    credSpy.mockResolvedValue({
+      provider: "datago",
+      configured: false,
+      masked: null,
+      updated_at: null,
+    });
 
     await waitFor(() => expect(deleteSpy).toHaveBeenCalledWith("datago"));
+    await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(2));
   });
 });
 

--- a/__tests__/providerPage.test.tsx
+++ b/__tests__/providerPage.test.tsx
@@ -76,7 +76,6 @@ describe("ProviderPage real mode (#S01)", () => {
       providers: [{ provider: "datago", requires_credential: true, configured: true }],
     });
     vi.spyOn(builderApi, "getProviderCredential").mockResolvedValue({
-      provider: "datago",
       configured: false,
       masked: null,
       updated_at: null,
@@ -118,7 +117,6 @@ describe("ProviderPage real mode (#S01)", () => {
       providers: [{ provider: "datago", requires_credential: true, configured: true }],
     });
     vi.spyOn(builderApi, "getProviderCredential").mockResolvedValue({
-      provider: "datago",
       configured: false,
       masked: null,
       updated_at: null,
@@ -139,7 +137,6 @@ describe("ProviderPage real mode (#S01)", () => {
       providers: [{ provider: "datago", requires_credential: true, configured: true }],
     });
     vi.spyOn(builderApi, "getProviderCredential").mockResolvedValue({
-      provider: "datago",
       configured: true,
       masked: "AK••••9f",
       updated_at: "2026-08-30T10:00:00.000Z",
@@ -160,7 +157,6 @@ describe("ProviderPage real mode (#S01)", () => {
       providers: [{ provider: "datago", requires_credential: true, configured: false }],
     });
     const credSpy = vi.spyOn(builderApi, "getProviderCredential").mockResolvedValue({
-      provider: "datago",
       configured: false,
       masked: null,
       updated_at: null,
@@ -178,7 +174,6 @@ describe("ProviderPage real mode (#S01)", () => {
 
     // 저장 후 사용자 credential이 생겼다고 응답하도록 바꾼다.
     credSpy.mockResolvedValue({
-      provider: "datago",
       configured: true,
       masked: "se••••23",
       updated_at: "2026-08-31T00:00:00.000Z",
@@ -201,7 +196,6 @@ describe("ProviderPage real mode (#S01)", () => {
       providers: [{ provider: "datago", requires_credential: true, configured: true }],
     });
     const credSpy = vi.spyOn(builderApi, "getProviderCredential").mockResolvedValue({
-      provider: "datago",
       configured: true,
       masked: "AK••••9f",
       updated_at: "2026-08-30T10:00:00.000Z",
@@ -215,7 +209,6 @@ describe("ProviderPage real mode (#S01)", () => {
     fireEvent.click(await screen.findByRole("button", { name: "삭제" }));
 
     credSpy.mockResolvedValue({
-      provider: "datago",
       configured: false,
       masked: null,
       updated_at: null,

--- a/__tests__/settingsVersionCheck.test.tsx
+++ b/__tests__/settingsVersionCheck.test.tsx
@@ -1,8 +1,9 @@
 /**
- * SettingsPage 계약 버전 호환성 점검 테스트 (#75).
+ * SettingsPage Builder API 버전 호환성 점검 테스트 (#75, ADR 0013).
  *
- * Builder가 보고한 api_version이 Studio의 API_CONTRACT_VERSION과 다르면 화면에 버전 불일치
- * 경고가 표면화되는지, 일치하면 경고가 없는지를 검증한다.
+ * Builder가 보고한 api_version이 Studio 통합 표면의 최소 버전과 SemVer 호환되지 않으면
+ * (major가 다르거나 최소값 미만) 화면에 경고가 뜨고, 호환되면(같은 major·최소값 이상,
+ * 더 높은 additive minor/patch 포함) 경고가 없어야 한다. exact-equality 비교가 아니다.
  */
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
@@ -23,37 +24,57 @@ vi.mock("@/shared/lib/builderApi", async () => {
 });
 
 const { SettingsPage } = await import("@/pages/SettingsPage");
-const { API_CONTRACT_VERSION } = await import("@/shared/lib/builderApi");
+const { MIN_BUILDER_API_VERSION } = await import("@/shared/lib/builderApi");
 
 afterEach(() => {
   version.mockReset();
   isRealBuilderEnabled.mockReturnValue(true);
 });
 
+function renderSettings() {
+  render(
+    <MemoryRouter>
+      <SettingsPage />
+    </MemoryRouter>,
+  );
+}
+
 describe("SettingsPage version check", () => {
-  it("surfaces a warning when builder api_version mismatches the studio contract", async () => {
+  it("surfaces a warning when the builder major differs (2.0.0)", async () => {
     version.mockResolvedValue({ service: "builder", api_version: "2.0.0" });
-    render(
-      <MemoryRouter>
-        <SettingsPage />
-      </MemoryRouter>,
-    );
+    renderSettings();
 
     const warning = await screen.findByRole("alert");
     expect(warning.textContent).toContain("계약 버전 불일치");
     expect(warning.textContent).toContain("2.0.0");
   });
 
-  it("shows no mismatch warning when versions agree", async () => {
-    version.mockResolvedValue({ service: "builder", api_version: API_CONTRACT_VERSION });
-    render(
-      <MemoryRouter>
-        <SettingsPage />
-      </MemoryRouter>,
-    );
+  it("surfaces a warning when the builder version is below the required minimum (1.17.0)", async () => {
+    version.mockResolvedValue({ service: "builder", api_version: "1.17.0" });
+    renderSettings();
+
+    const warning = await screen.findByRole("alert");
+    expect(warning.textContent).toContain("계약 버전 불일치");
+  });
+
+  it("shows no warning at the exact minimum version", async () => {
+    version.mockResolvedValue({ service: "builder", api_version: MIN_BUILDER_API_VERSION });
+    renderSettings();
 
     await waitFor(() =>
-      expect(screen.getByText(new RegExp(`Builder API 버전 ${API_CONTRACT_VERSION}`))).toBeInTheDocument(),
+      expect(
+        screen.getByText(new RegExp(`Builder API 버전 ${MIN_BUILDER_API_VERSION}`)),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("shows no false-incompatible warning for a higher additive minor (1.21.0, current Builder main)", async () => {
+    version.mockResolvedValue({ service: "builder", api_version: "1.21.0" });
+    renderSettings();
+
+    await waitFor(() =>
+      expect(screen.getByText(/Builder API 버전 1\.21\.0/)).toBeInTheDocument(),
     );
     expect(screen.queryByRole("alert")).toBeNull();
   });

--- a/src/features/build-spec/specStore.ts
+++ b/src/features/build-spec/specStore.ts
@@ -102,7 +102,7 @@ function writeEnvelope(envelope: SpecStoreEnvelope): void {
  *   통과시키지 않는다 — URL 전체가 고엔트로피로 판정되면 host/path까지 통째로 사라져
  *   복원 시 스키마(https:// 강제)를 깨기 때문이다.
  */
-function redactSpecForStorage(spec: BuildSpec): BuildSpec {
+export function redactSpecForStorage(spec: BuildSpec): BuildSpec {
   return {
     ...spec,
     sources: spec.sources.map((source) => {

--- a/src/features/runs/api/getBuild.ts
+++ b/src/features/runs/api/getBuild.ts
@@ -1,25 +1,51 @@
 /**
- * 개별 빌드 실행 정보 조회 API (#120).
+ * 개별 빌드 실행 정보 조회 API (#120, F02).
  *
- * Builder에는 개별 조회 엔드포인트(`GET /builds/{run_id}`)가 없다. 그래서 실행 이력
- * 목록에서 run_id로 찾고, 스펙은 Studio가 실행 시점에 보관해 둔 값(specStore)으로
- * 채운다. Builder가 `GET /builds/{run_id}`와 spec 영속화를 제공하게 되면 이 함수의
- * 내부만 단일 호출로 교체하면 된다.
+ * mock 모드에서는 결정적 mock 이력이 전체 BuildSpec을 들고 있으므로 그대로 쓴다.
+ *
+ * 실연동 모드에서는 Builder current contract를 authoritative source로 쓴다:
+ *  - BuildSpec: `GET /builds/{run_id}/spec` snapshot이 정본이다(다른 브라우저/CLI에서
+ *    생성돼 localStorage에 스펙이 없어도 편집 가능). legacy run(snapshot 404)일 때만
+ *    로컬 `specStore`로 fallback한다.
+ *  - status: 절대 임의로 succeeded로 만들지 않는다. `GET /builds` 목록에 있으면 그
+ *    terminal summary status를, 없으면 authoritative `GET /builds/{run_id}/manifest`의
+ *    `status`(ok→succeeded / failed→failed / cancelled→cancelled)를 쓴다. 둘 다
+ *    불가하면 succeeded/failed/cancelled를 추측하지 않고 명시적 오류로 처리한다.
  */
-import { loadBuildSpec } from "@/features/build-spec/specStore";
-import { isRealBuilderEnabled } from "@/shared/lib/builderApi";
-import type { BuildListItem, BuildRun } from "@/shared/lib/types";
+import { loadBuildSpec, redactSpecForStorage } from "@/features/build-spec/specStore";
+import { fromYamlText } from "@/features/build-spec/yamlText";
+import { ApiError, builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
+import type { BuildListItem, BuildRun, BuildRunStatus, BuildSpec } from "@/shared/lib/types";
 import { listBuilds, mockBuilds } from "./index";
+
+/**
+ * authoritative manifest의 `status`를 Studio BuildRunStatus로 매핑한다. `status` 필드가
+ * 없는 legacy/partial manifest는 null(추측 금지).
+ */
+async function resolveManifestStatus(runId: string): Promise<BuildRunStatus | null> {
+  try {
+    const manifest = await builderApi.getBuildManifest(runId);
+    switch (manifest.status) {
+      case "ok":
+        return "succeeded";
+      case "failed":
+        return "failed";
+      case "cancelled":
+        return "cancelled";
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
+}
 
 /**
  * buildId로 빌드 실행 정보를 조회한다.
  *
- * 목록에서 찾은 실행 정보에, 보관된 스펙이 있으면 그것으로 덮어써 반환한다. 보관된
- * 스펙은 실행에 실제로 사용된 값이므로 목록이 들고 있는 요약보다 정확하다.
- *
  * @param buildId - 조회할 빌드 ID(run_id).
  * @returns 빌드 실행 정보.
- * @throws Error 해당 ID의 빌드를 찾지 못한 경우.
+ * @throws Error 스펙 또는 상태를 authoritative하게 확인할 수 없는 경우.
  */
 export async function getBuild(buildId: string): Promise<BuildRun> {
   if (!buildId) {
@@ -29,8 +55,6 @@ export async function getBuild(buildId: string): Promise<BuildRun> {
   const storedSpec = loadBuildSpec(buildId);
 
   // mock 모드: 결정적 mock 이력이 전체 BuildSpec을 들고 있으므로 그대로 활용한다.
-  // (실연동용 listBuilds()는 #153 이후 spec 없는 BuildListItem[]만 반환하므로 상세를
-  // 구성할 수 없다.)
   if (!isRealBuilderEnabled()) {
     const mockRun = mockBuilds().find((candidate) => candidate.id === buildId);
     if (mockRun) {
@@ -42,29 +66,52 @@ export async function getBuild(buildId: string): Promise<BuildRun> {
     throw new Error(`빌드를 찾을 수 없습니다: ${buildId}`);
   }
 
-  // 실연동 모드: Builder 목록은 spec/title을 제공하지 않으므로(BuildListItem) 상세를
-  // 채우려면 Studio가 실행 시점에 보관한 스펙(storedSpec)이 반드시 필요하다.
-  const items: BuildListItem[] = await listBuilds();
+  // --- 실연동 모드 ---
+
+  // 1) BuildSpec: Builder snapshot이 authoritative. legacy(404)일 때만 로컬 fallback.
+  let spec: BuildSpec | null = null;
+  try {
+    const snapshot = await builderApi.getBuildSpecSnapshot(buildId);
+    // Builder가 redaction한 canonical YAML. 복원 시 storage 경계와 동일하게 한 번 더
+    // 정규화해 secret-keyed 값이 인식 가능한 `[REDACTED]` marker가 되도록 한다 — 기존
+    // S07 marker detection/fail-closed가 그대로 동작한다. raw credential은 복원하지 않는다.
+    spec = redactSpecForStorage(fromYamlText(snapshot.spec));
+  } catch (cause) {
+    // snapshot이 legacy(404)일 때만 로컬 specStore로 내려간다. 권한/네트워크/파싱
+    // 오류는 "정보 없음"으로 뭉개지 않고 그대로 노출한다.
+    if (!(cause instanceof ApiError && cause.status === 404)) {
+      throw cause;
+    }
+    if (storedSpec) {
+      spec = storedSpec;
+    }
+  }
+
+  if (!spec) {
+    throw new Error(
+      `빌드를 찾을 수 없습니다: ${buildId}. 이 실행의 BuildSpec snapshot이 없고(legacy) 로컬에 보관된 스펙도 없습니다.`,
+    );
+  }
+
+  // 2) status: GET /builds 목록 > authoritative manifest.status > 명시적 오류.
+  const items: BuildListItem[] = await listBuilds().catch(() => [] as BuildListItem[]);
   const item = items.find((candidate) => candidate.id === buildId);
-  if (item && storedSpec) {
+  if (item) {
     return {
-      id: item.id,
-      spec: storedSpec,
+      id: buildId,
+      spec,
       status: item.status,
       startedAt: item.startedAt ?? "",
       finishedAt: item.finishedAt ?? undefined,
     };
   }
 
-  // 목록에 없지만 스펙이 보관돼 있는 경우(방금 실행한 빌드). 실행 상태는 알 수 없으므로
-  // 지어내지 않는다.
-  if (storedSpec) {
-    return { id: buildId, spec: storedSpec, status: "succeeded" as const, startedAt: "" };
+  const manifestStatus = await resolveManifestStatus(buildId);
+  if (manifestStatus) {
+    return { id: buildId, spec, status: manifestStatus, startedAt: "", finishedAt: undefined };
   }
 
-  // 실연동 모드에서 목록이 비어 있는 원인은 Builder `GET /builds` 미연동이다(#102).
-  // 사용자가 "존재하지 않는 빌드"로 오해하지 않도록 원인을 드러낸다.
   throw new Error(
-    `빌드를 찾을 수 없습니다: ${buildId}. Builder 이력 목록 연동(#102) 이후 조회할 수 있습니다.`,
+    `빌드 상태를 확인할 수 없습니다: ${buildId}. Builder 이력 목록과 manifest 어디에서도 이 실행의 최종 상태를 찾지 못했습니다.`,
   );
 }

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -97,8 +97,10 @@ export async function executeBuild(
     onHandle?.({ runId, mode: "sync" });
     result = await runSyncBuild(spec, runId, startedAt, signal);
   } else {
-    onHandle?.({ runId, mode: "async" });
-    result = await runAsyncBuild(spec, runId, startedAt, signal, onJobStatus);
+    // async 표면에서는 POST /builds가 성공해 authoritative run_id를 확보한 **다음에만**
+    // handle을 노출한다(F03). 그래야 submit-in-flight 구간의 Cancel이 아직 서버에
+    // 존재하지 않는 run_id로 협조적 취소를 쏘는 race를 막을 수 있다.
+    result = await runAsyncBuild(spec, runId, startedAt, signal, onJobStatus, onHandle);
   }
 
   // Builder는 spec을 영속화하지 않으므로(#120), 이후 편집 화면이 기존 스펙을 복원할 수
@@ -163,8 +165,13 @@ async function runAsyncBuild(
   startedAt: string,
   signal: AbortSignal | undefined,
   onJobStatus: ((status: BuilderJobStatus) => void) | undefined,
+  onHandle: ((handle: BuildExecutionHandle) => void) | undefined,
 ): Promise<BuildRun> {
   const submitted = await builderApi.submitBuild(serializeSpec(spec), runId, signal);
+  // 서버가 반환한 run_id가 정본이다. 이 시점부터만 협조적 취소(POST
+  // /builds/{run_id}/cancel)를 걸 수 있다 — submit 이전 Cancel은 호출부가 pending
+  // intent로 보관했다가 여기서 노출되는 handle을 통해 정확히 1회 반영한다(F03).
+  onHandle?.({ runId: submitted.run_id, mode: "async" });
   onJobStatus?.(submitted.status);
 
   // 제출 직후 이미 terminal인 경우(동일 run_id 재제출 등) 폴링 없이 바로 판정한다.

--- a/src/features/runs/useBuildJob.ts
+++ b/src/features/runs/useBuildJob.ts
@@ -63,12 +63,28 @@ export function useBuildJob(): BuildJob {
   // 진행 중인 실행이 어떤 Builder 표면(sync/async)을 타는지와 그 run_id. 사용자 취소가
   // async job에 대해 POST /builds/{run_id}/cancel을 호출할 수 있게 한다.
   const handleRef = useRef<BuildExecutionHandle | null>(null);
+  // async submit이 아직 진행 중일 때(= handle 미노출) 눌린 Cancel의 intent. abort하지
+  // 않고 보관했다가, authoritative run_id가 담긴 handle이 오면 정확히 1회 반영한다(F03).
+  const pendingCancelRef = useRef(false);
+  // 이 실행에 대해 async 협조적 취소를 이미 1회 쐈는지(반복 early Cancel coalesce).
+  const cancelIssuedRef = useRef(false);
+
+  // async job에 대한 협조적 취소를 정확히 1회 요청한다. polling은 끊지 않는다 —
+  // Builder terminal status가 최종 정답이고, cancel 요청 실패도 local cancelled로
+  // 바꾸지 않는다(#S03).
+  const issueAsyncCancel = useCallback((runId: string) => {
+    if (cancelIssuedRef.current) return;
+    cancelIssuedRef.current = true;
+    void builderApi.cancelBuildJob(runId).catch(() => {});
+  }, []);
 
   const start = useCallback(async (spec: BuildSpec) => {
     if (controllerRef.current) return;
     const controller = new AbortController();
     controllerRef.current = controller;
     handleRef.current = null;
+    pendingCancelRef.current = false;
+    cancelIssuedRef.current = false;
     setStatus("running");
     setBuilderStatus(undefined);
     setError(undefined);
@@ -83,6 +99,11 @@ export function useBuildJob(): BuildJob {
         },
         (handle) => {
           handleRef.current = handle;
+          // submit 이전에 Cancel이 눌려 있었다면, authoritative run_id가 확보된 지금
+          // 정확히 1회 협조적 취소를 건다(F03).
+          if (handle.mode === "async" && pendingCancelRef.current) {
+            issueAsyncCancel(handle.runId);
+          }
         },
       );
       if (controller.signal.aborted) return;
@@ -121,18 +142,27 @@ export function useBuildJob(): BuildJob {
       // 실제 Builder에 협조적 취소를 요청하고 polling은 그대로 둔다 — "취소된 척"
       // 하며 polling을 끊지 않고, Builder가 cancelling → cancelled terminal에 도달하는
       // 것을 관찰해 최종 상태(result.status)로 판정한다(#S03). 이미 terminal이거나
-      // 네트워크 오류면 polling 결과가 authoritative하므로 여기서는 삼킨다 —
-      // cancel 요청 실패를 local `cancelled`로 바꾸지 않는다.
-      void builderApi.cancelBuildJob(handle.runId).catch(() => {});
+      // 네트워크 오류면 polling 결과가 authoritative하므로 issueAsyncCancel이 삼킨다 —
+      // cancel 요청 실패를 local `cancelled`로 바꾸지 않는다. 반복 호출은 1회로 coalesce된다.
+      issueAsyncCancel(handle.runId);
       return;
     }
-    // sync `POST /build`(file source, ADR 0014) 또는 아직 run_id를 모르는 상태:
-    // server-side 협조적 취소 경로가 없다. fetch abort는 클라이언트 요청만 중단할 뿐
-    // Builder 실행을 취소하지 않으므로, 성공/실패/취소 중 무엇도 확정하지 않고
-    // "요청을 클라이언트에서 중단했다"는 사실만 남긴다.
-    controllerRef.current?.abort();
-    setInterrupted(true);
-  }, []);
+    if (handle?.mode === "sync") {
+      // sync `POST /build`(file source, ADR 0014): server-side 협조적 취소 경로가 없다.
+      // fetch abort는 클라이언트 요청만 중단할 뿐 Builder 실행을 취소하지 않으므로,
+      // 성공/실패/취소 중 무엇도 확정하지 않고 "요청을 클라이언트에서 중단했다"는
+      // 사실만 남긴다(#S04, 기존 동작 유지).
+      controllerRef.current?.abort();
+      setInterrupted(true);
+      return;
+    }
+    // 아직 handle이 없다 = async POST /builds 제출이 진행 중이다. 여기서 fetch를
+    // abort하면 서버가 이미 submit을 받았는지 알 수 없어 orphan build가 생길 수 있다.
+    // 그래서 abort하지 않고 "cancel 요청됨" intent만 기록한다 — submit이 성공해
+    // authoritative run_id가 담긴 handle이 오면 그때 정확히 1회 협조적 취소를 건다(F03).
+    // 반복해서 눌러도 boolean이라 1회로 coalesce된다.
+    pendingCancelRef.current = true;
+  }, [issueAsyncCancel]);
 
   // 언마운트 시 진행 중인 실행을 중단해 unmount 이후 setState를 방지한다(#73).
   useEffect(() => () => controllerRef.current?.abort(), []);

--- a/src/pages/BuildArtifactsPage.tsx
+++ b/src/pages/BuildArtifactsPage.tsx
@@ -2,7 +2,11 @@
  * 빌드 결과물 페이지 (/builds/:buildId/artifacts).
  *
  * manifest 요약, 생성 파일 목록, manifest 원본(JSON)을 보여준다(제안 §5.7, #30).
- * 현재 manifest는 mock이며 #29 Builder API 연동 시 실제 데이터로 교체된다.
+ *
+ * 실연동 모드에서는 `GET /builds/{run_id}/manifest`의 authoritative manifest 본문을
+ * 그대로 렌더링한다. 일부 legacy/partial 실행은 manifest에 메타데이터 필드가 없을 수
+ * 있으며, 그 경우에만 "일부 메타데이터가 없다"고 사실대로 안내한다. mock 모드에서는
+ * 결정적 fixture manifest를 쓴다.
  */
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
@@ -61,7 +65,7 @@ export function BuildArtifactsPage() {
   const totalRecords = manifest?.row_counts
     ? Object.values(manifest.row_counts).reduce((sum, count) => sum + count, 0)
     : undefined;
-  // 실연동 모드 경고 배너용: 핵심 메타데이터(레코드 수/출처)가 제공되지 않으면 안내한다.
+  // legacy/partial manifest 안내용: 일부 실행은 manifest에 메타데이터 필드가 없다.
   const hasMetadata =
     manifest?.row_counts !== undefined && manifest?.provenance !== undefined;
 
@@ -164,10 +168,9 @@ export function BuildArtifactsPage() {
               manifest.json
             </p>
             {!hasMetadata && (
-              <p className="mt-2 text-xs text-orange-600 dark:text-orange-400">
-                실연동 모드에서는 Builder /build 응답 manifest가 아직 연동되지 않아, 
-                메타데이터 필드(시간/환경/지문/레코드 수/스키마/출처)가 제공되지 않습니다. 
-                파일 목록(outputs)만 실제 데이터입니다.
+              <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
+                이 실행의 manifest에는 일부 메타데이터 필드(레코드 수·스키마·출처 등)가
+                포함되어 있지 않습니다. 파일 목록(outputs)은 그대로 사용할 수 있습니다.
               </p>
             )}
             <pre className="mt-4 overflow-x-auto rounded-xl bg-zinc-950 p-4 text-xs leading-6 text-zinc-100">

--- a/src/pages/BuildRunPage.tsx
+++ b/src/pages/BuildRunPage.tsx
@@ -1,19 +1,20 @@
 /**
- * 빌드 실행 추적 페이지 (/builds/:buildId/run).
+ * 빌드 실행 추적 페이지 (/builds/:buildId/run) — legacy deep-link 호환용.
  *
  * 이전에는 buildId와 무관하게 항상 "대기(queued)"·0번째 stepper를 보여주는 정적
- * placeholder였다 — Builds 목록에서 running인 run을 열어도 이 화면은 항상 waiting으로
- * 보여 같은 run이 화면마다 모순된 상태를 표시했다(UI audit #3). Builder는 stage별 세부
- * 진행률/로그 API를 아직 제공하지 않으므로, 있지도 않은 진행률을 재현하는 대신 Builds
- * 목록/상세(BuildsPage)와 동일한 canonical 상태(historical summary + live job polling)만
- * 보여주고, 지원되지 않는 부분은 "상세 진행 정보 미지원"으로 명확히 구분한다.
+ * placeholder였다(UI audit #3). 지금은 Builds 목록/상세(BuildsPage)와 동일한 canonical
+ * 상태(historical summary + live job polling)만 보여준다.
+ *
+ * 단계별 진행(Bronze/Silver/Gold), 실행 이벤트 타임라인, 협조적 실행 취소는 canonical
+ * Build 상세(`/builds?run=...`)가 이미 제공한다 — 이 legacy 화면은 두 번째 상태 머신을
+ * 만들지 않고 canonical 상세로 안내한다. "API 미지원" 같은 사실과 다른 문구는 두지 않는다.
  */
 import { useParams } from "react-router-dom";
 import { useSelectedRunPolling } from "@/features/runs/useSelectedRunPolling";
 import { useBuild } from "@/features/runs/useBuild";
 import { isRealBuilderEnabled } from "@/shared/lib/builderApi";
 import type { BuildRunStatus } from "@/shared/lib/types";
-import { Button, Card, EmptyState, LinkButton, PageHeader, Skeleton, StatusBadge } from "@/shared/ui";
+import { Card, EmptyState, LinkButton, PageHeader, Skeleton, StatusBadge } from "@/shared/ui";
 
 /**
  * 빌드 실행의 canonical 상태를 추적하는 페이지.
@@ -43,9 +44,9 @@ export function BuildRunPage() {
         title={`${buildId || "빌드"} 실행`}
         description="Builds 목록/상세와 동일한 run 상태를 보여줍니다."
         actions={
-          <Button variant="secondary" disabled>
-            취소
-          </Button>
+          <LinkButton variant="secondary" to={`/builds?run=${encodeURIComponent(buildId)}`}>
+            Build 상세에서 관리
+          </LinkButton>
         }
       />
 
@@ -77,8 +78,8 @@ export function BuildRunPage() {
 
       <Card variant="dashed" className="p-0">
         <EmptyState
-          title="상세 진행 정보 미지원"
-          description="Builder는 이 화면에서 stage별 세부 진행률·실행 로그 API를 아직 제공하지 않습니다(#39). 위 상태 배지가 이 run의 canonical 상태이며, stage별 진행(Bronze/Silver/Gold)은 Build 상세의 Pipeline / Stage Progress에서 확인할 수 있습니다."
+          title="상세 진행은 Build 상세에서 확인하세요"
+          description="이 화면은 Builds 목록/상세와 동일한 canonical run 상태만 보여줍니다. 단계별 진행(Bronze/Silver/Gold), 실행 이벤트 타임라인, 협조적 실행 취소는 Build 상세(/builds?run=...)에서 제공됩니다."
         />
       </Card>
 

--- a/src/pages/ProviderPage.tsx
+++ b/src/pages/ProviderPage.tsx
@@ -3,12 +3,15 @@
  *
  * Issue #259: Provider credential/connection 관리와 Settings를 통합한다.
  *
- * P0 범위:
- * - provider selector/detail
- * - masked credential 등록/변경/삭제
- * - connection test loading/double-click 방지
- * - connected/failed/not_configured + latency/checked_at/error category
- * - raw secret DOM/error/log 비노출
+ * 진실성 원칙 (F01, builder ADR 0012):
+ * - GET /providers 요약의 `configured`는 **effective provider configuration**
+ *   (user credential > server default > 없음)이다. "이 사용자가 credential을 저장했다"가
+ *   아니다.
+ * - "이 사용자가 저장한 credential"의 유무/마스킹 값은 GET /providers/{provider}/credential
+ *   메타데이터(`{ configured, masked, updated_at }`, raw secret 없음)로만 판정한다.
+ * - requires_credential=false여도 요약 configured=true일 수 있다(무인증 provider).
+ * - 세 축을 화면에서 분리한다: (1) provider 사용 가능 여부, (2) 사용자 저장 credential
+ *   존재 여부, (3) 연결 테스트 결과.
  */
 import { useCallback, useEffect, useState } from "react";
 import {
@@ -30,7 +33,14 @@ interface ProviderConfig {
   id: string;
   name: string;
   description: string;
-  /** `unknown` = configured/사용 가능하지만 connection을 아직 점검하지 않음. */
+  /** 이 provider가 사용자 credential을 필요로 하는지(GET /providers). */
+  requiresCredential: boolean;
+  /**
+   * GET /providers 요약의 `configured` — effective provider configuration
+   * (user credential > server default > 없음). 사용자 저장 credential 유무가 아니다.
+   */
+  summaryConfigured: boolean;
+  /** 연결 테스트 결과. `unknown` = 아직 점검하지 않음. */
   status: "connected" | "failed" | "not_configured" | "unknown";
   latency?: number;
   checkedAt?: string;
@@ -41,16 +51,32 @@ interface CredentialForm {
   credential: string;
 }
 
+/**
+ * 선택된 provider에 대한 "사용자 저장 credential" 메타데이터 상태.
+ * `configured`는 GET /providers/{provider}/credential 응답 기준(사용자 본인 저장 여부).
+ */
+type CredentialMetaState =
+  | { status: "idle" | "loading" }
+  | { status: "not_applicable" }
+  | { status: "error"; message: string }
+  | {
+      status: "loaded";
+      configured: boolean;
+      masked: string | null;
+      updatedAt: string | null;
+    };
+
 /** Builder GET /providers 요약을 화면 모델로 변환한다(연결 상태는 별도 status 점검으로 채운다). */
 function mapProviderSummary(summary: ProviderSummary): ProviderConfig {
   return {
     id: summary.provider,
     name: summary.provider,
+    requiresCredential: summary.requires_credential,
+    summaryConfigured: summary.configured,
     description: summary.requires_credential
       ? "자격 증명이 필요한 제공 기관입니다."
       : "자격 증명 없이 사용할 수 있는 제공 기관입니다.",
-    status:
-      summary.requires_credential && !summary.configured ? "not_configured" : "unknown",
+    status: "unknown",
   };
 }
 
@@ -60,6 +86,7 @@ export function ProviderPage() {
   const [isTesting, setIsTesting] = useState(false);
   const [showCredentialForm, setShowCredentialForm] = useState(false);
   const [credentialForm, setCredentialForm] = useState<CredentialForm>({ credential: "" });
+  const [credentialMeta, setCredentialMeta] = useState<CredentialMetaState>({ status: "idle" });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -73,9 +100,19 @@ export function ProviderPage() {
         const response = await builderApi.listProviders();
         const mapped = response.providers.map(mapProviderSummary);
         setProviders(mapped);
-        setSelectedProvider((current) =>
-          current ? mapped.find((p) => p.id === current.id) ?? null : null,
-        );
+        setSelectedProvider((current) => {
+          if (!current) return null;
+          const next = mapped.find((p) => p.id === current.id);
+          if (!next) return null;
+          // 연결 테스트 결과는 목록 새로고침으로 잃지 않도록 보존한다.
+          return {
+            ...next,
+            status: current.status,
+            latency: current.latency,
+            checkedAt: current.checkedAt,
+            errorCategory: current.errorCategory,
+          };
+        });
       } else {
         // 명시적 mock/demo mode에서만 mock 목록을 쓴다.
         setProviders(getMockProviders());
@@ -92,9 +129,41 @@ export function ProviderPage() {
     void loadProviders();
   }, [loadProviders]);
 
+  /**
+   * 선택된 provider의 "사용자 저장 credential" 메타데이터를 authoritative하게 다시 읽는다.
+   * requires_credential=false면 조회 자체를 하지 않는다(등록/삭제할 credential이 없음).
+   */
+  const loadCredentialMeta = useCallback(
+    async (provider: ProviderConfig) => {
+      if (!provider.requiresCredential) {
+        setCredentialMeta({ status: "not_applicable" });
+        return;
+      }
+      setCredentialMeta({ status: "loading" });
+      try {
+        if (isRealBuilderEnabled()) {
+          const meta = await builderApi.getProviderCredential(provider.id);
+          setCredentialMeta({
+            status: "loaded",
+            configured: meta.configured,
+            masked: meta.masked,
+            updatedAt: meta.updated_at,
+          });
+        } else {
+          setCredentialMeta(mockCredentialMeta(provider));
+        }
+      } catch {
+        setCredentialMeta({ status: "error", message: "자격 증명 상태를 불러오지 못했습니다" });
+      }
+    },
+    [],
+  );
+
   const handleProviderSelect = (provider: ProviderConfig) => {
     setSelectedProvider(provider);
     setShowCredentialForm(false);
+    setCredentialForm({ credential: "" });
+    void loadCredentialMeta(provider);
   };
 
   /** status 점검/테스트 응답을 목록과 선택 상태에 반영한다. */
@@ -139,27 +208,19 @@ export function ProviderPage() {
 
   const handleCredentialSubmit = async () => {
     if (!selectedProvider || !credentialForm.credential) return;
-    const provider = selectedProvider.id;
+    if (!selectedProvider.requiresCredential) return;
+    const provider = selectedProvider;
     setError(null);
     try {
       if (isRealBuilderEnabled()) {
         // PUT /providers/{provider}/credential, body는 { credential } 하나뿐. 원문은
         // response로 기대하지 않고, 선택된 provider의 canonical id를 URL에 쓴다(#S02).
-        await builderApi.putProviderCredential(provider, credentialForm.credential);
-        setCredentialForm({ credential: "" });
-        setShowCredentialForm(false);
-        await loadProviders();
-      } else {
-        applyStatus({
-          provider,
-          status: "connected",
-          configured: true,
-          latency_ms: 42,
-          checked_at: new Date().toISOString(),
-        });
-        setCredentialForm({ credential: "" });
-        setShowCredentialForm(false);
+        await builderApi.putProviderCredential(provider.id, credentialForm.credential);
       }
+      setCredentialForm({ credential: "" });
+      setShowCredentialForm(false);
+      // 저장 후 metadata와 provider 요약을 다시 authoritative하게 갱신한다.
+      await Promise.all([loadProviders(), loadCredentialMeta(provider)]);
     } catch {
       setError("Credential 저장에 실패했습니다");
     }
@@ -167,30 +228,17 @@ export function ProviderPage() {
 
   const handleCredentialDelete = async () => {
     if (!selectedProvider) return;
-    const provider = selectedProvider.id;
+    const provider = selectedProvider;
     setError(null);
     try {
       if (isRealBuilderEnabled()) {
-        await builderApi.deleteProviderCredential(provider);
-        await loadProviders();
-      } else {
-        applyStatus({
-          provider,
-          status: "not_configured",
-          configured: false,
-          latency_ms: 0,
-          checked_at: new Date().toISOString(),
-        });
+        await builderApi.deleteProviderCredential(provider.id);
       }
+      // 삭제 후 metadata와 provider 요약을 다시 authoritative하게 갱신한다.
+      await Promise.all([loadProviders(), loadCredentialMeta(provider)]);
     } catch {
       setError("Credential 삭제에 실패했습니다");
     }
-  };
-
-  const maskCredential = (credential: string): string => {
-    if (!credential) return "";
-    if (credential.length <= 4) return "****";
-    return credential.substring(0, 2) + "****" + credential.substring(credential.length - 2);
   };
 
   const getStatusBadge = (status: ProviderConfig["status"]) => {
@@ -209,15 +257,21 @@ export function ProviderPage() {
     return { className: styles[status], label: labels[status] };
   };
 
+  // 사용자 본인이 저장한 credential이 있는지(삭제 버튼/마스킹 값 표시의 유일한 근거).
+  const userCredentialConfigured =
+    credentialMeta.status === "loaded" && credentialMeta.configured;
+  const canRegisterCredential =
+    !!selectedProvider &&
+    selectedProvider.requiresCredential &&
+    credentialMeta.status === "loaded";
+
   return (
     <main className="flex flex-1 flex-col gap-8 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
       <PageHeader
         eyebrow="Provider"
         title="데이터 제공 기관 연결"
         description="공공데이터 제공 기관과 연결하고 자격 증명(credential)을 관리합니다."
-        actions={
-          <LinkButton to="/settings">설정으로 이동</LinkButton>
-        }
+        actions={<LinkButton to="/settings">설정으로 이동</LinkButton>}
       />
 
       {error && (
@@ -309,7 +363,7 @@ export function ProviderPage() {
                 {selectedProvider.status === "connected" && (
                   <div className="mt-4 grid grid-cols-2 gap-4 text-sm">
                     <div>
-                      <span className="text-muted-foreground">지연 시각</span>
+                      <span className="text-muted-foreground">확인 시각</span>
                       <p className="font-medium">
                         {selectedProvider.checkedAt
                           ? new Date(selectedProvider.checkedAt).toLocaleString("ko-KR")
@@ -350,31 +404,34 @@ export function ProviderPage() {
               <Card>
                 <div className="flex items-center justify-between">
                   <h4 className="font-semibold">자격 증명 (Credential)</h4>
-                  {selectedProvider.status === "not_configured" && (
-                    <Button
-                      size="sm"
-                      onClick={() => setShowCredentialForm(true)}
-                    >
-                      등록하기
-                    </Button>
-                  )}
-                  {selectedProvider.status !== "not_configured" && (
-                    <Button
-                      size="sm"
-                      variant="danger"
-                      onClick={handleCredentialDelete}
-                    >
+                  {userCredentialConfigured ? (
+                    <Button size="sm" variant="danger" onClick={handleCredentialDelete}>
                       삭제
                     </Button>
-                  )}
+                  ) : canRegisterCredential && !showCredentialForm ? (
+                    <Button size="sm" onClick={() => setShowCredentialForm(true)}>
+                      {selectedProvider.summaryConfigured ? "사용자 자격 증명 등록" : "등록하기"}
+                    </Button>
+                  ) : null}
                 </div>
 
-                {showCredentialForm ? (
+                {!selectedProvider.requiresCredential ? (
+                  <p className="mt-4 text-sm text-muted-foreground">
+                    이 제공 기관은 자격 증명 없이 사용할 수 있습니다. 등록하거나 삭제할
+                    자격 증명이 없습니다.
+                  </p>
+                ) : credentialMeta.status === "loading" || credentialMeta.status === "idle" ? (
+                  <p className="mt-4 text-sm text-muted-foreground">
+                    자격 증명 상태를 불러오는 중…
+                  </p>
+                ) : credentialMeta.status === "error" ? (
+                  <p className="mt-4 text-sm text-red-600 dark:text-red-400">
+                    {credentialMeta.message}
+                  </p>
+                ) : showCredentialForm ? (
                   <div className="mt-4 space-y-4">
                     <div>
-                      <label className="block text-sm font-medium mb-2">
-                        API Key
-                      </label>
+                      <label className="block text-sm font-medium mb-2">API Key</label>
                       <input
                         type="password"
                         className="w-full rounded-md border border-input bg-card px-3 py-2 text-sm"
@@ -396,26 +453,40 @@ export function ProviderPage() {
                       <Button
                         size="sm"
                         variant="secondary"
-                        onClick={() => setShowCredentialForm(false)}
+                        onClick={() => {
+                          setShowCredentialForm(false);
+                          setCredentialForm({ credential: "" });
+                        }}
                       >
                         취소
                       </Button>
                     </div>
                   </div>
-                ) : selectedProvider.status === "not_configured" ? (
-                  <p className="mt-4 text-sm text-muted-foreground">
-                    이 Provider를 사용하려면 자격 증명을 등록해야 합니다.
-                  </p>
-                ) : (
+                ) : credentialMeta.status === "loaded" && credentialMeta.configured ? (
                   <div className="mt-4">
                     <div className="text-sm text-muted-foreground">
-                      <span className="font-medium">마스킹된 API Key:</span>{" "}
-                      {maskCredential("••••••••••••••••")}
+                      <span className="font-medium">저장된 API Key (마스킹):</span>{" "}
+                      {credentialMeta.masked ?? "설정됨"}
                     </div>
+                    {credentialMeta.updatedAt ? (
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        마지막 업데이트:{" "}
+                        {new Date(credentialMeta.updatedAt).toLocaleString("ko-KR")}
+                      </p>
+                    ) : null}
                     <p className="mt-2 text-xs text-muted-foreground">
-                      보안상 원문 표시되지 않습니다.
+                      Builder가 마스킹한 값이며 원문은 표시되지 않습니다.
                     </p>
                   </div>
+                ) : selectedProvider.summaryConfigured ? (
+                  <p className="mt-4 text-sm text-muted-foreground">
+                    이 제공 기관은 현재 Builder 기본 자격 증명으로 사용 중입니다. 별도
+                    사용자 자격 증명을 등록하면 이 기관 호출에 우선 적용됩니다.
+                  </p>
+                ) : (
+                  <p className="mt-4 text-sm text-muted-foreground">
+                    이 제공 기관을 사용하려면 자격 증명을 등록해야 합니다.
+                  </p>
                 )}
               </Card>
             </div>
@@ -426,18 +497,34 @@ export function ProviderPage() {
   );
 }
 
+/** mock/demo 모드에서 선택된 provider의 사용자 credential 상태를 시뮬레이션한다. */
+function mockCredentialMeta(provider: ProviderConfig): CredentialMetaState {
+  if (!provider.requiresCredential) return { status: "not_applicable" };
+  const configured = provider.status === "connected";
+  return {
+    status: "loaded",
+    configured,
+    masked: configured ? "ab••••yz" : null,
+    updatedAt: configured ? new Date(Date.now() - 3600000).toISOString() : null,
+  };
+}
+
 function getMockProviders(): ProviderConfig[] {
   return [
     {
       id: "datago",
       name: "데이터고",
       description: "대한민국 대표 공공데이터 포털",
+      requiresCredential: true,
+      summaryConfigured: false,
       status: "not_configured",
     },
     {
       id: "kosis",
       name: "KOSIS",
       description: "한국 통계청 통계포털",
+      requiresCredential: true,
+      summaryConfigured: true,
       status: "connected",
       latency: 150,
       checkedAt: new Date(Date.now() - 3600000).toISOString(),
@@ -446,6 +533,8 @@ function getMockProviders(): ProviderConfig[] {
       id: "g2b",
       name: "G2B",
       description: "국가과학기술정보원",
+      requiresCredential: true,
+      summaryConfigured: false,
       status: "failed",
       errorCategory: "AUTH_ERROR",
       checkedAt: new Date(Date.now() - 86400000).toISOString(),

--- a/src/pages/ProviderPage.tsx
+++ b/src/pages/ProviderPage.tsx
@@ -352,7 +352,7 @@ export function ProviderPage() {
                     </p>
                   </div>
                   <span
-                    className={`inline-flex items-center rounded-full px-2. py-0.5 text-xs font-medium ${
+                    className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
                       getStatusBadge(selectedProvider.status).className
                     }`}
                   >

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -13,10 +13,11 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { API_BASE } from "@/shared/config/env";
 import {
-  API_CONTRACT_VERSION,
   ApiError,
   builderApi,
+  isBuilderApiCompatible,
   isRealBuilderEnabled,
+  MIN_BUILDER_API_VERSION,
 } from "@/shared/lib/builderApi";
 import type { ProviderSummary } from "@/shared/lib/builderApi.schema";
 import { useAuthStore } from "@/features/auth/store";
@@ -90,7 +91,7 @@ export function SettingsPage() {
             연결 상태
           </p>
           <span className="text-xs text-muted-foreground">
-            Studio 계약 버전 {API_CONTRACT_VERSION}
+            필요한 Builder API 최소 버전 {MIN_BUILDER_API_VERSION}
           </span>
         </div>
         <div className="mt-4 rounded-xl border border-dashed border-border bg-muted p-4">
@@ -116,10 +117,11 @@ export function SettingsPage() {
                   Builder API 버전 {connection.apiVersion}
                 </span>
               </div>
-              {connection.apiVersion !== API_CONTRACT_VERSION ? (
+              {!isBuilderApiCompatible(connection.apiVersion) ? (
                 <p role="alert" className="text-sm text-amber-700 dark:text-amber-400">
-                  계약 버전 불일치 주의: Builder {connection.apiVersion} ≠ Studio{" "}
-                  {API_CONTRACT_VERSION}. 일부 응답 형태가 호환되지 않을 수 있습니다.
+                  계약 버전 불일치 주의: Builder {connection.apiVersion}이(가) Studio가
+                  요구하는 최소 버전({MIN_BUILDER_API_VERSION}, 같은 major)과 호환되지
+                  않습니다. 일부 응답 형태가 호환되지 않을 수 있습니다.
                 </p>
               ) : null}
             </div>

--- a/src/shared/lib/builderApi.schema.ts
+++ b/src/shared/lib/builderApi.schema.ts
@@ -313,11 +313,10 @@ export const providerTestResponseSchema = z.object({
  * `masked`/`updated_at`은 저장된 credential이 없으면 null이다.
  */
 export const providerCredentialResponseSchema = z.object({
-  provider: z.string(),
   configured: z.boolean(),
   masked: z.string().nullable(),
   updated_at: z.string().nullable(),
-});
+}).strict();
 
 /** kind="file" source 업로드 메타데이터(secret-free, content는 포함하지 않음). */
 export const uploadMetadataSchema = z.object({

--- a/src/shared/lib/builderApi.schema.ts
+++ b/src/shared/lib/builderApi.schema.ts
@@ -305,6 +305,20 @@ export const providerTestResponseSchema = z.object({
   response_code: z.number().int().min(100).max(599).optional(),
 });
 
+/**
+ * GET /providers/{provider}/credential — 현재 principal이 저장한 credential의 메타데이터만
+ * 반환한다(ADR 0012). raw secret은 어떤 필드에도 들어 있지 않다. `configured`는 이 사용자가
+ * 직접 저장한 credential이 있는지이며, GET /providers 요약의 `configured`(effective provider
+ * configuration: user credential > server default > 없음)와는 의미가 다르다.
+ * `masked`/`updated_at`은 저장된 credential이 없으면 null이다.
+ */
+export const providerCredentialResponseSchema = z.object({
+  provider: z.string(),
+  configured: z.boolean(),
+  masked: z.string().nullable(),
+  updated_at: z.string().nullable(),
+});
+
 /** kind="file" source 업로드 메타데이터(secret-free, content는 포함하지 않음). */
 export const uploadMetadataSchema = z.object({
   upload_id: z.string().regex(/^upl_[a-f0-9]{32}$/),
@@ -318,6 +332,7 @@ export const uploadMetadataSchema = z.object({
 export type ProviderSummary = z.infer<typeof providerSummarySchema>;
 export type ProvidersResponse = z.infer<typeof providersResponseSchema>;
 export type ProviderTestResponse = z.infer<typeof providerTestResponseSchema>;
+export type ProviderCredentialResponse = z.infer<typeof providerCredentialResponseSchema>;
 export type UploadMetadata = z.infer<typeof uploadMetadataSchema>;
 
 /**

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -22,18 +22,53 @@ import * as schemas from "./builderApi.schema";
 import { z } from "zod";
 
 /**
- * Studio가 실제로 검토·연동한 Builder API 계약 버전(고정 pin, "최신 Builder main과 항상
- * 동일"이 아니다). 1.17.0은 Builder PR #547에서 검토한 idempotent publish
- * readiness/POST 계약까지 포함한다.
+ * Studio의 현재 통합 표면(async build job + cooperative cancel + manifest
+ * status/partial + provider credential + monitoring + publish)이 요구하는 **최소**
+ * Builder API 버전이다. exact contract pin이 아니다 — Builder ADR 0013에 따라
+ * Studio는 "같은 major, server >= 이 최소값"이면 호환으로 간주하고, 더 높은
+ * additive minor/patch(1.19~1.21 등)는 그대로 허용한다.
  *
- * Builder는 additive 변경마다 이 값을 계속 올린다. Studio는 자신이 실제로 검토·
- * 연동한 버전만 고정한다 — 현재는 async build job과 publish 표면까지 검토·연동했다.
- * 미연동 operation(예:
- * provider credentials 1.8.0, monitoring 1.11.0)은 여기 숫자에 반영해도 실제
- * 호출이 없으므로 따로 올리지 않는다. pin 정책 자체는 builder ADR 0013(#521)의
- * 기능별 최소 SemVer 판정으로 전환 중이다.
+ * cancellation(POST /builds/{id}/cancel)과 manifest status/partial 필드는 Builder
+ * 1.18.0에서 도입됐고 Studio가 실제로 이 둘을 사용하므로, 통합 표면의 최소값은
+ * 1.18.0이다. 1.19~1.21에 추가된 미사용 endpoint는 이 최소값에 반영하지 않으며
+ * Studio에 별도로 구현하지도 않는다.
  */
-export const API_CONTRACT_VERSION = "1.17.0";
+export const MIN_BUILDER_API_VERSION = "1.18.0";
+
+/** `major.minor.patch` 세 부분으로 파싱한다. 형식이 어긋나면 null(fail-closed 신호). */
+function parseSemver(version: string): [number, number, number] | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version.trim());
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/**
+ * Builder가 보고한 `api_version`이 Studio 통합 표면과 호환되는지 판정한다 (ADR 0013).
+ *
+ * 규칙:
+ * - server major == required major (major가 다르면 breaking — 2.0.0은 비호환)
+ * - server >= required (같은 major 안에서 minor/patch가 최소값 이상)
+ * - 더 높은 additive minor/patch는 호환 (1.21.0 OK)
+ * - 파싱 불가/형식 오류는 fail-closed로 비호환 처리
+ *
+ * @param serverVersion - GET /version 응답의 `api_version`.
+ * @param requiredVersion - 요구 최소 버전(기본 MIN_BUILDER_API_VERSION).
+ */
+export function isBuilderApiCompatible(
+  serverVersion: string | undefined | null,
+  requiredVersion: string = MIN_BUILDER_API_VERSION,
+): boolean {
+  if (!serverVersion) return false;
+  const server = parseSemver(serverVersion);
+  const required = parseSemver(requiredVersion);
+  if (!server || !required) return false;
+  if (server[0] !== required[0]) return false;
+  for (let i = 0; i < 3; i++) {
+    if (server[i] > required[i]) return true;
+    if (server[i] < required[i]) return false;
+  }
+  return true;
+}
 
 /** 실제 Builder 호출 활성화 여부(미설정 시 mock 사용). */
 export function isRealBuilderEnabled(): boolean {
@@ -375,6 +410,7 @@ export type ProviderTestResponse = schemas.ProviderTestResponse;
 export type UploadMetadata = schemas.UploadMetadata;
 export type ProviderSummary = schemas.ProviderSummary;
 export type ProvidersResponse = schemas.ProvidersResponse;
+export type ProviderCredentialResponse = schemas.ProviderCredentialResponse;
 export type PreviewDiffItem = schemas.PreviewDiffItem;
 export type PreviewTransformSummary = schemas.PreviewTransformSummary;
 export type StageStatus = schemas.StageStatus;
@@ -667,6 +703,20 @@ export const builderApi = {
       `/providers/${encodeURIComponent(provider)}/status`,
       { signal, retries: 1 },
       schemas.providerTestResponseSchema,
+    ),
+
+  /**
+   * GET /providers/{provider}/credential — 현재 principal이 저장한 credential의
+   * 메타데이터(#259, ADR 0012). `{ configured, masked, updated_at }`만 반환하며 raw
+   * secret은 포함하지 않는다. GET /providers 요약의 `configured`(effective provider
+   * configuration)와 달리 이 `configured`는 "이 사용자가 직접 저장한 credential이
+   * 있는지"만 뜻한다.
+   */
+  getProviderCredential: (provider: string, signal?: AbortSignal) =>
+    apiFetch(
+      `/providers/${encodeURIComponent(provider)}/credential`,
+      { signal, retries: 1 },
+      schemas.providerCredentialResponseSchema,
     ),
 
   /**


### PR DESCRIPTION
## 개요

post-E2E 검토에서 남아 있던 Studio ↔ Builder 실연동 진실성 문제를 정리합니다.

이 PR은 `fix/post-e2e-bug-sweep` 위에 쌓인 stacked PR입니다.

## 주요 변경사항

### Provider credential 진실성

- `GET /providers`의 `configured`를 사용자 저장 credential 존재 여부로 오해하지 않도록 의미를 분리
- 사용자 저장 credential 상태는 `GET /providers/{provider}/credential` metadata를 authoritative source로 사용
- `requires_credential=false` Provider에 가짜 마스킹 값/삭제 버튼이 표시되지 않도록 수정
- server-default-only Provider는 기본 credential 사용 상태를 사실대로 표시하면서 사용자 credential 등록은 허용
- credential 저장/삭제 후 Provider summary와 credential metadata를 다시 조회
- `GET /providers/{provider}/credential` Studio schema를 Builder SSOT와 정확히 정렬
  - `{ configured, masked, updated_at }`
  - 존재하지 않는 `provider` 필드 제거
  - `additionalProperties: false`에 맞춰 strict validation 적용

### Build detail/edit authoritative data

- real mode에서 `GET /builds/{run_id}/spec` snapshot을 편집용 BuildSpec의 정본으로 사용
- snapshot 404인 legacy run에서만 local spec fallback
- 임의의 `succeeded` status 합성 제거
- 상태는 `/builds` summary → authoritative manifest status 순으로 확인하고, 둘 다 없으면 fail closed

### Async build cancellation race

- `POST /builds` 완료 전 임시 run ID로 cancel endpoint가 호출되던 race 제거
- submit 완료 후 Builder가 반환한 authoritative `run_id`가 확보된 뒤에만 async handle 노출
- submit 중 눌린 Cancel은 intent로 보관했다가 authoritative run ID 확보 후 정확히 1회 전달
- sync `/build`의 local request interruption semantics는 기존대로 유지

### Builder API version compatibility

- exact version equality 비교 제거
- `MIN_BUILDER_API_VERSION = 1.18.0` 도입
- Builder ADR의 SemVer 정책에 따라:
  - same major
  - server >= minimum
  - higher additive minor/patch 허용
  - malformed version fail closed
- 현재 Studio가 사용하는 cancellation + manifest status/partial 기준으로 최소 버전을 1.18.0으로 설정

### Build/Artifact UI 진실성

- authoritative manifest가 이미 연동됐는데도 남아 있던 "미연동" 문구 제거
- legacy/partial manifest는 실제 누락된 metadata만 사실대로 안내
- legacy Build Run 화면의 잘못된 "stage/event/cancel API 미지원" 문구 제거
- 별도 상태 머신을 만들지 않고 canonical Build 상세 화면으로 안내

## 회귀 테스트

추가/보강한 주요 검증:

- Provider credential:
  - no-credential Provider
  - server-default-only Provider
  - user credential metadata
  - save/delete 후 authoritative re-fetch
  - raw secret 비노출
  - 실제 Builder GET credential wire body parsing
- Build detail:
  - authoritative spec snapshot
  - legacy fallback
  - failed/cancelled manifest status
  - 상태 근거 없음 시 fail closed
- Async cancel:
  - pre-submit Cancel 시 cancel endpoint 미호출
  - authoritative run ID 확보 후 정확히 1회 cancel
  - repeated early Cancel coalescing
- Builder API:
  - 1.17.x 거부
  - 1.18.x / 1.21.x 허용
  - major mismatch / malformed version 거부
- stale Build/Artifact truthfulness 문구 회귀

## 검증

- Provider / Builder API / contract targeted tests: 78 passed
- `npx tsc --noEmit` ✅
- `npm run lint` ✅
  - 기존 `e2e/helpers.ts` warning 1건만 존재
- `npm run build` ✅
- `git diff --check` ✅

전체 Vitest 병렬 실행에서 기존 React-heavy 테스트 일부의 5초 timeout flake가 관측되지만,
해당 테스트는 격리 실행 시 통과하며 이번 변경 경로와 무관합니다.