### PR TITLE
fix: stabilize Studio real integration after Kubi E2E

### DIFF
--- a/__tests__/HomePage.test.tsx
+++ b/__tests__/HomePage.test.tsx
@@ -32,6 +32,10 @@ function configureKey() {
   });
 }
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe("HomePage", () => {
   it("renders the existing-user dashboard heading and KPI summary once builds load (#248)", async () => {
     render(
@@ -48,7 +52,7 @@ describe("HomePage", () => {
     ).toBeInTheDocument();
     // 상태 요약 KPI 카드 라벨
     expect(screen.getByText("DATASETS")).toBeInTheDocument();
-    expect(screen.getByText("BUILD SUCCESS")).toBeInTheDocument();
+    expect(screen.getByText("SUCCEEDED (24H)")).toBeInTheDocument();
     expect(screen.getByText("RUNNING")).toBeInTheDocument();
   });
 
@@ -68,10 +72,7 @@ describe("HomePage", () => {
   });
 
   it("points the new-user '데이터 추가하기' CTA at the canonical /add route, not /add-data (#regression)", async () => {
-    // 신규 사용자 분기를 재현하기 위해 빌드 목록을 빈 배열로 오버라이드한다.
-    mswServer.use(
-      http.get(`${BUILDER_BASE}/builds`, () => HttpResponse.json({ builds: [] })),
-    );
+    useEmptyBuildsRealMode();
 
     render(
       <MemoryRouter>
@@ -81,6 +82,35 @@ describe("HomePage", () => {
 
     const cta = await screen.findByRole("link", { name: "데이터 추가하기" });
     expect(cta).toHaveAttribute("href", "/add");
+  });
+
+  it("uses monitoring success counts and renders unavailable metrics as unavailable, never zero/PASS", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    mswServer.use(
+      http.get(`${BUILDER_BASE}/builds`, () => HttpResponse.json({
+        builds: [
+          { run_id: "ok-run", status: "ok", started_at: "2026-08-31T00:00:00Z", finished_at: "2026-08-31T00:01:00Z" },
+          { run_id: "failed-run", status: "failed", started_at: "2026-08-31T00:02:00Z", finished_at: "2026-08-31T00:03:00Z" },
+          { run_id: "cancelled-run", status: "cancelled", started_at: "2026-08-31T00:04:00Z", finished_at: "2026-08-31T00:05:00Z" },
+        ],
+      })),
+      http.get(`${BUILDER_BASE}/monitoring/builds`, () => HttpResponse.json({
+        window: "24h",
+        bucket: "hour",
+        availability: "available",
+        excluded_count: 0,
+        buckets: [{ bucket_start: "2026-08-31T00:00:00Z", bucket_end: "2026-08-31T01:00:00Z", total: 9, success: 7, failed: 1, cancelled: 1 }],
+        recent_runs: [],
+      })),
+    );
+
+    render(<MemoryRouter><HomePage /></MemoryRouter>);
+
+    expect(await screen.findByText("7")).toBeInTheDocument();
+    expect(screen.getAllByText("확인 불가")).toHaveLength(3);
+    expect(screen.getByText("품질 경고 집계 확인 불가")).toBeInTheDocument();
+    expect(screen.queryByText("품질 경고가 없습니다")).not.toBeInTheDocument();
+    expect(screen.queryByText("모든 빌드가 정상적으로 완료되었습니다")).not.toBeInTheDocument();
   });
 });
 

--- a/__tests__/artifactsApi.test.ts
+++ b/__tests__/artifactsApi.test.ts
@@ -22,34 +22,39 @@ afterEach(() => {
 });
 
 describe("getBuildManifest (#75)", () => {
-  it("maps the real /artifacts {files, run_id} shape to a BuildManifest in real mode", async () => {
+  it("returns the authoritative Builder manifest without synthesizing or dropping fields", async () => {
     vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
     const fetchMock = vi.fn().mockResolvedValue(
       mockResponse(200, {
-        run_id: "run-99",
-        files: ["artifacts/builds/run-99/data.jsonl", "artifacts/builds/run-99/README.md"],
+        build_id: "run-99",
+        schema_version: "2.3.0",
+        started_at: "2026-08-31T00:00:00Z",
+        finished_at: "2026-08-31T00:01:00Z",
+        status: "cancelled",
+        partial: true,
+        outputs: ["artifacts/builds/run-99/data.jsonl"],
+        inputs_fingerprint: "sha256:authoritative",
+        created_by: "oidc:user",
+        future_builder_field: { preserved: true },
       }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
     const manifest = await getBuildManifest("run-99");
 
-    expect(String(fetchMock.mock.calls[0][0])).toContain("/artifacts/run-99");
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/builds/run-99/manifest");
     expect(manifest.build_id).toBe("run-99");
-    expect(manifest.outputs).toEqual([
-      "artifacts/builds/run-99/data.jsonl",
-      "artifacts/builds/run-99/README.md",
-    ]);
-    // /artifacts가 제공하지 않는 필드는 undefined로 남겨 미제공 상태를 표현 (#119)
-    expect(manifest.row_counts).toBeUndefined();
-    expect(manifest.provenance).toBeUndefined();
-    expect(manifest.inputs_fingerprint).toBeNull();
-    expect(manifest.started_at).toBeUndefined();
-    expect(manifest.finished_at).toBeUndefined();
-    expect(manifest.inputs).toBeUndefined();
-    expect(manifest.warnings).toBeUndefined();
-    expect(manifest.errors).toBeUndefined();
-    expect(manifest.schema_summaries).toBeUndefined();
+    expect(manifest.schema_version).toBe("2.3.0");
+    expect(manifest.inputs_fingerprint).toBe("sha256:authoritative");
+    expect(manifest).toMatchObject({ future_builder_field: { preserved: true } });
+    expect(manifest.build_environment).toBeUndefined();
+  });
+
+  it("does not replace an unavailable real manifest with a synthetic manifest", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse(404, { error: "manifest not found" })));
+
+    await expect(getBuildManifest("missing-run")).rejects.toThrow();
   });
 
   it("returns the mock manifest without network in mock mode", async () => {

--- a/__tests__/asyncBuildJob.test.ts
+++ b/__tests__/asyncBuildJob.test.ts
@@ -9,8 +9,9 @@
  */
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { executeBuild, type BuilderJobStatus } from "@/features/runs/api";
+import { executeBuild, listBuilds, specHasFileSource, type BuilderJobStatus } from "@/features/runs/api";
 import { useBuildJob } from "@/features/runs/useBuildJob";
+import { builderApi } from "@/shared/lib/builderApi";
 import type { BuildSpec } from "@/shared/lib/types";
 
 function specOf(datasetId: string): BuildSpec {
@@ -19,6 +20,39 @@ function specOf(datasetId: string): BuildSpec {
     title: datasetId,
     description: "test spec",
     sources: [{ provider: "datago", dataset: "air_quality" }],
+    exports: [],
+  } as unknown as BuildSpec;
+}
+
+function urlSpec(datasetId: string): BuildSpec {
+  return {
+    datasetId,
+    title: datasetId,
+    description: "test spec",
+    sources: [{ kind: "url", endpoint: "https://example.com/data.json", format: "json" }],
+    exports: [],
+  } as unknown as BuildSpec;
+}
+
+function fileSpec(datasetId: string): BuildSpec {
+  return {
+    datasetId,
+    title: datasetId,
+    description: "test spec",
+    sources: [{ kind: "file", uploadId: `upl_${"0".repeat(32)}`, format: "csv", params: {} }],
+    exports: [],
+  } as unknown as BuildSpec;
+}
+
+function mixedSpec(datasetId: string): BuildSpec {
+  return {
+    datasetId,
+    title: datasetId,
+    description: "test spec",
+    sources: [
+      { provider: "datago", dataset: "air_quality", params: {} },
+      { kind: "file", uploadId: `upl_${"0".repeat(32)}`, format: "csv", params: {} },
+    ],
     exports: [],
   } as unknown as BuildSpec;
 }
@@ -50,7 +84,8 @@ describe("async build job polling (#245)", () => {
     expect(run.error).toBe("upstream API timeout");
   });
 
-  it("exposes builder job status through useBuildJob and cancels polling locally", async () => {
+  it("cancel() calls Builder POST /builds/{run_id}/cancel and observes the cancelled terminal (#S03)", async () => {
+    const cancelSpy = vi.spyOn(builderApi, "cancelBuildJob");
     const { result } = renderHook(() => useBuildJob());
 
     let promise: Promise<void> = Promise.resolve();
@@ -64,9 +99,154 @@ describe("async build job polling (#245)", () => {
       result.current.cancel();
     });
 
+    // 실제 Builder 취소 endpoint를 호출한다 — polling만 끊고 "취소된 척"하지 않는다.
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+    expect(cancelSpy.mock.calls[0][0]).toMatch(/^success-\d+$/);
+
+    // Builder가 cancelling → cancelled로 전이하는 것을 polling으로 관찰해 종결한다.
     await act(async () => {
       await promise.catch(() => undefined);
     });
+    expect(result.current.builderStatus).toBe("cancelled");
     expect(result.current.status).toBe("cancelled");
+    expect(result.current.run?.status).toBe("cancelled");
+    cancelSpy.mockRestore();
+  });
+
+  it("a FAILED cancel request never becomes a local cancelled — polling stays authoritative (MINOR A)", async () => {
+    // POST /builds/{run_id}/cancel이 실패(네트워크/5xx)해도 Studio는 이를 취소로
+    // 확정하지 않는다. MSW cancel 핸들러가 실행되지 않으므로 job은 서버 timeline대로
+    // succeeded terminal에 도달하고, 그 값이 authoritative하다.
+    const cancelSpy = vi
+      .spyOn(builderApi, "cancelBuildJob")
+      .mockRejectedValue(new Error("cancel request failed"));
+    const { result } = renderHook(() => useBuildJob());
+
+    let promise: Promise<void> = Promise.resolve();
+    act(() => {
+      promise = result.current.start(specOf("success"));
+    });
+    await waitFor(() => expect(result.current.builderStatus).toBe("queued"));
+
+    act(() => {
+      result.current.cancel();
+    });
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await promise.catch(() => undefined);
+    });
+    // 취소 요청 실패를 로컬 cancelled로 바꾸지 않는다 — polling terminal이 정답이다.
+    expect(result.current.status).toBe("succeeded");
+    expect(result.current.run?.status).toBe("succeeded");
+    expect(result.current.interrupted).toBe(false);
+    cancelSpy.mockRestore();
+  });
+
+  it("sync /build abort is a client-side interruption, not a confirmed cancellation (MAJOR / MINOR B)", async () => {
+    const cancelSpy = vi.spyOn(builderApi, "cancelBuildJob");
+    // sync build 요청을 abort될 때까지 붙잡아, abort 타이밍을 테스트가 제어한다.
+    const buildSpy = vi.spyOn(builderApi, "build").mockImplementation(
+      (_spec, _runId, signal) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener("abort", () =>
+            reject(new DOMException("aborted", "AbortError")),
+          );
+        }),
+    );
+    const { result } = renderHook(() => useBuildJob());
+
+    let promise: Promise<void> = Promise.resolve();
+    act(() => {
+      promise = result.current.start(fileSpec("f"));
+    });
+    await waitFor(() => expect(result.current.status).toBe("running"));
+
+    act(() => {
+      result.current.cancel();
+    });
+    await act(async () => {
+      await promise.catch(() => undefined);
+    });
+
+    // async 협조적 취소 endpoint는 sync build에서 절대 호출되지 않는다.
+    expect(cancelSpy).not.toHaveBeenCalled();
+    // canonical BuildRun/status를 cancelled(또는 succeeded/failed)로 확정하지 않는다.
+    expect(result.current.status).toBe("idle");
+    expect(result.current.status).not.toBe("cancelled");
+    expect(result.current.run).toBeUndefined();
+    // 오직 client-side "요청 중단" 의미만 노출한다.
+    expect(result.current.interrupted).toBe(true);
+    buildSpy.mockRestore();
+    cancelSpy.mockRestore();
+  });
+});
+
+describe("Add Data source dispatch: sync /build vs async /builds (#X01, ADR 0014)", () => {
+  it("routes a public_api-only spec to async POST /builds", async () => {
+    const submitSpy = vi.spyOn(builderApi, "submitBuild");
+    const buildSpy = vi.spyOn(builderApi, "build");
+    await executeBuild(specOf("pub"));
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+    expect(buildSpy).not.toHaveBeenCalled();
+    submitSpy.mockRestore();
+    buildSpy.mockRestore();
+  });
+
+  it("routes a url-only spec to async POST /builds", async () => {
+    const submitSpy = vi.spyOn(builderApi, "submitBuild");
+    const buildSpy = vi.spyOn(builderApi, "build");
+    await executeBuild(urlSpec("u"));
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+    expect(buildSpy).not.toHaveBeenCalled();
+    submitSpy.mockRestore();
+    buildSpy.mockRestore();
+  });
+
+  it("routes a file spec to sync POST /build and never calls POST /builds", async () => {
+    const submitSpy = vi.spyOn(builderApi, "submitBuild");
+    const buildSpy = vi.spyOn(builderApi, "build");
+    const run = await executeBuild(fileSpec("f"));
+    expect(buildSpy).toHaveBeenCalledTimes(1);
+    expect(submitSpy).not.toHaveBeenCalled();
+    expect(run.status).toBe("succeeded");
+    submitSpy.mockRestore();
+    buildSpy.mockRestore();
+  });
+
+  it("routes a mixed spec (file + public_api) to sync POST /build — BuildSpec-wide, not first-source-only", async () => {
+    const submitSpy = vi.spyOn(builderApi, "submitBuild");
+    const buildSpy = vi.spyOn(builderApi, "build");
+    await executeBuild(mixedSpec("m"));
+    expect(buildSpy).toHaveBeenCalledTimes(1);
+    expect(submitSpy).not.toHaveBeenCalled();
+    submitSpy.mockRestore();
+    buildSpy.mockRestore();
+  });
+
+  it("specHasFileSource inspects the whole spec", () => {
+    expect(specHasFileSource(mixedSpec("m"))).toBe(true);
+    expect(specHasFileSource(fileSpec("f"))).toBe(true);
+    expect(specHasFileSource(specOf("p"))).toBe(false);
+    expect(specHasFileSource(urlSpec("u"))).toBe(false);
+  });
+});
+
+describe("listBuilds status mapping preserves cancelled (#S04)", () => {
+  it("maps Builder BuildSummary ok/failed/cancelled without collapsing cancelled to failed", async () => {
+    const spy = vi.spyOn(builderApi, "listBuilds").mockResolvedValue({
+      builds: [
+        { run_id: "a", status: "ok", started_at: null, finished_at: null },
+        { run_id: "b", status: "failed", started_at: null, finished_at: null },
+        { run_id: "c", status: "cancelled", started_at: null, finished_at: null },
+      ],
+    });
+    const items = await listBuilds();
+    expect(items.map((i) => [i.id, i.status])).toEqual([
+      ["a", "succeeded"],
+      ["b", "failed"],
+      ["c", "cancelled"],
+    ]);
+    spy.mockRestore();
   });
 });

--- a/__tests__/buildsKubiSeedRace.test.tsx
+++ b/__tests__/buildsKubiSeedRace.test.tsx
@@ -1,0 +1,364 @@
+/**
+ * C1 regression — Builds "이 Run 분석" seed vs. normalizeBuildContextSearch race (#255 §2 / #256 stale guard).
+ *
+ * 버그: spec/stages 응답이 아직 loading인 상태에서 "이 Run 분석"을 즉시 누르면 `KubiRunAnalysis`가
+ * mount되며 pending seed를 소비해 `ask()`가 그 순간의 `liveContext`(= `?run=` 하나뿐, dataset/
+ * stage/source 없음)를 그대로 turn.context로 고정한다. 잠시 뒤 `normalizeBuildContextSearch`가
+ * `?dataset=`을 URL에 채우면 `contextsMatch`가 깨져 방금 만든 turn이 stale로 분류되고,
+ * `KubiRunAnalysis`의 turn 선택 memo(`!isStale`만 통과)가 답변을 버리고 "분석 준비 중…"으로
+ * 되돌아간다.
+ *
+ * 수정: 클릭은 즉시 카드를 열되, URL이 normalizeBuildContextSearch의 고정점(canonical)이 될
+ * 때까지 seed를 보류하고, canonical해진 뒤 정확히 한 번 seed한다. 아래 두 테스트는 수정 전
+ * fail / 수정 후 pass 해야 한다.
+ */
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as datasetsApi from "@/features/datasets/api";
+import * as runsApi from "@/features/runs/api";
+import * as runDetailApi from "@/features/runs/api/runDetail";
+import { useAssistConfig } from "@/features/assistant/config";
+import { createProvider } from "@/features/assistant/provider";
+import { useKubiStore } from "@/features/kubi/useKubiSession";
+import { BuildsPage } from "@/pages/BuildsPage";
+import type { BuildListItem } from "@/shared/lib/types";
+import type {
+  BuildQualityResponse,
+  BuildSpecSnapshotResponse,
+  RunStagesResponse,
+} from "@/shared/lib/builderApi";
+
+vi.mock("@/features/assistant/provider", () => ({ createProvider: vi.fn() }));
+
+const RUN_ID = "seed-race-run";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const ANSWER = "테스트 분석 답변입니다.";
+const OK_JSON = JSON.stringify({ answer: ANSWER, evidenceRefs: [], generatedSql: null, suggestedActions: [] });
+
+let streamCalls = 0;
+function mockStream(text: string) {
+  streamCalls = 0;
+  vi.mocked(createProvider).mockReturnValue({
+    isConfigured: true,
+    stream: () => {
+      streamCalls += 1;
+      return (async function* () {
+        yield "```json\n" + text + "\n```";
+      })();
+    },
+  } as unknown as ReturnType<typeof createProvider>);
+}
+
+/** 호출 순서대로 "throw"(LLM 오류) 또는 "ok"(정상 응답)로 동작하는 stream mock. */
+function mockStreamSequence(...behaviors: ("throw" | "ok")[]) {
+  streamCalls = 0;
+  vi.mocked(createProvider).mockReturnValue({
+    isConfigured: true,
+    stream: () => {
+      const behavior = behaviors[streamCalls] ?? "ok";
+      streamCalls += 1;
+      return (async function* () {
+        if (behavior === "throw") throw new Error("LLM 일시 오류");
+        yield "```json\n" + OK_JSON + "\n```";
+      })();
+    },
+  } as unknown as ReturnType<typeof createProvider>);
+}
+
+const listItem: BuildListItem = {
+  id: RUN_ID,
+  title: "Seed Race Run",
+  status: "failed",
+  startedAt: "2026-08-20T00:00:00Z",
+  finishedAt: "2026-08-20T00:05:00Z",
+};
+
+const quality: BuildQualityResponse = {
+  run_id: RUN_ID,
+  availability: "unavailable",
+  evaluated_checks: 0,
+  quality_results: {},
+  schema_drift: {},
+};
+
+/** 단일 소스, silver가 failed인 stage 응답 → normalizeBuildContextSearch가 ?stage=silver&source= 를 채운다. */
+const stagesResponse: RunStagesResponse = {
+  run_id: RUN_ID,
+  sources: [
+    {
+      source_key: "datago__air",
+      bronze: { status: "completed", available: true },
+      silver: { status: "failed", available: false },
+      gold: { status: "not_run", available: false },
+    },
+  ],
+};
+
+const specSnapshot: BuildSpecSnapshotResponse = {
+  run_id: RUN_ID,
+  spec: "dataset_id: air-quality\n",
+  spec_digest: "sha256:" + "0".repeat(64),
+};
+
+function renderBuilds() {
+  return render(
+    <MemoryRouter initialEntries={[`/builds?run=${RUN_ID}`]}>
+      <BuildsPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  useKubiStore.setState({ turns: [], onboarded: false, pendingSeed: null });
+  act(() => {
+    useAssistConfig.getState().setConfig({ apiKey: "sk-test-key", model: "gpt-4o-mini", baseUrl: "" });
+  });
+  mockStream(JSON.stringify({ answer: "테스트 분석 답변입니다.", evidenceRefs: [], generatedSql: null, suggestedActions: [] }));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("C1 — Builds Kubi seed vs. context back-fill race", () => {
+  it("defers the seed until the URL context is canonical, so the fresh turn is not stale-flipped away (spec+stages deferred)", async () => {
+    vi.spyOn(runsApi, "listBuilds").mockResolvedValue([listItem]);
+    vi.spyOn(datasetsApi, "getBuildQuality").mockResolvedValue(quality);
+
+    // spec/stages를 의도적으로 지연시킨다 — 클릭 시점에 아직 loading.
+    const spec = deferred<BuildSpecSnapshotResponse>();
+    const stages = deferred<RunStagesResponse>();
+    vi.spyOn(runDetailApi, "getBuildSpecSnapshot").mockReturnValue(spec.promise);
+    vi.spyOn(datasetsApi, "listBuildStages").mockReturnValue(stages.promise);
+
+    renderBuilds();
+
+    const analyzeButton = await screen.findByRole("button", { name: "이 Run 분석" });
+    fireEvent.click(analyzeButton);
+
+    // 카드는 즉시 열린다.
+    expect(await screen.findByRole("heading", { name: "Kubi Run 분석" })).toBeInTheDocument();
+    // 아직 context가 canonical하지 않으므로 seed하지 않는다 — turn이 생기지 않는다.
+    expect(useKubiStore.getState().turns).toHaveLength(0);
+    expect(screen.getByText("분석 준비 중…")).toBeInTheDocument();
+
+    // spec/stages가 도착하고, BuildsPage의 normalizeBuildContextSearch가 URL을 정규화한다.
+    await act(async () => {
+      spec.resolve(specSnapshot);
+      stages.resolve(stagesResponse);
+    });
+
+    // 이제 canonical context로 seed가 정확히 한 번 실행되고 답변이 뜬다.
+    expect(await screen.findByText("테스트 분석 답변입니다.")).toBeInTheDocument();
+
+    // turn.context는 정규화된 canonical 값(dataset/stage/source)을 담고 있어야 한다.
+    const turn = useKubiStore.getState().turns[0];
+    expect(useKubiStore.getState().turns).toHaveLength(1);
+    expect(turn.context.datasetId).toBe("air-quality");
+    expect(turn.context.stage).toBe("silver");
+    expect(turn.context.source).toBe("datago__air");
+
+    // 회귀 가드: 뒤늦은 URL 정규화로 turn이 stale로 사라지지 않는다.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.getByText("테스트 분석 답변입니다.")).toBeInTheDocument();
+    expect(screen.queryByText("분석 준비 중…")).not.toBeInTheDocument();
+    expect(screen.queryByText("이전 화면 기준")).not.toBeInTheDocument();
+    // 중복 LLM 요청 없음.
+    expect(streamCalls).toBe(1);
+  });
+
+  it("still defers when spec is already loaded but stages settle a beat later and add ?stage=/?source= (click right before normalization)", async () => {
+    vi.spyOn(runsApi, "listBuilds").mockResolvedValue([listItem]);
+    vi.spyOn(datasetsApi, "getBuildQuality").mockResolvedValue(quality);
+
+    // spec은 즉시 로드(→ ?dataset= 정규화가 곧 일어남), stages만 지연.
+    vi.spyOn(runDetailApi, "getBuildSpecSnapshot").mockResolvedValue(specSnapshot);
+    const stages = deferred<RunStagesResponse>();
+    vi.spyOn(datasetsApi, "listBuildStages").mockReturnValue(stages.promise);
+
+    renderBuilds();
+
+    const analyzeButton = await screen.findByRole("button", { name: "이 Run 분석" });
+    // spec 정규화(?dataset=)가 방금 반영됐어도 stages는 아직 pending → context는 canonical 아님.
+    await waitFor(() => expect(datasetsApi.listBuildStages).toHaveBeenCalled());
+    fireEvent.click(analyzeButton);
+
+    expect(await screen.findByRole("heading", { name: "Kubi Run 분석" })).toBeInTheDocument();
+    expect(useKubiStore.getState().turns).toHaveLength(0);
+
+    // stages 도착 → normalizeBuildContextSearch가 ?stage=silver&source=datago__air 추가.
+    await act(async () => {
+      stages.resolve(stagesResponse);
+    });
+
+    expect(await screen.findByText("테스트 분석 답변입니다.")).toBeInTheDocument();
+    const turn = useKubiStore.getState().turns[0];
+    expect(turn.context.stage).toBe("silver");
+    expect(turn.context.source).toBe("datago__air");
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.getByText("테스트 분석 답변입니다.")).toBeInTheDocument();
+    expect(screen.queryByText("분석 준비 중…")).not.toBeInTheDocument();
+    expect(streamCalls).toBe(1);
+  });
+
+  it("discards a pending analyze intent when the selected run changes before it seeds", async () => {
+    const otherItem: BuildListItem = { ...listItem, id: "other-run", title: "Other Run" };
+    vi.spyOn(runsApi, "listBuilds").mockResolvedValue([listItem, otherItem]);
+    vi.spyOn(datasetsApi, "getBuildQuality").mockResolvedValue(quality);
+
+    // 두 run 모두 spec/stages를 영구 pending으로 둔다 → context가 절대 canonical해지지 않는다.
+    vi.spyOn(runDetailApi, "getBuildSpecSnapshot").mockReturnValue(deferred<BuildSpecSnapshotResponse>().promise);
+    vi.spyOn(datasetsApi, "listBuildStages").mockReturnValue(deferred<RunStagesResponse>().promise);
+
+    renderBuilds();
+
+    fireEvent.click(await screen.findByRole("button", { name: "이 Run 분석" }));
+    expect(await screen.findByRole("heading", { name: "Kubi Run 분석" }));
+    expect(useKubiStore.getState().turns).toHaveLength(0);
+
+    // 다른 run 선택 → 이전 pending analyze 의도가 폐기돼야 한다.
+    fireEvent.click(screen.getByText("Other Run"));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Other Run" })).toBeInTheDocument());
+
+    await new Promise((r) => setTimeout(r, 50));
+    // 이전 run의 pending seed가 뒤늦게 실행되지 않는다.
+    expect(useKubiStore.getState().turns).toHaveLength(0);
+    expect(useKubiStore.getState().pendingSeed).toBeNull();
+  });
+
+  it("re-clicking '이 Run 분석' on the same run re-analyzes (retry after an errored analysis is not blocked)", async () => {
+    // C1 보류 로직이 "run 수명 동안 1회"가 아니라 "클릭 1회당 seed 1회"여야 한다 —
+    // 인라인 분석이 LLM 오류로 실패했을 때 재시도할 다른 affordance가 없으므로(ErrorNotice에
+    // inline retry 없음) "이 Run 분석" 재클릭이 유일한 재시도 경로다.
+    vi.spyOn(runsApi, "listBuilds").mockResolvedValue([listItem]);
+    vi.spyOn(datasetsApi, "getBuildQuality").mockResolvedValue(quality);
+    vi.spyOn(runDetailApi, "getBuildSpecSnapshot").mockResolvedValue(specSnapshot);
+    vi.spyOn(datasetsApi, "listBuildStages").mockResolvedValue(stagesResponse);
+    mockStreamSequence("throw", "ok");
+
+    renderBuilds();
+
+    const analyzeButton = await screen.findByRole("button", { name: "이 Run 분석" });
+    fireEvent.click(analyzeButton);
+
+    // 1차: LLM 오류로 실패한 turn이 인라인 카드에 표시된다.
+    expect(await screen.findByText("LLM 일시 오류")).toBeInTheDocument();
+    expect(useKubiStore.getState().turns).toHaveLength(1);
+    expect(streamCalls).toBe(1);
+
+    // 재클릭 → 새 분석이 시작되고 이번엔 성공한다.
+    fireEvent.click(analyzeButton);
+
+    expect(await screen.findByText(ANSWER)).toBeInTheDocument();
+    await waitFor(() => expect(useKubiStore.getState().turns).toHaveLength(2));
+    expect(useKubiStore.getState().turns[1].status).toBe("ok");
+    expect(streamCalls).toBe(2);
+  });
+
+  it("adds exactly one new turn per re-click after a successful analysis (no duplicate seed/LLM request)", async () => {
+    vi.spyOn(runsApi, "listBuilds").mockResolvedValue([listItem]);
+    vi.spyOn(datasetsApi, "getBuildQuality").mockResolvedValue(quality);
+    vi.spyOn(runDetailApi, "getBuildSpecSnapshot").mockResolvedValue(specSnapshot);
+    vi.spyOn(datasetsApi, "listBuildStages").mockResolvedValue(stagesResponse);
+
+    renderBuilds();
+    const analyzeButton = await screen.findByRole("button", { name: "이 Run 분석" });
+
+    fireEvent.click(analyzeButton);
+    expect(await screen.findByText(ANSWER)).toBeInTheDocument();
+    await waitFor(() => expect(useKubiStore.getState().turns).toHaveLength(1));
+    expect(streamCalls).toBe(1);
+
+    fireEvent.click(analyzeButton);
+    await waitFor(() => expect(useKubiStore.getState().turns).toHaveLength(2));
+    // 재클릭 후 여유를 둬도 3번째 turn/LLM 호출이 새어 나오지 않는다.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(useKubiStore.getState().turns).toHaveLength(2);
+    expect(streamCalls).toBe(2);
+  });
+
+  it("coalesces rapid clicks fired before the context is canonical into a single seed", async () => {
+    vi.spyOn(runsApi, "listBuilds").mockResolvedValue([listItem]);
+    vi.spyOn(datasetsApi, "getBuildQuality").mockResolvedValue(quality);
+    // pending window를 확보하려고 spec/stages를 지연시킨다.
+    const spec = deferred<BuildSpecSnapshotResponse>();
+    const stages = deferred<RunStagesResponse>();
+    vi.spyOn(runDetailApi, "getBuildSpecSnapshot").mockReturnValue(spec.promise);
+    vi.spyOn(datasetsApi, "listBuildStages").mockReturnValue(stages.promise);
+
+    renderBuilds();
+    const analyzeButton = await screen.findByRole("button", { name: "이 Run 분석" });
+
+    // context가 canonical해지기 전에 여러 번 클릭 = 한 의도로 합쳐진다(analyzePending은 boolean).
+    fireEvent.click(analyzeButton);
+    fireEvent.click(analyzeButton);
+    fireEvent.click(analyzeButton);
+    expect(useKubiStore.getState().turns).toHaveLength(0);
+
+    await act(async () => {
+      spec.resolve(specSnapshot);
+      stages.resolve(stagesResponse);
+    });
+
+    expect(await screen.findByText(ANSWER)).toBeInTheDocument();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(useKubiStore.getState().turns).toHaveLength(1);
+    expect(streamCalls).toBe(1);
+  });
+
+  it("does not auto-seed the newly selected run after a discarded pending intent (no late seed)", async () => {
+    const otherItem: BuildListItem = { ...listItem, id: "other-run", title: "Other Run" };
+    vi.spyOn(runsApi, "listBuilds").mockResolvedValue([listItem, otherItem]);
+    vi.spyOn(datasetsApi, "getBuildQuality").mockResolvedValue(quality);
+    // run A: spec/stages 영구 pending → 클릭해도 canonical 안 됨(analyzePending만 true).
+    // run B(other-run): spec/stages 즉시 resolve → B의 URL은 곧 canonical해진다.
+    vi.spyOn(runDetailApi, "getBuildSpecSnapshot").mockImplementation((runId: string) =>
+      runId === "other-run" ? Promise.resolve({ ...specSnapshot, run_id: "other-run" }) : deferred<BuildSpecSnapshotResponse>().promise,
+    );
+    vi.spyOn(datasetsApi, "listBuildStages").mockImplementation((runId: string) =>
+      runId === "other-run" ? Promise.resolve({ ...stagesResponse, run_id: "other-run" }) : deferred<RunStagesResponse>().promise,
+    );
+
+    renderBuilds();
+
+    fireEvent.click(await screen.findByRole("button", { name: "이 Run 분석" }));
+    expect(await screen.findByRole("heading", { name: "Kubi Run 분석" }));
+    expect(useKubiStore.getState().turns).toHaveLength(0);
+
+    // run 변경 → 이전 pending 폐기. B의 context가 canonical해져도 클릭 없이 자동 분석하지 않는다.
+    fireEvent.click(screen.getByText("Other Run"));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Other Run" })).toBeInTheDocument());
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(useKubiStore.getState().turns).toHaveLength(0);
+    expect(useKubiStore.getState().pendingSeed).toBeNull();
+  });
+
+  it("does not stay pending forever when the BuildSpec snapshot request errors (spec error is 'settled')", async () => {
+    vi.spyOn(runsApi, "listBuilds").mockResolvedValue([listItem]);
+    vi.spyOn(datasetsApi, "getBuildQuality").mockResolvedValue(quality);
+    // spec은 error(legacy run 등), stages는 정상.
+    vi.spyOn(runDetailApi, "getBuildSpecSnapshot").mockRejectedValue(new Error("no snapshot for legacy run"));
+    vi.spyOn(datasetsApi, "listBuildStages").mockResolvedValue(stagesResponse);
+
+    renderBuilds();
+    fireEvent.click(await screen.findByRole("button", { name: "이 Run 분석" }));
+
+    // spec error도 settled로 취급되므로 seed가 실행되고 분석이 진행된다.
+    expect(await screen.findByText(ANSWER)).toBeInTheDocument();
+    expect(useKubiStore.getState().turns).toHaveLength(1);
+    // dataset은 spec이 없어 못 채우지만 stage/source는 stages에서 canonical하게 채워진다.
+    expect(useKubiStore.getState().turns[0].context.stage).toBe("silver");
+    expect(useKubiStore.getState().turns[0].context.datasetId).toBeUndefined();
+  });
+});

--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -24,6 +24,7 @@ const EXPECTED_OPERATIONS = [
   "getBuildJob",
   "cancelBuildJob",
   "artifacts",
+  "getBuildManifest",
   "listBuilds",
   "catalog",
   "listDatasets",

--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -22,6 +22,7 @@ const EXPECTED_OPERATIONS = [
   "build",
   "submitBuild",
   "getBuildJob",
+  "cancelBuildJob",
   "artifacts",
   "listBuilds",
   "catalog",
@@ -41,6 +42,9 @@ const EXPECTED_OPERATIONS = [
   "getMonitoringBuilds",
   "listProviders",
   "testProviderConnection",
+  "getProviderStatus",
+  "putProviderCredential",
+  "deleteProviderCredential",
   "uploadFile",
 ] as const;
 

--- a/__tests__/datasetDetail.test.tsx
+++ b/__tests__/datasetDetail.test.tsx
@@ -164,6 +164,38 @@ describe("Dataset Detail P0 (#253)", () => {
     expect(within(panel).getByText("air-2026-08-14")).toBeInTheDocument();
   });
 
+  it("back-fills the canonical run/source/stage context on direct entry to ?tab=ai, matching the tab-click path (A1)", async () => {
+    // goToTab("ai")를 거치지 않는 직접 진입/새로고침에서도 화면이 확정한 latest run과
+    // canonical source·stage가 Kubi URL context에 반영돼야 한다(#319 후속).
+    renderDetail("/datasets/air-quality?tab=ai");
+
+    await waitFor(() => {
+      const location = screen.getByTestId("location").textContent ?? "";
+      expect(location).toContain("run=air-2026-08-14");
+      expect(location).toContain("source=datago__air");
+      expect(location).toContain("stage=gold");
+    });
+
+    // 수렴 후에는 더 이상 URL을 갱신하지 않는다(update loop 없음).
+    const settled = screen.getByTestId("location").textContent;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(screen.getByTestId("location").textContent).toBe(settled);
+
+    const panel = await screen.findByRole("tabpanel", { name: "AI" });
+    expect(within(panel).getByText("air-2026-08-14")).toBeInTheDocument();
+  });
+
+  it("does not overwrite an explicit valid run/source/stage on direct entry to ?tab=ai (A1)", async () => {
+    renderDetail("/datasets/air-quality?tab=ai&run=air-2026-08-13&source=datago__air&stage=silver");
+
+    await screen.findByRole("tabpanel", { name: "AI" });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const location = screen.getByTestId("location").textContent ?? "";
+    expect(location).toContain("run=air-2026-08-13");
+    expect(location).toContain("source=datago__air");
+    expect(location).toContain("stage=silver");
+  });
+
   it("renders Kubi inline on the AI tab with this dataset's context, not a drawer launcher (#256 review)", async () => {
     renderDetail("/datasets/air-quality?tab=ai");
     const panel = await screen.findByRole("tabpanel", { name: "AI" });
@@ -178,6 +210,9 @@ describe("Dataset Detail P0 (#253)", () => {
     // fail-closed로 빠지지 않는다(#319 후속) — Dataset Detail의 goToTab("ai")가 실제로 하는 동기화.
     renderDetail("/datasets/air-quality?tab=ai&source=datago__air&stage=silver");
     const panel = await screen.findByRole("tabpanel", { name: "AI" });
+    // A1: 직접 진입 시에도 latest run이 URL context에 back-fill될 때까지 기다린 뒤 상호작용한다
+    // (goToTab("ai")가 클릭 경로에서 동기적으로 하던 동기화와 동일한 최종 상태).
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent("run=air-2026-08-14"));
 
     fireEvent.click(within(panel).getByRole("button", { name: "데모 질문 보내보기" }));
 

--- a/__tests__/draftStorage.test.ts
+++ b/__tests__/draftStorage.test.ts
@@ -67,4 +67,37 @@ describe("draftStorage", () => {
     saveDraft({ title: "ok" });
     expect(loadDraft(schema)).toEqual({ title: "ok" });
   });
+
+  describe("read-time sanitize + rewrite (S07 리뷰 §2)", () => {
+    const schema = z.object({ title: z.string(), sourceParams: z.string() });
+    const sanitize = (d: { title: string; sourceParams: string }) => ({
+      ...d,
+      sourceParams: d.sourceParams.replace(/secret-[a-z0-9]+/g, "[REDACTED]"),
+    });
+
+    it("과거 버전이 저장한 평문 secret 초안을 load 시 정리하고 즉시 rewrite한다", () => {
+      // 과거 포맷: sanitize 없이 raw secret이 그대로 저장돼 있음.
+      saveDraft({ title: "빌드", sourceParams: '{"serviceKey":"secret-abc123"}' });
+
+      const loaded = loadDraft(schema, DRAFT_KEY, sanitize);
+      // 반환값에 raw secret이 없다.
+      expect(loaded).toEqual({ title: "빌드", sourceParams: '{"serviceKey":"[REDACTED]"}' });
+
+      // localStorage도 즉시 sanitized 됐다.
+      const raw = JSON.parse(localStorage.getItem(DRAFT_KEY) ?? "{}");
+      expect(raw.data.sourceParams).toBe('{"serviceKey":"[REDACTED]"}');
+      expect(JSON.stringify(raw)).not.toContain("secret-abc123");
+      expect(raw.data.title).toBe("빌드");
+    });
+
+    it("이미 정리된(=변화 없는) 초안은 불필요한 rewrite를 하지 않는다", () => {
+      saveDraft({ title: "빌드", sourceParams: '{"region":"11"}' });
+      const before = localStorage.getItem(DRAFT_KEY);
+
+      const loaded = loadDraft(schema, DRAFT_KEY, sanitize);
+      expect(loaded).toEqual({ title: "빌드", sourceParams: '{"region":"11"}' });
+      // 바이트 단위로 동일 — savedAt 갱신조차 없다.
+      expect(localStorage.getItem(DRAFT_KEY)).toBe(before);
+    });
+  });
 });

--- a/__tests__/msw/handlers.ts
+++ b/__tests__/msw/handlers.ts
@@ -18,7 +18,10 @@ import { API_BASE } from "@/shared/config/env";
  * spec에 `dataset_id: fail_source`가 포함된 경우로 판별한다(동기 /build 모의와
  * 동일한 규칙).
  */
-const asyncJobStates = new Map<string, { pollCount: number; failed: boolean }>();
+const asyncJobStates = new Map<
+  string,
+  { pollCount: number; failed: boolean; cancelled?: boolean; cancelPollCount?: number }
+>();
 
 const ASYNC_JOB_TIMELINE = ["queued", "running"] as const;
 
@@ -137,6 +140,17 @@ export const handlers = [
     if (!state) {
       return HttpResponse.json({ error: `build job not found: ${runId}` }, { status: 404 });
     }
+    // 협조적 취소 관찰 시퀀스: POST /builds/{run_id}/cancel 이후 첫 폴링은 cancelling,
+    // 그다음부터 cancelled terminal(builder #481).
+    if (state.cancelled) {
+      state.cancelPollCount = (state.cancelPollCount ?? 0) + 1;
+      return HttpResponse.json({
+        run_id: runId,
+        status: state.cancelPollCount >= 2 ? "cancelled" : "cancelling",
+        created_at: "2026-08-16T09:00:00+00:00",
+        updated_at: "2026-08-16T09:00:05+00:00",
+      });
+    }
     state.pollCount += 1;
     const timelineIndex = Math.min(state.pollCount - 1, ASYNC_JOB_TIMELINE.length - 1);
     const failed = state.failed;
@@ -167,6 +181,25 @@ export const handlers = [
       status: ASYNC_JOB_TIMELINE[timelineIndex],
       created_at: "2026-08-16T09:00:00+00:00",
       updated_at: "2026-08-16T09:00:01+00:00",
+    });
+  }),
+
+  /**
+   * POST /builds/{run_id}/cancel — 협조적 취소 요청 (#245, builder #481).
+   * 등록된 job이면 취소 시퀀스를 켜고 최신 스냅샷(cancelling)을 돌려준다.
+   */
+  http.post<{ run_id: string }>(`${API_BASE}/builds/:run_id/cancel`, ({ params }) => {
+    const runId = params.run_id as string;
+    const state = asyncJobStates.get(runId);
+    if (!state) {
+      return HttpResponse.json({ error: `build job not found: ${runId}` }, { status: 404 });
+    }
+    state.cancelled = true;
+    return HttpResponse.json({
+      run_id: runId,
+      status: "cancelling",
+      created_at: "2026-08-16T09:00:00+00:00",
+      updated_at: "2026-08-16T09:00:04+00:00",
     });
   }),
 

--- a/__tests__/newBuildDraft.test.tsx
+++ b/__tests__/newBuildDraft.test.tsx
@@ -1,8 +1,24 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NewBuildPage } from "@/pages/NewBuildPage";
 import { clearDraft } from "@/features/build-spec/draftStorage";
+
+// Builder API 경계 spy (S07 리뷰 §2). legacy 평문 draft가 복원되어 secret placeholder가
+// 폼에 들어간 상태에서 Preview/Validate/Run 어느 경로도 Builder를 호출하지 않아야 한다.
+// newBuildWizard.test.tsx와 동일하게 feature api 모듈 자체를 mock한다.
+const { previewBuildMock, validateSpecMock, executeBuildMock } = vi.hoisted(() => ({
+  previewBuildMock: vi.fn(),
+  validateSpecMock: vi.fn(),
+  executeBuildMock: vi.fn(),
+}));
+
+vi.mock("@/features/preview/api", () => ({ previewBuild: previewBuildMock }));
+vi.mock("@/features/validation/api", () => ({ validateSpec: validateSpecMock }));
+vi.mock("@/features/runs/api", async (importActual) => ({
+  ...(await importActual<typeof import("@/features/runs/api")>()),
+  executeBuild: executeBuildMock,
+}));
 
 function renderWizard() {
   return render(
@@ -13,7 +29,12 @@ function renderWizard() {
 }
 
 describe("New Build draft persistence (#10)", () => {
-  beforeEach(() => clearDraft());
+  beforeEach(() => {
+    clearDraft();
+    previewBuildMock.mockReset().mockResolvedValue({ rows: [], schema: {}, warnings: [] });
+    validateSpecMock.mockReset().mockResolvedValue({ valid: true, errors: [] });
+    executeBuildMock.mockReset().mockResolvedValue({ id: "should-not-run", status: "succeeded" });
+  });
   afterEach(() => clearDraft());
 
   it("saves the current input and restores it on a fresh mount", async () => {
@@ -33,6 +54,107 @@ describe("New Build draft persistence (#10)", () => {
     fireEvent.click(screen.getByRole("button", { name: "불러오기" }));
     expect(screen.getByRole("heading", { name: "기본 정보" })).toBeInTheDocument();
     expect(screen.getByLabelText(/데이터셋 ID/)).toHaveValue("kma-daily");
+  });
+
+  it("scrubs credential-like sourceParams before writing the draft to localStorage (S07)", async () => {
+    const secret = "abcdef0123456789abcdef0123456789ABCDEF";
+    renderWizard();
+    fireEvent.click(screen.getByRole("button", { name: "다음" })); // 템플릿 → 기본 정보
+    fireEvent.change(screen.getByLabelText(/데이터셋 ID/), { target: { value: "air-quality" } });
+    fireEvent.change(screen.getByLabelText(/제목/), { target: { value: "대기오염" } });
+    fireEvent.change(screen.getByLabelText(/설명/), { target: { value: "설명" } });
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    await screen.findByRole("heading", { name: "데이터 소스" });
+    fireEvent.change(screen.getByLabelText(/제공자/), { target: { value: "datago" } });
+    fireEvent.change(screen.getByLabelText(/데이터셋/), { target: { value: "air" } });
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    await screen.findByRole("heading", { name: "파라미터" });
+
+    fireEvent.change(screen.getByLabelText(/요청 파라미터/), {
+      target: { value: JSON.stringify({ sidoName: "서울", serviceKey: secret }) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "초안 저장" }));
+    expect(screen.getByRole("button", { name: /저장됨/ })).toBeInTheDocument();
+
+    // 저장된 어떤 localStorage 항목에도 raw secret이 남지 않는다.
+    const dump = Object.keys(localStorage)
+      .map((key) => localStorage.getItem(key) ?? "")
+      .join("\n");
+    expect(dump).not.toContain(secret);
+    expect(dump).toContain("__KPD_PARAMS_SECRET_REDACTED__");
+    // 비민감 파라미터는 초안에 그대로 남는다.
+    expect(dump).toContain("sidoName");
+
+    // in-memory 폼 상태는 그대로라 진행 중인 Preview/Build 요청에 영향이 없다.
+    expect(screen.getByLabelText(/요청 파라미터/)).toHaveValue(
+      JSON.stringify({ sidoName: "서울", serviceKey: secret }),
+    );
+  });
+
+  it("read-time로 legacy 평문 draft를 sanitize + rewrite하고, 복원된 marker는 fail-closed 처리한다 (S07 리뷰 §2)", async () => {
+    const secret = "abcdef0123456789abcdef0123456789ABCDEF";
+    // S07 이전 포맷: sanitize 없이 raw serviceKey가 그대로 저장된 초안.
+    localStorage.setItem(
+      "kpubdata-studio:new-build-draft",
+      JSON.stringify({
+        version: 1,
+        savedAt: "2020-01-01T00:00:00.000Z",
+        data: {
+          datasetId: "air-quality",
+          title: "대기오염",
+          description: "설명",
+          provider: "datago",
+          sourceDataset: "air",
+          sourceParams: JSON.stringify({ sidoName: "서울", serviceKey: secret }),
+          outputPath: "artifacts/builds/air",
+          exportFormats: ["jsonl"],
+        },
+      }),
+    );
+
+    renderWizard();
+    fireEvent.click(screen.getByRole("button", { name: "불러오기" }));
+
+    // 복원 직후 localStorage가 sanitized 됐다 — raw secret 제거, marker 삽입.
+    const stored = localStorage.getItem("kpubdata-studio:new-build-draft") ?? "";
+    expect(stored).not.toContain(secret);
+    expect(stored).toContain("__KPD_PARAMS_SECRET_REDACTED__");
+
+    // 파라미터 단계로 이동하면 필드에 raw secret이 아니라 marker가 보인다.
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    await screen.findByRole("heading", { name: "데이터 소스" }, { timeout: 4000 });
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    await screen.findByRole("heading", { name: "파라미터" }, { timeout: 4000 });
+    const fieldValue = (screen.getByLabelText(/요청 파라미터/) as HTMLTextAreaElement).value;
+    expect(fieldValue).toContain("__KPD_PARAMS_SECRET_REDACTED__");
+    expect(fieldValue).not.toContain(secret);
+
+    // 미리보기 진입 시 fail-closed — Builder로 marker를 제출하지 않는다.
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    await screen.findByRole("heading", { name: "미리보기" }, { timeout: 4000 });
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 새로고침" }));
+    expect(
+      await screen.findByText(/시크릿이 포함된 파라미터 값이 제거되었습니다/),
+    ).toBeInTheDocument();
+    // 오류 문구만이 아니라 Builder `/preview` 자체가 호출되지 않았다.
+    expect(previewBuildMock).toHaveBeenCalledTimes(0);
+
+    // Validate 경로도 동일하게 fail-closed — Builder `/validate` 미호출.
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    await screen.findByRole("heading", { name: "출력 형식" }, { timeout: 4000 });
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    await screen.findByRole("heading", { name: "검증·실행" }, { timeout: 4000 });
+    fireEvent.click(screen.getByRole("button", { name: "다시 검증" }));
+    expect(
+      await screen.findByText(/시크릿이 포함된 파라미터 값이 제거되었습니다/),
+    ).toBeInTheDocument();
+    expect(validateSpecMock).toHaveBeenCalledTimes(0);
+
+    // Run 경로 — 버튼은 disabled고, 강제 클릭해도 Builder 실행(executeBuild)은 0회.
+    const runButton = screen.getByRole("button", { name: "빌드 실행" });
+    expect(runButton).toBeDisabled();
+    fireEvent.click(runButton);
+    expect(executeBuildMock).toHaveBeenCalledTimes(0);
   });
 
   it("discards the saved draft and hides the banner", () => {

--- a/__tests__/newBuildEditRedacted.test.tsx
+++ b/__tests__/newBuildEditRedacted.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Build Edit(`/builds/:buildId/edit`)에서 복원된 BuildSpec의 redaction marker가
+ * Preview/Validate/Run 모든 진입점에서 fail-closed 되는지 확인한다 (S07 리뷰 §1).
+ *
+ * specStore는 실행 시점 spec을 보관할 때 credential을 `[REDACTED]`로 redact한다. 그
+ * 값이 편집 폼으로 복원된 뒤 그대로 Builder(preview/validate/build)로 제출되면 literal
+ * placeholder가 provider credential 자리에 들어간다 — 여기서 그 경로가 막히는지 본다.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NewBuildPage } from "@/pages/NewBuildPage";
+import { clearBuildSpecs, loadBuildSpec, saveBuildSpec } from "@/features/build-spec/specStore";
+import type { BuildSpec } from "@/shared/lib/types";
+
+// Builder API 경계를 직접 spy한다(S07 리뷰 §1). fail-closed는 "오류 UI가 뜬다"가 아니라
+// "Builder로 아무것도 나가지 않는다"가 핵심 불변식이므로, redaction marker가 복원된
+// 상태에서 Preview/Validate/Run 어느 경로도 이 세 함수를 호출하지 않음을 고정한다.
+// - previewBuild : Builder `/preview`(newBuildWizard.test.tsx와 동일한 mock 지점)
+// - validateSpec : Builder `/validate`
+// - executeBuild : Builder `/build`(job.start → useBuildJob → executeBuild 실행 경계)
+const { previewBuildMock, validateSpecMock, executeBuildMock } = vi.hoisted(() => ({
+  previewBuildMock: vi.fn(),
+  validateSpecMock: vi.fn(),
+  executeBuildMock: vi.fn(),
+}));
+
+vi.mock("@/features/preview/api", () => ({ previewBuild: previewBuildMock }));
+vi.mock("@/features/validation/api", () => ({ validateSpec: validateSpecMock }));
+vi.mock("@/features/runs/api", async (importActual) => ({
+  ...(await importActual<typeof import("@/features/runs/api")>()),
+  executeBuild: executeBuildMock,
+}));
+
+/** 세 경로 모두 Builder 호출이 0회임을 한 번에 단언한다. */
+function expectNoBuilderCalls() {
+  expect(previewBuildMock).toHaveBeenCalledTimes(0);
+  expect(validateSpecMock).toHaveBeenCalledTimes(0);
+  expect(executeBuildMock).toHaveBeenCalledTimes(0);
+}
+
+const RUN_ID = "air-quality-redacted-run";
+
+const SPEC_WITH_SECRET: BuildSpec = {
+  datasetId: "air-quality",
+  title: "대기오염",
+  description: "설명",
+  sources: [
+    {
+      provider: "datago",
+      dataset: "air",
+      params: { sidoName: "서울", serviceKey: "A7vK2mQ9xP4rT8yW3nC6dF1hJ5sL0zB4uH8" },
+    },
+  ],
+  exports: [{ format: "jsonl" }],
+  metadata: { outputPath: "artifacts/builds/air" },
+};
+
+function renderEdit() {
+  return render(
+    <MemoryRouter initialEntries={[`/builds/${RUN_ID}/edit`]}>
+      <Routes>
+        <Route path="/builds/:buildId/edit" element={<NewBuildPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+async function gotoStep(heading: string) {
+  fireEvent.click(screen.getByRole("button", { name: "다음" }));
+  // 단계마다 catalog fetch effect가 끼어 재렌더가 늦을 수 있어(병렬 실행 부하) 여유를 둔다.
+  await screen.findByRole("heading", { name: heading }, { timeout: 4000 });
+}
+
+describe("Build Edit — 복원된 redaction marker fail-closed (S07)", () => {
+  beforeEach(() => {
+    clearBuildSpecs();
+    saveBuildSpec(RUN_ID, SPEC_WITH_SECRET);
+    previewBuildMock.mockReset().mockResolvedValue({ rows: [], schema: {}, warnings: [] });
+    validateSpecMock.mockReset().mockResolvedValue({ valid: true, errors: [] });
+    executeBuildMock.mockReset().mockResolvedValue({ id: "should-not-run", status: "succeeded" });
+  });
+  afterEach(() => clearBuildSpecs());
+
+  it("specStore가 credential을 [REDACTED]로 보관한다(전제)", () => {
+    const params = loadBuildSpec(RUN_ID)?.sources[0].params as Record<string, unknown>;
+    expect(params.serviceKey).toBe("[REDACTED]");
+    expect(params.sidoName).toBe("서울");
+  });
+
+  it("Preview 진입 시 fail-closed — 재입력을 요구한다", async () => {
+    renderEdit();
+    // 편집 모드는 build 로드 후 기본 정보 단계에서 시작한다.
+    await screen.findByRole("heading", { name: "기본 정보" }, { timeout: 8000 });
+    await gotoStep("데이터 소스");
+    await gotoStep("파라미터");
+    // 복원된 파라미터에 raw secret이 아니라 marker가 들어 있다.
+    const paramsValue = (screen.getByLabelText(/요청 파라미터/) as HTMLTextAreaElement).value;
+    expect(paramsValue).toContain("[REDACTED]");
+    expect(paramsValue).not.toContain("A7vK2mQ9xP4rT8yW3nC6dF1hJ5sL0zB4uH8");
+
+    await gotoStep("미리보기");
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 새로고침" }));
+
+    expect(
+      await screen.findByText(/시크릿이 포함된 파라미터 값이 제거되었습니다/),
+    ).toBeInTheDocument();
+    // 핵심: 오류 UI만이 아니라 Builder `/preview`로 marker가 전송되지 않았다.
+    expect(previewBuildMock).toHaveBeenCalledTimes(0);
+    expectNoBuilderCalls();
+  });
+
+  it("Validate 진입 시 fail-closed — 통과 메시지가 뜨지 않고 실행이 막힌다", async () => {
+    renderEdit();
+    await screen.findByRole("heading", { name: "기본 정보" }, { timeout: 8000 });
+    await gotoStep("데이터 소스");
+    await gotoStep("파라미터");
+    await gotoStep("미리보기");
+    await gotoStep("출력 형식");
+    await gotoStep("검증·실행");
+
+    fireEvent.click(screen.getByRole("button", { name: "다시 검증" }));
+
+    expect(await screen.findByText(/시크릿이 포함된 파라미터 값이 제거되었습니다/)).toBeInTheDocument();
+    expect(
+      screen.queryByText("검증을 통과했습니다. 빌드를 실행할 수 있습니다."),
+    ).not.toBeInTheDocument();
+
+    // 핵심: Builder `/validate`가 호출되지 않았다(오류는 클라이언트 가드에서 났다).
+    expect(validateSpecMock).toHaveBeenCalledTimes(0);
+
+    // Run 경로도 막혀 있다 — 버튼은 disabled고, 강제로 클릭해도 executeBuild는 0회.
+    const runButton = screen.getByRole("button", { name: "빌드 실행" });
+    expect(runButton).toBeDisabled();
+    fireEvent.click(runButton);
+    expect(executeBuildMock).toHaveBeenCalledTimes(0);
+
+    expectNoBuilderCalls();
+  });
+
+  it("Run 경로 — 검증·실행 단계까지 진행해도 Builder 실행 호출이 0회", async () => {
+    renderEdit();
+    await screen.findByRole("heading", { name: "기본 정보" }, { timeout: 8000 });
+    await gotoStep("데이터 소스");
+    await gotoStep("파라미터");
+    await gotoStep("미리보기");
+    // 미리보기 경로 시도.
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 새로고침" }));
+    expect(
+      await screen.findByText(/시크릿이 포함된 파라미터 값이 제거되었습니다/),
+    ).toBeInTheDocument();
+
+    await gotoStep("출력 형식");
+    await gotoStep("검증·실행");
+    // 검증 경로 시도.
+    fireEvent.click(screen.getByRole("button", { name: "다시 검증" }));
+    expect(
+      await screen.findByText(/시크릿이 포함된 파라미터 값이 제거되었습니다/),
+    ).toBeInTheDocument();
+
+    // 실행 경로 시도.
+    fireEvent.click(screen.getByRole("button", { name: "빌드 실행" }));
+
+    // 세 경로 모두 Builder로 나가지 않았다.
+    expectNoBuilderCalls();
+  });
+});

--- a/__tests__/providerPage.test.tsx
+++ b/__tests__/providerPage.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * ProviderPage — real Builder API 연동 + credential/status 계약 회귀 (#S01, #S02).
+ *
+ * - real mode는 GET /providers를 canonical source로 쓰고, 실패를 mock 성공으로
+ *   위장하지 않는다(명시적 error + 빈 목록).
+ * - 연결 테스트는 GET /providers/{provider}/status(임의 POST /test 아님).
+ * - credential 저장/삭제는 singular `/credential` + { credential } body, 그리고
+ *   선택된 provider의 canonical id를 URL에 쓴다.
+ * - 명시적 mock mode는 기존 mock 목록 동작을 유지한다.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProviderPage } from "@/pages/ProviderPage";
+import { builderApi } from "@/shared/lib/builderApi";
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ProviderPage />
+    </MemoryRouter>,
+  );
+}
+
+const STATUS_OK = {
+  provider: "datago",
+  status: "connected" as const,
+  configured: true,
+  latency_ms: 120,
+  checked_at: "2026-08-31T00:00:00.000Z",
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("ProviderPage real mode (#S01)", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+  });
+
+  it("lists providers from GET /providers via the builder client", async () => {
+    const spy = vi.spyOn(builderApi, "listProviders").mockResolvedValue({
+      providers: [
+        { provider: "datago", requires_credential: true, configured: false },
+        { provider: "kosis", requires_credential: false, configured: false },
+      ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("datago")).toBeInTheDocument();
+    expect(screen.getByText("kosis")).toBeInTheDocument();
+    expect(spy).toHaveBeenCalledTimes(1);
+    // mock provider 이름이 새어 나오지 않는다.
+    expect(screen.queryByText("데이터고")).not.toBeInTheDocument();
+  });
+
+  it("shows an explicit error and does NOT fall back to mock providers on API failure", async () => {
+    vi.spyOn(builderApi, "listProviders").mockRejectedValue(new Error("network down"));
+
+    renderPage();
+
+    expect(await screen.findByText("Provider 정보를 불러올 수 없습니다")).toBeInTheDocument();
+    expect(screen.queryByText("데이터고")).not.toBeInTheDocument();
+    expect(screen.queryByText("KOSIS")).not.toBeInTheDocument();
+    expect(screen.getByText("등록된 Provider가 없습니다")).toBeInTheDocument();
+  });
+
+  it("connection test calls GET /providers/{provider}/status (not POST /test)", async () => {
+    vi.spyOn(builderApi, "listProviders").mockResolvedValue({
+      providers: [{ provider: "datago", requires_credential: true, configured: true }],
+    });
+    const statusSpy = vi
+      .spyOn(builderApi, "getProviderStatus")
+      .mockResolvedValue(STATUS_OK);
+
+    renderPage();
+    fireEvent.click(await screen.findByText("datago"));
+    fireEvent.click(screen.getByRole("button", { name: "연결 테스트" }));
+
+    await waitFor(() => expect(statusSpy).toHaveBeenCalledWith("datago"));
+    expect((await screen.findAllByText("연결됨")).length).toBeGreaterThan(0);
+  });
+
+  it("credential save uses PUT /providers/{provider}/credential with { credential } and the selected provider id", async () => {
+    vi.spyOn(builderApi, "listProviders").mockResolvedValue({
+      providers: [{ provider: "datago", requires_credential: true, configured: false }],
+    });
+    const putSpy = vi
+      .spyOn(builderApi, "putProviderCredential")
+      .mockResolvedValue(undefined);
+
+    renderPage();
+    fireEvent.click(await screen.findByText("datago"));
+    fireEvent.click(screen.getByRole("button", { name: "등록하기" }));
+    fireEvent.change(screen.getByPlaceholderText("API Key를 입력하세요"), {
+      target: { value: "secret-key-123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() =>
+      expect(putSpy).toHaveBeenCalledWith("datago", "secret-key-123"),
+    );
+  });
+
+  it("credential delete uses DELETE /providers/{provider}/credential for the selected provider", async () => {
+    vi.spyOn(builderApi, "listProviders").mockResolvedValue({
+      providers: [{ provider: "datago", requires_credential: true, configured: true }],
+    });
+    const deleteSpy = vi
+      .spyOn(builderApi, "deleteProviderCredential")
+      .mockResolvedValue(undefined);
+
+    renderPage();
+    fireEvent.click(await screen.findByText("datago"));
+    fireEvent.click(screen.getByRole("button", { name: "삭제" }));
+
+    await waitFor(() => expect(deleteSpy).toHaveBeenCalledWith("datago"));
+  });
+});
+
+describe("ProviderPage mock mode (unchanged)", () => {
+  it("keeps the deterministic mock provider list when real builder is disabled", async () => {
+    const spy = vi.spyOn(builderApi, "listProviders");
+    renderPage();
+
+    expect(await screen.findByText("데이터고")).toBeInTheDocument();
+    expect(screen.getByText("KOSIS")).toBeInTheDocument();
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/add-data/components/ReviewBuildStep.test.tsx
+++ b/src/features/add-data/components/ReviewBuildStep.test.tsx
@@ -104,6 +104,41 @@ describe("ReviewBuildStep — URL source secret redaction (#283)", () => {
   });
 });
 
+describe("ReviewBuildStep — sync build client-side interruption wording (MAJOR)", () => {
+  function renderWithJob(props: { jobStatus: "idle" | "cancelled"; jobInterrupted?: boolean }) {
+    const draft = publicApiDraft(JSON.stringify({ region: "seoul" }));
+    const specResult = buildSpecFromDraft(draft);
+    render(
+      <ReviewBuildStep
+        draft={draft}
+        spec={specResult.spec}
+        specError={specResult.error}
+        validation={{ status: "validated", valid: true, errors: [] }}
+        previewSources={[]}
+        previewLimit={5}
+        previewSampleMode="first"
+        isStale={false}
+        jobStatus={props.jobStatus}
+        jobInterrupted={props.jobInterrupted}
+        onBuild={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+  }
+
+  it("client-side abort는 '취소' 확정 문구 대신 '요청을 중단' 문구만 보여준다", () => {
+    renderWithJob({ jobStatus: "idle", jobInterrupted: true });
+    expect(screen.getByText(/요청을 중단했습니다\. 서버 빌드 결과는 확인되지 않았습니다\./)).toBeInTheDocument();
+    expect(screen.queryByText("실행이 취소되었습니다.")).not.toBeInTheDocument();
+  });
+
+  it("실제 async cancelled terminal에서만 '실행이 취소되었습니다.'를 보여준다", () => {
+    renderWithJob({ jobStatus: "cancelled" });
+    expect(screen.getByText("실행이 취소되었습니다.")).toBeInTheDocument();
+    expect(screen.queryByText(/요청을 중단했습니다/)).not.toBeInTheDocument();
+  });
+});
+
 describe("ReviewBuildStep — public_api sourceParams secret redaction (#283 후속 리뷰 §1)", () => {
   it("serviceKey 원문이 Review DOM에 없다", () => {
     const secret = "A7vK2mQ9xP4rT8yW3nC6dF1hJ5sL0zB";

--- a/src/features/add-data/components/ReviewBuildStep.tsx
+++ b/src/features/add-data/components/ReviewBuildStep.tsx
@@ -37,6 +37,8 @@ export interface ReviewBuildStepProps {
   isStale: boolean;
   jobStatus: BuildJobStatus;
   jobError?: string;
+  /** 사용자가 진행 중인 요청을 클라이언트에서 중단함(서버 실행 결과 미확인, sync build). */
+  jobInterrupted?: boolean;
   runId?: string;
   onBuild: () => void;
   onCancel: () => void;
@@ -84,6 +86,7 @@ export function ReviewBuildStep({
   isStale,
   jobStatus,
   jobError,
+  jobInterrupted,
   runId,
   onBuild,
   onCancel,
@@ -259,6 +262,11 @@ export function ReviewBuildStep({
         ) : null}
         {jobStatus === "cancelled" ? (
           <span className="text-sm text-muted-foreground">실행이 취소되었습니다.</span>
+        ) : null}
+        {jobInterrupted && jobStatus !== "cancelled" ? (
+          <span className="text-sm text-muted-foreground">
+            요청을 중단했습니다. 서버 빌드 결과는 확인되지 않았습니다.
+          </span>
         ) : null}
       </div>
     </div>

--- a/src/features/add-data/paramsRedaction.test.ts
+++ b/src/features/add-data/paramsRedaction.test.ts
@@ -6,7 +6,13 @@
  * regex를 여기서 다시 만들지 않는다.
  */
 import { describe, expect, it } from "vitest";
-import { PARAMS_REDACTED_SENTINEL, redactSourceParamsObject, redactSourceParamsText, sourceParamsHasRedactedSecret } from "./paramsRedaction";
+import {
+  PARAMS_REDACTED_SENTINEL,
+  jsonValueHasRedactedSecret,
+  redactSourceParamsObject,
+  redactSourceParamsText,
+  sourceParamsHasRedactedSecret,
+} from "./paramsRedaction";
 
 const SECRET = "A7vK2mQ9xP4rT8yW3nC6dF1hJ5sL0zB";
 
@@ -80,5 +86,39 @@ describe("sourceParamsHasRedactedSecret", () => {
 
   it("secret이 없던 원문은 false를 돌려준다", () => {
     expect(sourceParamsHasRedactedSecret('{"region":"seoul"}')).toBe(false);
+  });
+
+  it("persistence 경계의 모든 marker를 감지한다 (S07 리뷰 §1)", () => {
+    // draft redaction sentinel
+    expect(sourceParamsHasRedactedSecret('{"serviceKey":"__KPD_PARAMS_SECRET_REDACTED__"}')).toBe(true);
+    // URL query redaction placeholder
+    expect(sourceParamsHasRedactedSecret("https://x/y?serviceKey=__KPD_URL_SECRET_REDACTED__")).toBe(true);
+    // redactSecrets() 종결 marker (specStore/savedSpecs)
+    expect(sourceParamsHasRedactedSecret('{"serviceKey":"[REDACTED]"}')).toBe(true);
+    // scrub 내부 placeholder
+    expect(sourceParamsHasRedactedSecret('{"k":"__SCRUBBED_abc_0__"}')).toBe(true);
+  });
+
+  it("bare 'REDACTED'(대괄호 없음)는 정상 값으로 보고 false를 유지한다", () => {
+    expect(sourceParamsHasRedactedSecret('{"status":"REDACTED"}')).toBe(false);
+  });
+});
+
+describe("jsonValueHasRedactedSecret", () => {
+  it("nested object/array 어디에 있든 4종 marker를 모두 감지한다 (S07 리뷰 §1)", () => {
+    expect(jsonValueHasRedactedSecret({ sources: [{ params: { serviceKey: "[REDACTED]" } }] })).toBe(true);
+    expect(jsonValueHasRedactedSecret({ a: { b: ["__KPD_PARAMS_SECRET_REDACTED__"] } })).toBe(true);
+    expect(jsonValueHasRedactedSecret({ endpoint: "https://x?k=__KPD_URL_SECRET_REDACTED__" })).toBe(true);
+    expect(jsonValueHasRedactedSecret({ note: "__SCRUBBED_r_1__" })).toBe(true);
+  });
+
+  it("정상 BuildSpec 형태는 false", () => {
+    expect(
+      jsonValueHasRedactedSecret({
+        datasetId: "air",
+        sources: [{ provider: "datago", dataset: "air", params: { region: "11", status: "REDACTED" } }],
+        metadata: { outputPath: "artifacts/builds/air" },
+      }),
+    ).toBe(false);
   });
 });

--- a/src/features/add-data/paramsRedaction.ts
+++ b/src/features/add-data/paramsRedaction.ts
@@ -13,7 +13,8 @@
  * `redactBuildSpecForDisplay`/`draftStorage`)가 redact된 사본만 만들어 쓰고, in-memory
  * draft/spec은 원문 그대로 유지한다.
  */
-import { isSecretKey, looksLikeSecret } from "@/features/assistant/scrub";
+import { hasSecretPlaceholder, isSecretKey, looksLikeSecret, REDACTED_SECRET_MARKER } from "@/features/assistant/scrub";
+import { REDACTED_PLACEHOLDER } from "@/features/add-data/urlRedaction";
 import type { JsonValue } from "@/shared/lib/types";
 
 // URL endpoint의 `REDACTED_PLACEHOLDER`(urlRedaction.ts)와 같은 이유로 프로젝트 전용
@@ -90,15 +91,29 @@ export function redactSourceParamsText(sourceParams: string): RedactedParamsText
 }
 
 /**
- * 저장된 초안을 복원했을 때 sourceParams에 sentinel이 남아있는지(= 실제 secret 원문이
- * 사라졌는지) 판정한다. `buildSpecFromDraft`를 fail-closed 시키는 데 쓴다 — sentinel을
- * 실제 파라미터 값처럼 Builder에 제출하지 않기 위함.
+ * 저장된 초안을 복원했을 때 sourceParams에 redaction marker가 남아있는지(= 실제 secret
+ * 원문이 사라졌는지) 판정한다. `buildSpecFromDraft`/`toBuildSpec`을 fail-closed 시키는 데
+ * 쓴다 — marker를 실제 파라미터 값처럼 Builder에 제출하지 않기 위함.
+ *
+ * persistence 경계에서 쓰이는 모든 marker를 한 곳에서 인식한다(S07 리뷰 §1):
+ * `redactSourceParamsText`의 `__KPD_PARAMS_SECRET_REDACTED__`, URL query의
+ * `__KPD_URL_SECRET_REDACTED__`, `redactSecrets()`의 종결 `[REDACTED]`, scrub 내부
+ * `__SCRUBBED_*`.
  */
 export function sourceParamsHasRedactedSecret(sourceParams: string): boolean {
-  return sourceParams.includes(PARAMS_REDACTED_SENTINEL);
+  return (
+    sourceParams.includes(PARAMS_REDACTED_SENTINEL) ||
+    sourceParams.includes(REDACTED_PLACEHOLDER) ||
+    hasSecretPlaceholder(sourceParams)
+  );
 }
 
 export function jsonValueHasRedactedSecret(value: unknown): boolean {
   const serialized = JSON.stringify(value) ?? "";
-  return serialized.includes(PARAMS_REDACTED_SENTINEL) || serialized.includes("__KPD_URL_SECRET_REDACTED__");
+  return (
+    serialized.includes(PARAMS_REDACTED_SENTINEL) ||
+    serialized.includes(REDACTED_PLACEHOLDER) ||
+    serialized.includes(REDACTED_SECRET_MARKER) ||
+    hasSecretPlaceholder(value)
+  );
 }

--- a/src/features/artifacts/api/index.ts
+++ b/src/features/artifacts/api/index.ts
@@ -2,16 +2,20 @@
  * 빌드 결과 아티팩트/manifest 조회 API 진입점.
  *
  * mock 모드에서는 결정적 mock manifest를 반환해 뷰어 UI를 개발/검증할 수 있게 한다.
- * 실연동 모드(`VITE_USE_REAL_BUILDER=true`)에서는 Builder `GET /artifacts/{run_id}`를
- * 호출하고, 실제 와이어 형태 `{files, run_id}`를 페이지가 렌더링하는 `BuildManifest`로
- * 매핑한다. /artifacts가 제공하지 않는 필드(recordCount/sources 등)는 안전한 기본값으로
- * 채워 페이지가 누락 필드로 깨지지 않게 한다(#75).
+ * 실연동 모드(`VITE_USE_REAL_BUILDER=true`)에서는 Builder
+ * `GET /builds/{run_id}/manifest`의 authoritative manifest 본문을 그대로 반환한다.
+ * mock 모드에서만 결정적 fixture manifest를 사용한다.
  */
 import { findDemoDataset } from "@/shared/lib/demoDatasets";
 import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
 import type { BuildManifest } from "@/shared/lib/types";
 
 import type { ExportTarget } from "@/shared/lib/types";
+
+/** Builder manifest의 additive field를 API 경계에서만 보존하는 응답 타입. */
+export type AuthoritativeBuildManifest =
+  | BuildManifest
+  | (BuildManifest & Record<string, unknown>);
 
 /**
  * export 형식별 산출물 파일 확장자. specMapping의 output_path 규칙과 동일하게 맞춰
@@ -94,34 +98,10 @@ function mockManifest(buildId: string): BuildManifest {
 }
 
 /**
- * Builder의 실제 `/artifacts` 응답({files, run_id})을 페이지가 쓰는 BuildManifest로
- * 매핑한다. /artifacts가 제공하지 않는 메타 필드는 undefined로 남겨 미제공 상태를 표현한다.
- *
- * 실연동 모드에서는 Builder `/build` 응답 manifest가 연동되지 않아, 메타 필드(시간/환경/
- * 지문/레코드 수/스키마/출처)는 Builder 완성 후 연동할 수 있다. UI에서는 이를 명확히
- * "미제공"으로 표시하도록 처리해야 한다(#119).
- *
- * @param runId - 빌드 실행 ID.
- * @param files - Builder가 반환한 산출물 파일 경로 목록.
- * @returns BuildManifest(제공되지 않은 필드는 undefined).
- */
-function artifactsToManifest(runId: string, files: string[]): BuildManifest {
-  return {
-    schema_version: "1.0.0",
-    build_id: runId,
-    build_environment: null,
-    inputs_fingerprint: null,
-    outputs: files,
-    // 제공되지 않은 필드는 undefined로 남겨서 미제공 상태를 표현
-    // started_at, finished_at, inputs, warnings, errors, row_counts, schema_summaries, provenance
-  };
-}
-
-/**
  * 특정 빌드 실행의 manifest 정보를 조회한다.
  *
- * 실연동 모드면 Builder `/artifacts/{run_id}`의 파일 목록을 BuildManifest로 매핑하고,
- * 아니면 결정적 mock manifest를 반환한다.
+ * 실연동 모드면 Builder `GET /builds/{run_id}/manifest`의 authoritative 본문을,
+ * mock 모드면 결정적 fixture manifest를 반환한다.
  *
  * @param buildId - 조회 대상 빌드 실행 ID.
  * @param signal - 취소용 AbortSignal(선택).
@@ -130,11 +110,11 @@ function artifactsToManifest(runId: string, files: string[]): BuildManifest {
 export async function getBuildManifest(
   buildId: string,
   signal?: AbortSignal,
-): Promise<BuildManifest> {
+): Promise<AuthoritativeBuildManifest> {
   if (!isRealBuilderEnabled()) {
     return mockManifest(buildId);
   }
 
-  const result = await builderApi.artifacts(buildId, signal);
-  return artifactsToManifest(result.run_id, result.files);
+  const result = await builderApi.getBuildManifest(buildId, signal);
+  return result as AuthoritativeBuildManifest;
 }

--- a/src/features/assistant/scrub.ts
+++ b/src/features/assistant/scrub.ts
@@ -82,6 +82,13 @@ const SCRUBBED_PREFIX = "__SCRUBBED_";
 const SCRUBBED_PATTERN = /__SCRUBBED_[A-Za-z0-9-]+_\d+__/g;
 const SCRUBBED_TEST_PATTERN = /__SCRUBBED_[A-Za-z0-9-]+_\d+__/;
 
+/**
+ * `redactSecrets()`가 시크릿 값을 최종적으로 치환하는 종결 마커. 왕복 복원이 불가능한
+ * 값이므로(placeholder→원문 map이 없음), 복원된 spec/draft에서 이 문자열이 보이면
+ * "시크릿이 이미 제거됨 → 재입력 필요"로 취급해야 한다(#206, S07 리뷰 §1).
+ */
+export const REDACTED_SECRET_MARKER = "[REDACTED]";
+
 export interface ScrubResult {
   scrubbed: unknown;
   placeholders: Map<string, string>;
@@ -260,7 +267,9 @@ export function restoreSecrets(data: unknown, placeholders: Map<string, string>)
 }
 
 export function hasSecretPlaceholder(data: unknown): boolean {
-  if (typeof data === "string") return SCRUBBED_TEST_PATTERN.test(data);
+  if (typeof data === "string") {
+    return SCRUBBED_TEST_PATTERN.test(data) || data.includes(REDACTED_SECRET_MARKER);
+  }
   if (Array.isArray(data)) return data.some(hasSecretPlaceholder);
   if (data && typeof data === "object") {
     return Object.values(data as Record<string, unknown>).some(hasSecretPlaceholder);
@@ -276,7 +285,7 @@ export function redactSecrets(
   const scrubbed = scrubber.scrub(data);
 
   function redact(value: unknown): unknown {
-    if (typeof value === "string" && hasSecretPlaceholder(value)) return "[REDACTED]";
+    if (typeof value === "string" && hasSecretPlaceholder(value)) return REDACTED_SECRET_MARKER;
     if (Array.isArray(value)) return value.map(redact);
     if (value && typeof value === "object") {
       return Object.fromEntries(

--- a/src/features/build-spec/draftStorage.ts
+++ b/src/features/build-spec/draftStorage.ts
@@ -55,9 +55,17 @@ export function saveDraft<T>(value: T, key: string = ownedStorageKey(DRAFT_KEY))
  *
  * @param validator - 데이터를 검증할 zod 스키마(선택). 미제공 시 버전만 확인한다.
  * @param key - 초안 저장 key(선택). 미제공 시 New Build Wizard 기본 key를 쓴다.
+ * @param sanitize - 복원 직후 적용할 저장 경계 정책(선택, #206/S07). 결과가 원본과 다르면
+ *   (= 과거 버전이 평문 credential을 저장해 둔 경우) 정리된 값으로 즉시 다시 저장하고 그
+ *   값을 반환한다 — raw credential을 in-memory로 되돌려주지 않는다. non-secret 초안은
+ *   deep-equal이라 불필요한 재저장을 하지 않는다.
  * @returns 저장된 초안 값 또는 null.
  */
-export function loadDraft<T>(validator?: DraftValidator<T>, key: string = ownedStorageKey(DRAFT_KEY)): T | null {
+export function loadDraft<T>(
+  validator?: DraftValidator<T>,
+  key: string = ownedStorageKey(DRAFT_KEY),
+  sanitize?: (data: T) => T,
+): T | null {
   try {
     const raw = localStorage.getItem(key);
     if (!raw) return null;
@@ -72,15 +80,26 @@ export function loadDraft<T>(validator?: DraftValidator<T>, key: string = ownedS
       return null;
     }
     const data = (parsed as DraftEnvelope<unknown>).data;
+    let value: T;
     if (validator) {
       const result = validator.safeParse(data);
       if (!result.success) {
         clearDraft(key);
         return null;
       }
-      return result.data;
+      value = result.data;
+    } else {
+      value = data as T;
     }
-    return data as T;
+    if (sanitize) {
+      const cleaned = sanitize(value);
+      if (JSON.stringify(cleaned) !== JSON.stringify(value)) {
+        // 과거 버전이 남긴 평문 secret을 read 시점에 정리한다(write 경계와 동일 정책).
+        saveDraft(cleaned, key);
+        return cleaned;
+      }
+    }
+    return value;
   } catch {
     return null;
   }

--- a/src/features/build-spec/specStore.test.ts
+++ b/src/features/build-spec/specStore.test.ts
@@ -80,6 +80,112 @@ describe("specStore", () => {
     expect(localStorage.getItem("kpubdata-studio:build-specs")).toBeNull();
   });
 
+  it("credential-like 값은 저장 전에 redact하고 정상 필드는 보존한다 (S07)", () => {
+    const secret = "abcdef0123456789abcdef0123456789ABCDEF";
+    const spec = makeSpec({
+      sources: [
+        {
+          provider: "datago",
+          dataset: "air",
+          params: {
+            sidoName: "서울",
+            serviceKey: secret,
+            nested: { api_key: secret, note: "keep-me" },
+            list: [{ token: secret }, "plain-value"],
+          },
+        },
+      ],
+    });
+    saveBuildSpec("run-secret", spec);
+
+    const raw = localStorage.getItem("kpubdata-studio:build-specs") as string;
+    expect(raw).not.toContain(secret);
+
+    const loaded = loadBuildSpec("run-secret");
+    const params = loaded?.sources[0].params as Record<string, unknown>;
+    expect(params.sidoName).toBe("서울");
+    expect(params.serviceKey).toBe("[REDACTED]");
+    expect((params.nested as Record<string, unknown>).api_key).toBe("[REDACTED]");
+    expect((params.nested as Record<string, unknown>).note).toBe("keep-me");
+    expect((params.list as unknown[])[0]).toEqual({ token: "[REDACTED]" });
+    expect((params.list as unknown[])[1]).toBe("plain-value");
+    // 정상 BuildSpec 정보는 손상되지 않는다.
+    expect(loaded?.datasetId).toBe("air-quality");
+    expect(loaded?.sources[0].provider).toBe("datago");
+    expect(loaded?.metadata.source_url).toBe("https://example.test");
+  });
+
+  it("url source endpoint의 query credential은 저장 전에 redact한다 (S07)", () => {
+    const spec = makeSpec({
+      sources: [
+        {
+          kind: "url",
+          dataset: "air",
+          endpoint: "https://api.example.test/v1/data?serviceKey=super-secret-value&page=1",
+          params: {},
+        },
+      ],
+    });
+    saveBuildSpec("run-url", spec);
+
+    const raw = localStorage.getItem("kpubdata-studio:build-specs") as string;
+    expect(raw).not.toContain("super-secret-value");
+
+    const endpoint = loadBuildSpec("run-url")?.sources[0].endpoint ?? "";
+    expect(endpoint).toContain("__KPD_URL_SECRET_REDACTED__");
+    expect(endpoint).toContain("page=1");
+    expect(endpoint).toContain("api.example.test");
+  });
+
+  it("in-memory spec 객체는 저장 시 변형되지 않는다 (S07)", () => {
+    const secret = "abcdef0123456789abcdef0123456789ABCDEF";
+    const spec = makeSpec({
+      sources: [{ provider: "datago", dataset: "air", params: { serviceKey: secret } }],
+    });
+    saveBuildSpec("run-immutable", spec);
+    // 진행 중인 Preview/Build 요청이 쓰는 원본은 그대로여야 한다.
+    expect(spec.sources[0].params.serviceKey).toBe(secret);
+  });
+
+  it("과거 버전이 저장한 평문 credential을 load 시점에 sanitize + rewrite한다 (S07 리뷰 §2)", () => {
+    const secret = "abcdef0123456789abcdef0123456789ABCDEF";
+    // redaction 도입 이전 포맷을 흉내낸다 — 평문 serviceKey를 직접 봉투에 넣는다.
+    const legacy = makeSpec({
+      sources: [{ provider: "datago", dataset: "air", params: { sidoName: "서울", serviceKey: secret } }],
+    });
+    localStorage.setItem(
+      "kpubdata-studio:build-specs",
+      JSON.stringify({ version: 1, entries: { "run-legacy": { spec: legacy, savedAt: "2020-01-01T00:00:00.000Z" } } }),
+    );
+
+    const loaded = loadBuildSpec("run-legacy");
+    // 반환값에 raw secret이 없다(redacted 상태로만 복원).
+    expect((loaded?.sources[0].params as Record<string, unknown>).serviceKey).toBe("[REDACTED]");
+    expect((loaded?.sources[0].params as Record<string, unknown>).sidoName).toBe("서울");
+    expect(loaded?.datasetId).toBe("air-quality");
+
+    // localStorage도 즉시 sanitized 되어 raw secret이 남지 않는다.
+    const raw = localStorage.getItem("kpubdata-studio:build-specs") as string;
+    expect(raw).not.toContain(secret);
+    expect(raw).toContain("[REDACTED]");
+    // savedAt 등 나머지 entry 메타는 보존.
+    expect(JSON.parse(raw).entries["run-legacy"].savedAt).toBe("2020-01-01T00:00:00.000Z");
+  });
+
+  it("이미 sanitized된 entry는 load 시 값이 유지되고 불필요한 rewrite를 하지 않는다 (S07 리뷰 §2)", () => {
+    const spec = makeSpec({
+      sources: [{ provider: "datago", dataset: "air", params: { sidoName: "서울", serviceKey: "abcdef0123456789abcdef0123456789ABCDEF" } }],
+    });
+    saveBuildSpec("run-clean", spec); // 이 시점에 이미 redact되어 저장됨
+    const afterSave = localStorage.getItem("kpubdata-studio:build-specs") as string;
+
+    const loaded = loadBuildSpec("run-clean");
+    expect((loaded?.sources[0].params as Record<string, unknown>).serviceKey).toBe("[REDACTED]");
+    expect((loaded?.sources[0].params as Record<string, unknown>).sidoName).toBe("서울");
+    // load가 destructive rewrite를 하지 않았다 — 바이트 단위로 동일.
+    expect(localStorage.getItem("kpubdata-studio:build-specs")).toBe(afterSave);
+  });
+
   it("상한을 넘으면 오래된 항목부터 버린다", () => {
     for (let i = 0; i < SPEC_STORE_LIMIT + 5; i++) {
       saveBuildSpec(`run-${String(i).padStart(3, "0")}`, makeSpec({ datasetId: `ds-${i}` }));

--- a/src/features/build-spec/specStore.ts
+++ b/src/features/build-spec/specStore.ts
@@ -14,8 +14,10 @@
  * 저장 형태는 draftStorage와 같은 `{version, data, savedAt}` 봉투 규약을 따른다.
  */
 import { buildSpecSchema } from "@/shared/lib/schemas";
-import type { BuildSpec } from "@/shared/lib/types";
+import type { BuildSpec, JsonValue, SourceRef } from "@/shared/lib/types";
 import { ownedStorageKey } from "@/features/auth/storageOwner";
+import { redactSecrets } from "@/features/assistant/scrub";
+import { redactUrlEndpoint } from "@/features/add-data/urlRedaction";
 
 const SPEC_STORE_KEY = "kpubdata-studio:build-specs";
 
@@ -87,10 +89,42 @@ function writeEnvelope(envelope: SpecStoreEnvelope): void {
 }
 
 /**
+ * persistence boundary(#206, S07): localStorage에 쓰기 직전, API key/token 같은
+ * credential-like 값이 spec에 남지 않도록 redact한 **사본**을 만든다. 인자로 받은
+ * in-memory `spec`은 건드리지 않으므로(진행 중인 Preview/Build 요청은 원본을 그대로 씀)
+ * persistence 경계에서만 fail-safe로 동작한다.
+ *
+ * - `sources[].params`(nested object/array 포함)·`metadata`·`extra`의 secret-named key와
+ *   고엔트로피 값은 `redactSecrets`로 가린다 — Saved BuildSpec(`savedSpecs.ts`)과 동일한
+ *   정책·헬퍼.
+ * - `kind="url"` source의 `endpoint`는 query credential(`?serviceKey=...`, userinfo)만
+ *   Add Data와 같은 `redactUrlEndpoint` 규칙으로 가린다. endpoint 문자열은 `redactSecrets`에
+ *   통과시키지 않는다 — URL 전체가 고엔트로피로 판정되면 host/path까지 통째로 사라져
+ *   복원 시 스키마(https:// 강제)를 깨기 때문이다.
+ */
+function redactSpecForStorage(spec: BuildSpec): BuildSpec {
+  return {
+    ...spec,
+    sources: spec.sources.map((source) => {
+      const safe: SourceRef = {
+        ...source,
+        params: redactSecrets(source.params ?? {}) as Record<string, JsonValue>,
+      };
+      if (source.kind === "url" && source.endpoint) {
+        safe.endpoint = redactUrlEndpoint(source.endpoint).endpoint;
+      }
+      return safe;
+    }),
+    metadata: redactSecrets(spec.metadata) as Record<string, JsonValue>,
+    ...(spec.extra ? { extra: redactSecrets(spec.extra) as Record<string, JsonValue> } : {}),
+  };
+}
+
+/**
  * 실행된 빌드의 스펙을 run_id에 묶어 저장한다.
  *
  * 같은 run_id로 다시 저장하면 덮어쓴다. 항목 수가 상한을 넘으면 `savedAt` 기준으로
- * 오래된 것부터 버린다.
+ * 오래된 것부터 버린다. 저장 직전에 `redactSpecForStorage`로 credential-like 값을 가린다.
  *
  * @param runId - 빌드 실행 식별자.
  * @param spec - 실행에 사용된 빌드 스펙.
@@ -99,7 +133,7 @@ export function saveBuildSpec(runId: string, spec: BuildSpec): void {
   if (!runId) return;
 
   const envelope = readEnvelope();
-  envelope.entries[runId] = { spec, savedAt: new Date().toISOString() };
+  envelope.entries[runId] = { spec: redactSpecForStorage(spec), savedAt: new Date().toISOString() };
 
   const keys = Object.keys(envelope.entries);
   if (keys.length > SPEC_STORE_LIMIT) {
@@ -121,6 +155,12 @@ export function saveBuildSpec(runId: string, spec: BuildSpec): void {
  * 저장 이후 스펙 스키마가 바뀌었을 수 있으므로 zod로 재검증한다. 통과하지 못한
  * 항목은 편집 폼을 깨뜨리기 전에 버린다.
  *
+ * S07 리뷰 §2: 과거 버전(redaction 도입 이전)이 평문 credential을 저장해 둔 항목이 남아
+ * 있을 수 있다. 유효한 항목을 읽은 뒤 현재 저장 경계 정책(`redactSpecForStorage`)을 다시
+ * 적용하고, 결과가 저장 원본과 다르면 정리된 값으로 즉시 rewrite한 뒤 그 값을 반환한다 —
+ * raw credential을 in-memory로 되돌려주지 않는다. 이미 정리된 항목은 deep-equal이라
+ * 불필요한 rewrite를 하지 않는다.
+ *
  * @param runId - 빌드 실행 식별자.
  * @returns 저장된 스펙, 없거나 더 이상 유효하지 않으면 null.
  */
@@ -136,6 +176,13 @@ export function loadBuildSpec(runId: string): BuildSpec | null {
     delete envelope.entries[runId];
     writeEnvelope(envelope);
     return null;
+  }
+
+  const sanitized = redactSpecForStorage(result.data);
+  if (JSON.stringify(sanitized) !== JSON.stringify(result.data)) {
+    envelope.entries[runId] = { ...entry, spec: sanitized };
+    writeEnvelope(envelope);
+    return sanitized;
   }
   return result.data;
 }

--- a/src/features/kubi/KubiContent.tsx
+++ b/src/features/kubi/KubiContent.tsx
@@ -36,6 +36,10 @@ function ContextBar({ context, pageLabel, qualityLabel, sources, onContextChange
     { label: "RUN", value: context.runId ?? "—" },
     { label: "QUALITY", value: qualityLabel },
   ];
+  // Stage 근거 조회는 run이 있어야 하고, multi-source run에서는 source가 확정돼야 가능하다
+  // (source 미선택이면 evidence 로더가 stage를 fail-closed로 비운다 — evidence.ts). 단일 소스
+  // run은 Builder가 유일 소스를 자동 선택하므로 source 미선택이어도 Stage를 쓸 수 있다.
+  const stageSelectDisabled = !context.runId || (sources.length > 1 && !context.source);
   return (
     <div>
       <p className="mb-1.5 text-[10px] text-muted-foreground">현재 화면 · {pageLabel}</p>
@@ -48,7 +52,7 @@ function ContextBar({ context, pageLabel, qualityLabel, sources, onContextChange
             </p>
           </div>
         ))}
-        <label className="rounded-lg border border-border bg-muted/40 px-2.5 py-2"><span className="block text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">STAGE</span><select aria-label="Kubi 분석 Stage" className="mt-0.5 w-full bg-transparent text-xs font-medium" value={context.stage ?? ""} onChange={(event) => onContextChange("stage", event.target.value || undefined)} disabled={!context.runId}><option value="">{context.runId ? "Run 전체" : "사용 불가"}</option><option value="bronze">Bronze</option><option value="silver">Silver</option><option value="gold">Gold</option></select></label>
+        <label className="rounded-lg border border-border bg-muted/40 px-2.5 py-2"><span className="block text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">STAGE</span><select aria-label="Kubi 분석 Stage" className="mt-0.5 w-full bg-transparent text-xs font-medium" value={context.stage ?? ""} onChange={(event) => onContextChange("stage", event.target.value || undefined)} disabled={stageSelectDisabled}><option value="">{context.runId ? "Run 전체" : "사용 불가"}</option><option value="bronze">Bronze</option><option value="silver">Silver</option><option value="gold">Gold</option></select></label>
       </div>
       {context.runId && sources.length > 1 ? <label className="mt-2 block text-xs text-muted-foreground">분석 Source<select aria-label="Kubi 분석 Source" className="ml-2 rounded border border-input bg-card px-2 py-1 text-foreground" value={context.source ?? ""} onChange={(event) => onContextChange("source", event.target.value || undefined)}><option value="">먼저 선택하세요</option>{sources.map((source) => <option key={source} value={source}>{source}</option>)}</select></label> : null}
       <p className="mt-2 text-[11px] text-muted-foreground">{!context.runId ? "Run을 선택하면 Run 및 Stage 근거를 분석할 수 있습니다." : sources.length > 1 && !context.source ? "이 Run에는 source가 여러 개 있습니다. 분석할 source를 먼저 선택하세요." : !context.stage ? "Run 전체를 분석 중입니다. SQL을 생성하려면 Silver 또는 Gold를 선택하세요." : context.stage === "bronze" ? "Bronze에서는 Generated SQL을 실행할 수 없습니다. Silver 또는 Gold를 선택하세요." : `${context.stage === "gold" ? "Gold" : "Silver"} schema 기반 질문 및 SQL 생성 가능`}</p>
@@ -402,7 +406,7 @@ export function evidenceHref(turn: KubiTurn, ref: KubiEvidenceRef): string | nul
   return null;
 }
 
-function EvidenceSection({ turn }: { turn: KubiTurn }) {
+export function EvidenceSection({ turn }: { turn: KubiTurn }) {
   const [selected, setSelected] = useState<KubiEvidenceRef | null>(null);
   const refs = turn.response?.evidenceRefs ?? [];
   const rejected = turn.error?.kind === "hallucinated_refs" ? turn.error.rejectedRefs : [];

--- a/src/features/kubi/KubiLiveSources.test.tsx
+++ b/src/features/kubi/KubiLiveSources.test.tsx
@@ -99,4 +99,30 @@ describe("Kubi live Builder-confirmed source picker", () => {
     expect(await screen.findByText("이 Run에는 source가 여러 개 있습니다. 분석할 source를 먼저 선택하세요.")).toBeInTheDocument();
     expect(screen.getByLabelText("Kubi 분석 Source")).toHaveValue("");
   });
+
+  it("disables the Stage select on a multi-source Run until a source is chosen (A4)", async () => {
+    vi.spyOn(datasetsApi, "listBuildStages").mockResolvedValue(stages("run-a", ["provider.a", "provider.b"]));
+    render(<Harness initialPath="/kubi?run=run-a&stage=gold" />);
+
+    // multi-source인데 source 미선택 → Stage 선택 불가(evidence가 fail-closed로 빠지므로).
+    expect(await screen.findByLabelText("Kubi 분석 Stage")).toBeDisabled();
+    // disabled 상태여도 안내는 유지된다.
+    expect(screen.getByText("이 Run에는 source가 여러 개 있습니다. 분석할 source를 먼저 선택하세요.")).toBeInTheDocument();
+
+    fireEvent.change(await screen.findByLabelText("Kubi 분석 Source"), { target: { value: "provider.b" } });
+    await waitFor(() => expect(screen.getByLabelText("Kubi 분석 Stage")).toBeEnabled());
+  });
+
+  it("keeps the Stage select usable on a single-source Run even without an explicit source (A4)", async () => {
+    vi.spyOn(datasetsApi, "listBuildStages").mockResolvedValue(stages("run-a", ["provider.only"]));
+    render(<Harness initialPath="/kubi?run=run-a" />);
+    await waitFor(() => expect(datasetsApi.listBuildStages).toHaveBeenCalled());
+    expect(screen.getByLabelText("Kubi 분석 Stage")).toBeEnabled();
+  });
+
+  it("disables the Stage select when there is no Run in context (A4)", async () => {
+    vi.spyOn(datasetsApi, "listBuildStages").mockResolvedValue(stages("run-a", ["provider.a"]));
+    render(<Harness initialPath="/kubi" />);
+    expect(await screen.findByLabelText("Kubi 분석 Stage")).toBeDisabled();
+  });
 });

--- a/src/features/kubi/actions.test.ts
+++ b/src/features/kubi/actions.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadBuildSpec, saveBuildSpec } from "@/features/build-spec/specStore";
 import { loadDraft } from "@/features/build-spec/draftStorage";
 import { buildFormValuesSchema } from "@/shared/lib/schemas";
@@ -154,6 +154,69 @@ describe("previewBuildSpecPatch / applyBuildSpecPatch (#256 §10)", () => {
 
     expect(result.valid).toBe(false);
     expect(loadBuildSpec("run-1")).toEqual(BASE_SPEC);
+  });
+
+  describe("복원된 redaction marker는 fail-closed (S07 리뷰 §1)", () => {
+    // 실제 secret이 들어간 spec을 저장하면 specStore가 "[REDACTED]"로 redact해 보관한다.
+    const SPEC_WITH_SECRET: BuildSpec = {
+      ...BASE_SPEC,
+      sources: [
+        {
+          ...BASE_SPEC.sources[0],
+          params: { region: "서울", serviceKey: "A7vK2mQ9xP4rT8yW3nC6dF1hJ5sL0zB4uH8" },
+        },
+      ],
+    };
+
+    it("preview: before spec에 [REDACTED]가 있으면 credential field를 안 건드려도 거부한다", () => {
+      saveBuildSpec("run-x", SPEC_WITH_SECRET);
+      expect(
+        (loadBuildSpec("run-x")?.sources[0].params as Record<string, unknown>).serviceKey,
+      ).toBe("[REDACTED]");
+
+      const action: Extract<KubiAction, { type: "PATCH_BUILDSPEC" }> = {
+        type: "PATCH_BUILDSPEC",
+        runId: "run-x",
+        patch: [{ op: "replace", path: "/metadata/note", value: "updated" }],
+        reason: "test",
+      };
+      const preview = previewBuildSpecPatch(action);
+      expect(preview.ok).toBe(false);
+      if (!preview.ok) expect(preview.reason).toMatch(/시크릿 값이 제거/);
+    });
+
+    it("apply: after spec에 [REDACTED]가 남아 있으면 Builder /validate를 호출하지 않는다", async () => {
+      const validate = vi.fn(async () => ({ valid: true, errors: [] as string[] }));
+      const withRedacted: BuildSpec = {
+        ...BASE_SPEC,
+        sources: [{ ...BASE_SPEC.sources[0], params: { region: "서울", serviceKey: "[REDACTED]" } }],
+      };
+      const result = await applyBuildSpecPatch("run-x", withRedacted, validate);
+      expect(validate).not.toHaveBeenCalled();
+      expect(result.valid).toBe(false);
+    });
+
+    it("apply: marker 없는 실제 credential은 통과시킨다(회귀 방지)", async () => {
+      const validate = vi.fn(async () => ({ valid: true, errors: [] as string[] }));
+      const result = await applyBuildSpecPatch("run-x", SPEC_WITH_SECRET, validate);
+      expect(validate).toHaveBeenCalledTimes(1);
+      expect(result.valid).toBe(true);
+    });
+
+    it.each([
+      { label: "__KPD_PARAMS_SECRET_REDACTED__", value: "__KPD_PARAMS_SECRET_REDACTED__" },
+      { label: "__KPD_URL_SECRET_REDACTED__", value: "__KPD_URL_SECRET_REDACTED__" },
+      { label: "__SCRUBBED_*", value: "__SCRUBBED_abc_0__" },
+    ])("apply: $label marker도 계속 차단한다", async ({ value }) => {
+      const validate = vi.fn(async () => ({ valid: true, errors: [] as string[] }));
+      const spec: BuildSpec = {
+        ...BASE_SPEC,
+        sources: [{ ...BASE_SPEC.sources[0], params: { region: "서울", k: value } }],
+      };
+      const result = await applyBuildSpecPatch("run-x", spec, validate);
+      expect(validate).not.toHaveBeenCalled();
+      expect(result.valid).toBe(false);
+    });
   });
 });
 

--- a/src/features/kubi/actions.ts
+++ b/src/features/kubi/actions.ts
@@ -11,6 +11,7 @@ import { loadBuildSpec, saveBuildSpec } from "@/features/build-spec/specStore";
 import { saveDraft } from "@/features/build-spec/draftStorage";
 import { validateSpec } from "@/features/validation/api";
 import { hasSecretPlaceholder, isSecretKey, redactSecrets } from "@/features/assistant/scrub";
+import { jsonValueHasRedactedSecret } from "@/features/add-data/paramsRedaction";
 import { buildFormValuesSchema } from "@/shared/lib/schemas";
 import type { BuildSpec, JsonValue } from "@/shared/lib/types";
 import type { KubiAction, BuildSpecPatchOp } from "./schema";
@@ -87,6 +88,16 @@ export function previewBuildSpecPatch(
     };
   }
 
+  // 로컬 보관 정책상 저장된 spec에서 secret 값이 이미 redaction marker로 지워져 있으면
+  // fail-closed — marker가 남은 채로 patch를 적용하면 validate 단계에서 literal placeholder가
+  // Builder로 제출된다(S07 리뷰 §1). credential 재입력은 Provider 설정 화면 몫이다.
+  if (jsonValueHasRedactedSecret(before)) {
+    return {
+      ok: false,
+      reason: "저장된 BuildSpec에서 시크릿 값이 제거되어 있어(로컬 보관 정책) Kubi가 patch할 수 없습니다. serviceKey/apiKey/token 등은 Provider 설정 화면에서 다시 입력하세요.",
+    };
+  }
+
   const invalidPath = action.patch.find((op) => !ALLOWED_PATCH_PATH.test(op.path));
   if (invalidPath) {
     return {
@@ -108,6 +119,12 @@ export function previewBuildSpecPatch(
   try {
     const clone = structuredClone(before) as unknown as Record<string, unknown>;
     for (const op of action.patch) applyPointerOp(clone, op);
+    if (jsonValueHasRedactedSecret(clone)) {
+      return {
+        ok: false,
+        reason: "patch 결과에 redaction marker가 남아 있어 적용할 수 없습니다. 해당 credential을 실제 값으로 다시 입력하세요.",
+      };
+    }
     return { ok: true, before, after: clone as unknown as BuildSpec };
   } catch (cause) {
     return { ok: false, reason: cause instanceof Error ? cause.message : "patch를 적용할 수 없습니다." };
@@ -126,7 +143,9 @@ export async function applyBuildSpecPatch(
   after: BuildSpec,
   validate: typeof validateSpec = validateSpec,
 ): Promise<{ valid: boolean; errors: string[] }> {
-  if (hasSecretPlaceholder(after)) {
+  // `[REDACTED]`(specStore/savedSpecs) · `__KPD_*_REDACTED__`(draft) · `__SCRUBBED_*` 모두
+  // 차단한다 — 어느 marker든 남은 채로 validate하면 literal placeholder가 Builder로 간다.
+  if (jsonValueHasRedactedSecret(after)) {
     return { valid: false, errors: ["해결되지 않은 시크릿 플레이스홀더가 포함되어 있습니다."] };
   }
   const result = await validate(after);

--- a/src/features/kubi/crossCheck.test.ts
+++ b/src/features/kubi/crossCheck.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { crossCheckKubiResponse } from "./crossCheck";
-import type { KubiEvidence, KubiKnownRefs, KubiStructuredResponse } from "./types";
+import { datasetRunMembershipRef, type KubiEvidence, type KubiKnownRefs, type KubiStructuredResponse } from "./types";
 
 function makeEvidence(overrides: Partial<KubiEvidence> = {}): KubiEvidence {
   return {
@@ -17,6 +17,7 @@ function makeKnownRefs(overrides: Partial<KubiKnownRefs> = {}): KubiKnownRefs {
   return {
     datasetIds: new Set(["ds-1"]),
     runIds: new Set(["run-1"]),
+    datasetRunMemberships: new Set([datasetRunMembershipRef("ds-1", "run-1")]),
     providers: new Set(["datago"]),
     qualityResultIds: new Set(["src::missing::max_null_ratio::price"]),
     schemaDriftIds: new Set(["column_added::region"]),
@@ -117,6 +118,66 @@ describe("crossCheckKubiResponse (#256 hallucination gate)", () => {
       makeEvidence(),
       makeKnownRefs(),
     );
+    expect(result.response.suggestedActions).toHaveLength(1);
+  });
+
+  it("rejects OPEN_QUALITY referencing a missing dataset", () => {
+    const result = crossCheckKubiResponse(
+      makeResponse({
+        suggestedActions: [
+          { type: "OPEN_QUALITY", datasetId: "missing-dataset", runId: "run-1", reason: "품질을 확인하세요" },
+        ],
+      }),
+      makeEvidence(),
+      makeKnownRefs(),
+    );
+
+    expect(result.response.suggestedActions).toHaveLength(0);
+    expect(result.rejectedActions[0]).toContain("missing-dataset");
+  });
+
+  it("rejects OPEN_QUALITY when dataset and run exist separately but the membership differs", () => {
+    const result = crossCheckKubiResponse(
+      makeResponse({
+        suggestedActions: [
+          { type: "OPEN_QUALITY", datasetId: "ds-1", runId: "run-2", reason: "품질을 확인하세요" },
+        ],
+      }),
+      makeEvidence(),
+      makeKnownRefs({
+        runIds: new Set(["run-1", "run-2"]),
+        datasetRunMemberships: new Set([datasetRunMembershipRef("ds-2", "run-2")]),
+      }),
+    );
+
+    expect(result.response.suggestedActions).toHaveLength(0);
+    expect(result.rejectedActions[0]).toContain("소속");
+  });
+
+  it("fails closed when Builder membership lookup was unavailable", () => {
+    const result = crossCheckKubiResponse(
+      makeResponse({
+        suggestedActions: [
+          { type: "OPEN_QUALITY", datasetId: "ds-1", runId: "run-1", reason: "품질을 확인하세요" },
+        ],
+      }),
+      makeEvidence({ unavailable: ["runs"], partial: true }),
+      makeKnownRefs({ datasetRunMemberships: new Set() }),
+    );
+
+    expect(result.response.suggestedActions).toHaveLength(0);
+    expect(result.rejectedActions[0]).toContain("확인할 수 없음");
+  });
+
+  it("keeps dataset-only OPEN_QUALITY when no run was requested", () => {
+    const result = crossCheckKubiResponse(
+      makeResponse({
+        suggestedActions: [{ type: "OPEN_QUALITY", datasetId: "ds-1", reason: "최신 품질을 확인하세요" }],
+      }),
+      makeEvidence(),
+      makeKnownRefs(),
+    );
+
     expect(result.response.suggestedActions).toHaveLength(1);
   });
 

--- a/src/features/kubi/crossCheck.ts
+++ b/src/features/kubi/crossCheck.ts
@@ -7,6 +7,7 @@
  * 답변이 실제로 나은(evidence 기반) 부분은 그대로 사용자에게 보여준다.
  */
 import type { KubiEvidence, KubiEvidenceRef, KubiKnownRefs, KubiStructuredResponse } from "./types";
+import { datasetRunMembershipRef } from "./types";
 import type { KubiAction } from "./schema";
 
 export interface CrossCheckResult {
@@ -58,6 +59,12 @@ function isKnownAction(
       }
       if (action.runId && !known.runIds.has(action.runId)) {
         return { ok: false, reason: `OPEN_QUALITY: evidence에 없는 run "${action.runId}"` };
+      }
+      if (action.runId && !known.datasetRunMemberships.has(datasetRunMembershipRef(action.datasetId, action.runId))) {
+        return {
+          ok: false,
+          reason: `OPEN_QUALITY: run "${action.runId}"의 dataset "${action.datasetId}" 소속을 Builder evidence에서 확인할 수 없음`,
+        };
       }
       return { ok: true };
     case "PATCH_BUILDSPEC":

--- a/src/features/kubi/evidence.ts
+++ b/src/features/kubi/evidence.ts
@@ -16,16 +16,30 @@ import {
   listDatasetRuns,
 } from "@/features/datasets/api";
 import { loadBuildSpec } from "@/features/build-spec/specStore";
+import { getBuildSpecSnapshot } from "@/features/runs/api/runDetail";
 import { redactSecrets } from "@/features/assistant/scrub";
 import { builderApi } from "@/shared/lib/builderApi";
+import { parse as parseYaml } from "yaml";
 import type { KubiContext, KubiEvidence, KubiEvidenceSource, KubiKnownRefs } from "./types";
-import { qualityResultRefId, stageEvidenceRefId } from "./types";
+import { datasetRunMembershipRef, qualityResultRefId, stageEvidenceRefId } from "./types";
 
 async function settle<T>(promise: Promise<T>): Promise<{ ok: true; value: T } | { ok: false }> {
   try {
     return { ok: true, value: await promise };
   } catch {
     return { ok: false };
+  }
+}
+
+/** Builder canonical spec snapshot에서 명시적인 dataset_id만 읽는다. */
+function datasetIdFromSpecSnapshot(spec: string): string | null {
+  try {
+    const parsed = parseYaml(spec) as unknown;
+    if (!parsed || typeof parsed !== "object" || !("dataset_id" in parsed)) return null;
+    const datasetId = (parsed as Record<string, unknown>).dataset_id;
+    return typeof datasetId === "string" && datasetId.length > 0 ? datasetId : null;
+  } catch {
+    return null;
   }
 }
 
@@ -57,6 +71,7 @@ export async function loadKubiEvidence(
   const knownRefs: KubiKnownRefs = {
     datasetIds: new Set(),
     runIds: new Set(),
+    datasetRunMemberships: new Set(),
     providers: new Set(),
     qualityResultIds: new Set(),
     schemaDriftIds: new Set(),
@@ -123,6 +138,9 @@ export async function loadKubiEvidence(
       // getDataset 성공 응답의 latest_run_id — Builder 가 확인한 값이다(schema 상 string 이나
       // 방어적으로 falsy 를 거른다).
       confirmRunId(dataset.latest_run_id);
+      if (dataset.latest_run_id) {
+        knownRefs.datasetRunMemberships.add(datasetRunMembershipRef(dataset.dataset_id, dataset.latest_run_id));
+      }
       evidence.deepLinks.datasetDetail = `/datasets/${encodeURIComponent(dataset.dataset_id)}`;
       evidence.deepLinks.qualityCenter = `/quality?dataset=${encodeURIComponent(dataset.dataset_id)}`;
       runId = runId ?? dataset.latest_run_id;
@@ -138,7 +156,12 @@ export async function loadKubiEvidence(
         finishedAt: run.finished_at,
       }));
       // listDatasetRuns 성공 응답의 run_id — Builder 가 직접 반환한 실제 run 이다.
-      for (const run of runsResult.value.runs) confirmRunId(run.run_id);
+      for (const run of runsResult.value.runs) {
+        confirmRunId(run.run_id);
+        if (datasetResult.ok && datasetResult.value.dataset_id === context.datasetId) {
+          knownRefs.datasetRunMemberships.add(datasetRunMembershipRef(datasetResult.value.dataset_id, run.run_id));
+        }
+      }
     } else {
       unavailable.push("runs");
     }
@@ -150,6 +173,11 @@ export async function loadKubiEvidence(
     // safeRunIds 에는 넣지 않는다 — 아래 getBuildQuality / listBuildStages 는 nonexistent run 에
     // 404 를 주므로(Builder OpenAPI SSOT), 그 요청이 정상 응답할 때만 confirmRunId 로 등록한다.
     evidence.deepLinks.buildDetail = `/builds/${encodeURIComponent(runId)}`;
+
+    // 오래된 run이 recent run-list 범위 밖이어도 Builder canonical spec snapshot은 해당
+    // run이 실행된 dataset_id를 직접 제공한다. 다른 membership 근거와 독립적으로 조회하고,
+    // 실패/파싱 불가는 이 근거만 제외한다.
+    const specSnapshotPromise = settle(getBuildSpecSnapshot(runId, signal));
 
     const storedSpec = loadBuildSpec(runId);
     if (storedSpec) {
@@ -203,6 +231,15 @@ export async function loadKubiEvidence(
       };
     } else {
       unavailable.push("quality");
+    }
+
+    const specSnapshotResult = await specSnapshotPromise;
+    if (specSnapshotResult.ok && specSnapshotResult.value.run_id === runId) {
+      const snapshotDatasetId = datasetIdFromSpecSnapshot(specSnapshotResult.value.spec);
+      if (snapshotDatasetId) {
+        confirmRunId(runId);
+        knownRefs.datasetRunMemberships.add(datasetRunMembershipRef(snapshotDatasetId, runId));
+      }
     }
 
     // stage evidence는 source/stage 둘 다 문맥에 있을 때만 의미가 있다. source가 없으면

--- a/src/features/kubi/runProvenance.integration.test.ts
+++ b/src/features/kubi/runProvenance.integration.test.ts
@@ -6,8 +6,9 @@
  * 에서 "확인되지 않은 route runId 가 known 으로 새는" 회귀를 막지 못한다. 세 케이스를
  * 결합 흐름으로 고정한다.
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { saveBuildSpec } from "@/features/build-spec/specStore";
+import * as runDetailApi from "@/features/runs/api/runDetail";
 import type { BuildSpec } from "@/shared/lib/types";
 import { loadKubiEvidence } from "./evidence";
 import { crossCheckKubiResponse } from "./crossCheck";
@@ -15,6 +16,7 @@ import type { KubiContext, KubiStructuredResponse } from "./types";
 
 afterEach(() => {
   localStorage.clear();
+  vi.restoreAllMocks();
 });
 
 function response(overrides: Partial<KubiStructuredResponse> = {}): KubiStructuredResponse {
@@ -128,5 +130,108 @@ describe("run provenance — loadKubiEvidence → crossCheckKubiResponse", () =>
       knownRefs,
     );
     expect(accepted.response.suggestedActions).toHaveLength(1);
+  });
+
+  it("Case D — 다른 dataset 소속으로 확인된 run의 OPEN_QUALITY를 거부한다", async () => {
+    const context: KubiContext = {
+      page: "quality",
+      datasetId: "air-quality",
+      runId: "population-2026-08-13",
+    };
+    const { evidence, knownRefs } = await loadKubiEvidence(context);
+
+    // dataset과 run은 각각 Builder 응답으로 존재가 확인된다. 다만 run은 population 소속이다.
+    expect(knownRefs.datasetIds.has("air-quality")).toBe(true);
+    expect(knownRefs.runIds.has("population-2026-08-13")).toBe(true);
+
+    const checked = crossCheckKubiResponse(
+      response({
+        suggestedActions: [
+          {
+            type: "OPEN_QUALITY",
+            datasetId: "air-quality",
+            runId: "population-2026-08-13",
+            reason: "품질을 확인하세요",
+          },
+        ],
+      }),
+      evidence,
+      knownRefs,
+    );
+
+    expect(checked.response.suggestedActions).toHaveLength(0);
+    expect(checked.rejectedActions[0]).toContain("소속");
+  });
+
+  it("Case E — recent 10/latest 밖의 old run도 spec snapshot dataset_id가 일치하면 OPEN_QUALITY를 유지한다", async () => {
+    const oldRunId = "old-air-run-outside-recent-window";
+    vi.spyOn(runDetailApi, "getBuildSpecSnapshot").mockResolvedValue({
+      run_id: oldRunId,
+      spec: "dataset_id: air-quality\n",
+      spec_digest: `sha256:${"0".repeat(64)}`,
+    });
+
+    const { evidence, knownRefs } = await loadKubiEvidence({
+      page: "build-detail",
+      datasetId: "air-quality",
+      runId: oldRunId,
+    });
+    expect(evidence.recentRuns?.some((run) => run.runId === oldRunId)).toBe(false);
+    expect(evidence.dataset?.latestRunId).not.toBe(oldRunId);
+
+    const checked = crossCheckKubiResponse(
+      response({
+        suggestedActions: [{ type: "OPEN_QUALITY", datasetId: "air-quality", runId: oldRunId, reason: "품질" }],
+      }),
+      evidence,
+      knownRefs,
+    );
+
+    expect(checked.response.suggestedActions).toHaveLength(1);
+  });
+
+  it("Case F — old run spec snapshot의 dataset_id가 다르면 OPEN_QUALITY를 거부한다", async () => {
+    const oldRunId = "old-population-run-outside-recent-window";
+    vi.spyOn(runDetailApi, "getBuildSpecSnapshot").mockResolvedValue({
+      run_id: oldRunId,
+      spec: "dataset_id: population\n",
+      spec_digest: `sha256:${"1".repeat(64)}`,
+    });
+
+    const { evidence, knownRefs } = await loadKubiEvidence({
+      page: "build-detail",
+      datasetId: "air-quality",
+      runId: oldRunId,
+    });
+    const checked = crossCheckKubiResponse(
+      response({
+        suggestedActions: [{ type: "OPEN_QUALITY", datasetId: "air-quality", runId: oldRunId, reason: "품질" }],
+      }),
+      evidence,
+      knownRefs,
+    );
+
+    expect(checked.response.suggestedActions).toHaveLength(0);
+    expect(checked.rejectedActions[0]).toContain("소속");
+  });
+
+  it("Case G — old run spec lookup 실패이고 다른 membership 근거도 없으면 fail-closed한다", async () => {
+    const oldRunId = "old-run-without-membership-evidence";
+    vi.spyOn(runDetailApi, "getBuildSpecSnapshot").mockRejectedValue(new Error("snapshot unavailable"));
+
+    const { evidence, knownRefs } = await loadKubiEvidence({
+      page: "build-detail",
+      datasetId: "air-quality",
+      runId: oldRunId,
+    });
+    const checked = crossCheckKubiResponse(
+      response({
+        suggestedActions: [{ type: "OPEN_QUALITY", datasetId: "air-quality", runId: oldRunId, reason: "품질" }],
+      }),
+      evidence,
+      knownRefs,
+    );
+
+    expect(checked.response.suggestedActions).toHaveLength(0);
   });
 });

--- a/src/features/kubi/types.ts
+++ b/src/features/kubi/types.ts
@@ -137,6 +137,8 @@ export interface KubiEvidence {
 export interface KubiKnownRefs {
   datasetIds: Set<string>;
   runIds: Set<string>;
+  /** Builder dataset detail/run-list가 직접 확인한 dataset_id + run_id 소속 쌍. */
+  datasetRunMemberships: Set<string>;
   providers: Set<string>;
   qualityResultIds: Set<string>;
   schemaDriftIds: Set<string>;
@@ -148,6 +150,11 @@ export interface KubiKnownRefs {
    * 검증되지 않은 값이므로 Builder `/query`로 그대로 보내지 않는다(crossCheck).
    */
   sourceKeys: Set<string>;
+}
+
+/** dataset/run pair를 충돌 없이 trust set key로 직렬화한다. */
+export function datasetRunMembershipRef(datasetId: string, runId: string): string {
+  return JSON.stringify([datasetId, runId]);
 }
 
 /** LLM 구조화 응답이 근거로 인용한 evidence 조각. */

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -7,9 +7,9 @@
  */
 import { saveBuildSpec } from "@/features/build-spec/specStore";
 import { serializeSpec } from "@/features/build-spec/specMapping";
-import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
+import { builderApi, isRealBuilderEnabled, type BuildSummary } from "@/shared/lib/builderApi";
 import { DEMO_DATASETS, type DemoDataset } from "@/shared/lib/demoDatasets";
-import type { BuildListItem, BuildRun, BuildSpec } from "@/shared/lib/types";
+import type { BuildListItem, BuildRun, BuildRunStatus, BuildSpec } from "@/shared/lib/types";
 
 const MOCK_TIME = "1970-01-01T00:00:00.000Z";
 
@@ -46,10 +46,32 @@ export type BuilderJobStatus =
   | "failed"
   | "cancelled";
 
+/**
+ * 실행이 어떤 Builder 표면을 타는지(그리고 그 run_id)를 호출부(useBuildJob)에 알린다.
+ *
+ * - `async`: POST /builds + polling. 사용자 취소는 POST /builds/{run_id}/cancel로 전달해야 한다.
+ * - `sync`: POST /build (file source, ADR 0014). server-side 협조적 취소 경로가 없다.
+ */
+export interface BuildExecutionHandle {
+  runId: string;
+  mode: "sync" | "async";
+}
+
+/**
+ * BuildSpec에 file source가 하나라도 포함되면 true.
+ *
+ * ADR 0014: file source의 async build(POST /builds)는 현재 지원 범위 밖이다 — file이
+ * 섞인 spec은 전체를 sync POST /build로 실행해야 한다. "첫 source만" 보지 않고 전체를 본다.
+ */
+export function specHasFileSource(spec: BuildSpec): boolean {
+  return spec.sources.some((source) => source.kind === "file");
+}
+
 export async function executeBuild(
   spec: BuildSpec,
   signal?: AbortSignal,
   onJobStatus?: (status: BuilderJobStatus) => void,
+  onHandle?: (handle: BuildExecutionHandle) => void,
 ): Promise<BuildRun> {
   if (!isRealBuilderEnabled()) {
     const mockRun: BuildRun = {
@@ -67,7 +89,17 @@ export async function executeBuild(
   // 실연동 모드에서는 실제 실행 시각을 기록한다(이력/상세 화면에서 잘못된 1970 값 방지).
   const runId = generateRunId(spec.datasetId);
   const startedAt = new Date().toISOString();
-  const result = await runAsyncBuild(spec, runId, startedAt, signal, onJobStatus);
+
+  // file source가 포함된 spec은 async(POST /builds)가 아니라 sync(POST /build)로
+  // 실행한다(ADR 0014). public_api/url만 있으면 기존 async job 표면을 그대로 쓴다.
+  let result: BuildRun;
+  if (specHasFileSource(spec)) {
+    onHandle?.({ runId, mode: "sync" });
+    result = await runSyncBuild(spec, runId, startedAt, signal);
+  } else {
+    onHandle?.({ runId, mode: "async" });
+    result = await runAsyncBuild(spec, runId, startedAt, signal, onJobStatus);
+  }
 
   // Builder는 spec을 영속화하지 않으므로(#120), 이후 편집 화면이 기존 스펙을 복원할 수
   // 있도록 Studio가 실행 시점의 스펙을 run_id에 묶어 보관한다. 저장 실패는 무시되며
@@ -176,6 +208,53 @@ async function runAsyncBuild(
   return { id: finalRunId, spec, status: "succeeded", startedAt, finishedAt };
 }
 
+/**
+ * file source가 포함된 spec을 동기 `POST /build`로 실행한다(ADR 0014).
+ *
+ * async job 표면(POST /builds + polling)을 타지 않으므로 job status 콜백/취소
+ * endpoint는 관여하지 않는다. 성공/부분 실패 판정은 async 최종 build 응답과 동일한
+ * 규칙(최상위 error → outcomes[].error → 기본 문구, #75)을 따라 UI가 async 결과와
+ * 똑같이 소비할 수 있는 BuildRun을 돌려준다.
+ */
+async function runSyncBuild(
+  spec: BuildSpec,
+  runId: string,
+  startedAt: string,
+  signal: AbortSignal | undefined,
+): Promise<BuildRun> {
+  const response = await builderApi.build(serializeSpec(spec), runId, signal);
+  const finishedAt = new Date().toISOString();
+  const finalRunId = response.run_id || runId;
+
+  if (response.status !== "ok") {
+    const outcomeReason = response.outcomes.find((outcome) => outcome.error)?.error;
+    const reason =
+      ("error" in response && response.error) || outcomeReason || "일부 소스 빌드가 실패했습니다.";
+    return { id: finalRunId, spec, status: "failed", startedAt, finishedAt, error: reason };
+  }
+  return { id: finalRunId, spec, status: "succeeded", startedAt, finishedAt };
+}
+
+/**
+ * Builder `GET /builds`의 BuildSummary.status(canonical 어휘: ok/failed/cancelled)를
+ * Studio BuildRunStatus로 매핑한다.
+ *
+ * 취소된 run은 `cancelled`로 오며 절대 failed로 붕괴시키지 않는다(#S04). Builder 어휘
+ * 밖의 값은 조용히 성공으로 넘기지 않고 fail-closed(failed)로 둔다.
+ */
+function mapBuildSummaryStatus(status: BuildSummary["status"]): BuildRunStatus {
+  switch (status) {
+    case "ok":
+      return "succeeded";
+    case "cancelled":
+      return "cancelled";
+    case "failed":
+      return "failed";
+    default:
+      return "failed";
+  }
+}
+
 /** 데모 카탈로그 항목을 목록/이력 UI용 BuildSpec으로 변환한다. */
 function mockSpec(dataset: DemoDataset): BuildSpec {
   return {
@@ -235,7 +314,7 @@ export async function listBuilds(limit?: number): Promise<BuildListItem[]> {
   return response.builds.map((summary) => ({
     id: summary.run_id,
     title: null, // Builder GET /builds는 title을 제공하지 않음
-    status: summary.status === "ok" ? "succeeded" : "failed",
+    status: mapBuildSummaryStatus(summary.status),
     startedAt: summary.started_at ?? null, // 누락 또는 null을 명시적 null로 정규화
     finishedAt: summary.finished_at ?? null, // 누락 또는 null을 명시적 null로 정규화
   }));

--- a/src/features/runs/components/KubiRunAnalysis.test.tsx
+++ b/src/features/runs/components/KubiRunAnalysis.test.tsx
@@ -121,12 +121,20 @@ describe("KubiRunAnalysis", () => {
     expect(cancel).toHaveBeenCalledWith("turn-1");
   });
 
-  it("shows the answer and evidence summary once the turn completes", () => {
+  it("renders the answer as Markdown and surfaces evidence via the shared EvidenceSection (A2)", () => {
     const turn = baseTurn({
       status: "ok",
+      evidence: {
+        fetchedAt: "2026-08-18T00:00:00Z",
+        context: { page: "builds", runId: "run-1" },
+        deepLinks: {},
+        unavailable: [],
+        partial: false,
+        stage: { refId: "run-1::air::silver", stage: "silver", source: "air", status: "failed", available: false, rowCount: null },
+      } as KubiTurn["evidence"],
       response: {
-        answer: "이 Run은 source air의 silver 단계에서 실패했습니다.",
-        evidenceRefs: [{ kind: "stage", id: "air::silver", label: "air / silver" }],
+        answer: "이 Run은 **source air**의 silver 단계에서 실패했습니다.",
+        evidenceRefs: [{ kind: "stage", id: "run-1::air::silver", label: "air / silver" }],
         generatedSql: null,
         suggestedActions: [],
       },
@@ -136,8 +144,41 @@ describe("KubiRunAnalysis", () => {
 
     render(<KubiRunAnalysis onClose={vi.fn()} onAskMore={vi.fn()} />);
 
-    expect(screen.getByText("이 Run은 source air의 silver 단계에서 실패했습니다.")).toBeInTheDocument();
+    // Drawer와 동일한 안전 Markdown 렌더러를 재사용한다 — "**"는 리터럴로 남지 않는다.
+    expect(screen.getByText("source air").tagName).toBe("STRONG");
+    expect(screen.queryByText(/\*\*source air\*\*/)).not.toBeInTheDocument();
+
+    // 근거는 KubiContent와 동일한 EvidenceSection(Disclosure)로 제공된다.
+    fireEvent.click(screen.getByRole("button", { name: /근거 1개/ }));
     expect(screen.getByText("air / silver")).toBeInTheDocument();
+  });
+
+  it("surfaces rejected/hallucinated evidence even when the turn status is ok (A3)", () => {
+    const turn = baseTurn({
+      status: "ok",
+      response: {
+        answer: "요약된 정상 답변입니다.",
+        evidenceRefs: [],
+        generatedSql: null,
+        suggestedActions: [],
+      },
+      error: {
+        kind: "hallucinated_refs",
+        message: "제외된 근거: run:ghost-run",
+        rejectedRefs: ["run:ghost-run"],
+        rejectedActions: [],
+      },
+    });
+    useKubiSessionMock.mockReturnValue(session({ turns: [turn], isStale: () => false }));
+    useAssistConfigMock.mockReturnValue({ isConfigured: true });
+
+    render(<KubiRunAnalysis onClose={vi.fn()} onAskMore={vi.fn()} />);
+
+    // 정상 answer는 그대로 보이고,
+    expect(screen.getByText("요약된 정상 답변입니다.")).toBeInTheDocument();
+    // 제외된 근거가 있었다는 사실은 숨기지 않는다(role="alert").
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("제외된 근거: run:ghost-run");
   });
 
   it("shows an error notice when the turn failed", () => {

--- a/src/features/runs/components/KubiRunAnalysis.tsx
+++ b/src/features/runs/components/KubiRunAnalysis.tsx
@@ -13,7 +13,8 @@
  */
 import { useMemo } from "react";
 import { useAssistConfig } from "@/features/assistant/config";
-import { ErrorNotice } from "@/features/kubi/KubiContent";
+import { ErrorNotice, EvidenceSection } from "@/features/kubi/KubiContent";
+import { MarkdownContent } from "@/features/kubi/MarkdownContent";
 import { useKubiSession } from "@/features/kubi/useKubiSession";
 import { Button, Card } from "@/shared/ui";
 
@@ -85,31 +86,19 @@ export function KubiRunAnalysis({ onClose, onAskMore }: KubiRunAnalysisProps) {
 
               {turn.response ? (
                 <>
-                  <p className="whitespace-pre-wrap leading-6 text-foreground">{turn.response.answer}</p>
+                  {/* Drawer(KubiContent)와 동일한 안전 Markdown 렌더러를 재사용한다(#320). */}
+                  <MarkdownContent>{turn.response.answer}</MarkdownContent>
 
-                  {turn.evidence?.partial ? (
-                    <p className="text-xs text-muted-foreground">
-                      일부 evidence를 확인하지 못했습니다: {turn.evidence.unavailable.join(", ")}
+                  {/* status가 "ok"여도 cross-check가 근거/action/SQL을 제외했으면 그 사실을
+                      숨기지 않는다 — KubiContent와 동일한 경고 + EvidenceSection 표현을 쓴다.
+                      status === "error" 전용 ErrorNotice(위)와는 별개다. */}
+                  {turn.error?.kind === "hallucinated_refs" ? (
+                    <p role="alert" className="text-[11px] text-amber-700 dark:text-amber-400">
+                      {turn.error.message}
                     </p>
                   ) : null}
 
-                  {turn.response.evidenceRefs.length > 0 ? (
-                    <div>
-                      <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                        Evidence
-                      </p>
-                      <ul className="mt-1 flex flex-wrap gap-1.5">
-                        {turn.response.evidenceRefs.map((ref) => (
-                          <li
-                            key={`${ref.kind}:${ref.id}`}
-                            className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[10px]"
-                          >
-                            {ref.label}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ) : null}
+                  <EvidenceSection turn={turn} />
                 </>
               ) : null}
             </div>

--- a/src/features/runs/useBuildJob.ts
+++ b/src/features/runs/useBuildJob.ts
@@ -7,9 +7,19 @@
  * 상태(queued/running/...)를 builderStatus로 노출한다(#245).
  */
 import { useCallback, useEffect, useRef, useState } from "react";
-import { executeBuild, type BuilderJobStatus } from "@/features/runs/api";
-import { ApiError, extractErrorMessage } from "@/shared/lib/builderApi";
-import type { BuildRun, BuildSpec } from "@/shared/lib/types";
+import { executeBuild, type BuildExecutionHandle, type BuilderJobStatus } from "@/features/runs/api";
+import { ApiError, builderApi, extractErrorMessage } from "@/shared/lib/builderApi";
+import type { BuildRun, BuildRunStatus, BuildSpec } from "@/shared/lib/types";
+
+/**
+ * executeBuild가 돌려준 terminal BuildRun.status(succeeded/failed/cancelled)를 hook
+ * 상태로 옮긴다. cancelled를 failed로 붕괴시키지 않는다(#S04).
+ */
+function toJobStatus(runStatus: BuildRunStatus): BuildJobStatus {
+  if (runStatus === "succeeded") return "succeeded";
+  if (runStatus === "cancelled") return "cancelled";
+  return "failed";
+}
 
 export type BuildJobStatus = "idle" | "running" | "succeeded" | "failed" | "cancelled";
 
@@ -22,6 +32,15 @@ export interface BuildJob {
   run?: BuildRun;
   /** 실패 시 오류 메시지 */
   error?: string;
+  /**
+   * 사용자가 진행 중인 요청을 클라이언트에서 중단했음을 나타내는 local-only 표식.
+   *
+   * sync `POST /build`(file source, ADR 0014)는 server-side 협조적 취소 경로가 없어,
+   * fetch abort는 Builder 실행을 멈추지 않는다 — 서버에서는 빌드가 계속 성공/실패할 수
+   * 있다. 그래서 이 경우 status를 canonical `cancelled`로 확정하지 않고, "요청 중단"이라는
+   * 클라이언트 관점 사실만 이 플래그로 노출한다. wire/canonical BuildRun status는 아니다.
+   */
+  interrupted: boolean;
   /** 빌드 실행을 시작한다. */
   start: (spec: BuildSpec) => Promise<void>;
   /** 진행 중인 실행을 취소한다. */
@@ -38,27 +57,47 @@ export function useBuildJob(): BuildJob {
   const [builderStatus, setBuilderStatus] = useState<BuilderJobStatus>();
   const [run, setRun] = useState<BuildRun>();
   const [error, setError] = useState<string>();
+  const [interrupted, setInterrupted] = useState(false);
+  // 언마운트/재시작(lifecycle) 취소 전용 컨트롤러. 사용자 "취소"와는 의미가 다르다.
   const controllerRef = useRef<AbortController | null>(null);
+  // 진행 중인 실행이 어떤 Builder 표면(sync/async)을 타는지와 그 run_id. 사용자 취소가
+  // async job에 대해 POST /builds/{run_id}/cancel을 호출할 수 있게 한다.
+  const handleRef = useRef<BuildExecutionHandle | null>(null);
 
   const start = useCallback(async (spec: BuildSpec) => {
     if (controllerRef.current) return;
     const controller = new AbortController();
     controllerRef.current = controller;
+    handleRef.current = null;
     setStatus("running");
     setBuilderStatus(undefined);
     setError(undefined);
     setRun(undefined);
+    setInterrupted(false);
     try {
-      const result = await executeBuild(spec, controller.signal, (jobStatus) => {
-        if (!controller.signal.aborted) setBuilderStatus(jobStatus);
-      });
+      const result = await executeBuild(
+        spec,
+        controller.signal,
+        (jobStatus) => {
+          if (!controller.signal.aborted) setBuilderStatus(jobStatus);
+        },
+        (handle) => {
+          handleRef.current = handle;
+        },
+      );
       if (controller.signal.aborted) return;
       setRun(result);
-      setStatus(result.status === "succeeded" ? "succeeded" : "failed");
-      if (result.status !== "succeeded") setError(result.error ?? "일부 소스 빌드가 실패했습니다.");
+      // succeeded/failed/cancelled를 그대로 보존한다 — cancelled를 failed로 덮지 않는다(#S04).
+      setStatus(toJobStatus(result.status));
+      if (result.status === "failed") setError(result.error ?? "일부 소스 빌드가 실패했습니다.");
     } catch (cause) {
       if (controller.signal.aborted) {
-        setStatus("cancelled");
+        // AbortController.abort()는 (a) sync build의 사용자 취소, (b) 언마운트
+        // lifecycle cleanup에서만 온다(async 취소는 컨트롤러를 abort하지 않는다).
+        // 어느 쪽이든 fetch abort는 Builder server-side 실행 결과를 알 수 없으므로
+        // succeeded/failed/cancelled 어느 terminal도 확정하지 않는다 — running에서만
+        // 벗어난다. "요청 중단" 사실은 cancel()이 setInterrupted(true)로 이미 남겼다.
+        setStatus((current) => (current === "running" ? "idle" : current));
         return;
       }
       setStatus("failed");
@@ -72,16 +111,31 @@ export function useBuildJob(): BuildJob {
     } finally {
       // 실행이 끝나면(성공/실패/취소) 더 이상 유효하지 않은 컨트롤러 참조를 정리한다.
       if (controllerRef.current === controller) controllerRef.current = null;
+      handleRef.current = null;
     }
   }, []);
 
   const cancel = useCallback(() => {
+    const handle = handleRef.current;
+    if (handle?.mode === "async") {
+      // 실제 Builder에 협조적 취소를 요청하고 polling은 그대로 둔다 — "취소된 척"
+      // 하며 polling을 끊지 않고, Builder가 cancelling → cancelled terminal에 도달하는
+      // 것을 관찰해 최종 상태(result.status)로 판정한다(#S03). 이미 terminal이거나
+      // 네트워크 오류면 polling 결과가 authoritative하므로 여기서는 삼킨다 —
+      // cancel 요청 실패를 local `cancelled`로 바꾸지 않는다.
+      void builderApi.cancelBuildJob(handle.runId).catch(() => {});
+      return;
+    }
+    // sync `POST /build`(file source, ADR 0014) 또는 아직 run_id를 모르는 상태:
+    // server-side 협조적 취소 경로가 없다. fetch abort는 클라이언트 요청만 중단할 뿐
+    // Builder 실행을 취소하지 않으므로, 성공/실패/취소 중 무엇도 확정하지 않고
+    // "요청을 클라이언트에서 중단했다"는 사실만 남긴다.
     controllerRef.current?.abort();
-    setStatus((current) => (current === "running" ? "cancelled" : current));
+    setInterrupted(true);
   }, []);
 
   // 언마운트 시 진행 중인 실행을 중단해 unmount 이후 setState를 방지한다(#73).
   useEffect(() => () => controllerRef.current?.abort(), []);
 
-  return { status, builderStatus, run, error, start, cancel };
+  return { status, builderStatus, run, error, interrupted, start, cancel };
 }

--- a/src/pages/AddDataPage.tsx
+++ b/src/pages/AddDataPage.tsx
@@ -457,6 +457,7 @@ export function AddDataPage() {
             isStale={isStale}
             jobStatus={job.status}
             jobError={job.error}
+            jobInterrupted={job.interrupted}
             runId={job.run?.id}
             onBuild={() => {
               if (specResult.spec) void job.start(specResult.spec);

--- a/src/pages/BuildsPage.tsx
+++ b/src/pages/BuildsPage.tsx
@@ -525,14 +525,47 @@ function RunDetailPanel({
   const openKubiDrawer = useUIStore((state) => state.openKubiDrawer);
   const seedKubiQuestion = useKubiStore((state) => state.seedQuestion);
   const { isConfigured } = useAssistConfig();
+  const [searchParams] = useSearchParams();
 
   // "이 Run 분석"은 더 이상 전역 Kubi drawer를 자동으로 열지 않는다(#255 §2) — 대신 이 Run summary
   // 바로 아래에 inline card를 펼친다. Run을 바꾸면 카드를 닫아, 이전 Run의 분석 결과가 새 Run의
   // context에서 유효한 것처럼 보이지 않게 한다(#256 stale-context guard와 같은 원칙).
   const [showKubiAnalysis, setShowKubiAnalysis] = useState(false);
+  // "이번 분석 클릭은 접수됐지만 아직 seed하지 않은" 상태. URL context가 canonical해질 때까지
+  // 보류한다. 클릭 1회 = 이 flag 1회 set = seed 1회. run이 바뀌면 폐기한다.
+  const [analyzePending, setAnalyzePending] = useState(false);
+
   useEffect(() => {
     setShowKubiAnalysis(false);
+    setAnalyzePending(false);
   }, [runId]);
+
+  const analyzeQuestion = `Run ${runId}의 상태와 실패 원인을 분석해줘.`;
+
+  // "context가 canonical하다" = 현재 URL이 이미 normalizeBuildContextSearch의 고정점이다.
+  // BuildsPage의 정규화 effect와 정확히 같은 helper·같은 동등성 판정을 재사용한다(로직 복제 금지).
+  // spec/stages가 아직 settle되지 않았으면(추가로 dataset/stage/source가 붙을 수 있으므로)
+  // 겉보기 no-op이어도 canonical로 보지 않는다. error도 settle로 취급해 영구 대기를 막는다.
+  const contextCanonical = useMemo(() => {
+    const specSettled = specState.status === "loaded" || specState.status === "error";
+    const stagesSettled = stagesState.status === "loaded" || stagesState.status === "error";
+    if (!specSettled || !stagesSettled) return false;
+    return (
+      normalizeBuildContextSearch(searchParams, specState, stagesState).toString() ===
+      searchParams.toString()
+    );
+  }, [searchParams, specState, stagesState]);
+
+  // 보류된 분석 의도는 URL이 canonical해진 뒤에 seed한다. seed 직전에 pending flag를 내려
+  // 같은 클릭에 대한 재실행을 막는다(effect가 유일한 seeder다). 다음 "이 Run 분석" 클릭은
+  // flag를 다시 set하므로 재분석/에러 후 재시도는 그대로 가능하다 — 중복 방지는 "한 클릭당
+  // 한 번"이지 "run 수명 동안 한 번"이 아니다. (seed는 KubiRunAnalysis mount 시 useKubiSession의
+  // 기존 pending-seed 소비 effect가 ask()로 실행한다 — 그 경로/atomic consumeSeed는 미변경.)
+  useEffect(() => {
+    if (!analyzePending || !isConfigured || !contextCanonical) return;
+    setAnalyzePending(false);
+    seedKubiQuestion(analyzeQuestion);
+  }, [analyzePending, isConfigured, contextCanonical, analyzeQuestion, seedKubiQuestion]);
 
   const sources = stagesState.status === "loaded" ? stagesState.data.sources : [];
   const outcome = stagesState.status === "loaded" ? summarizeMultiSourceOutcome(sources) : "unavailable";
@@ -617,14 +650,17 @@ function RunDetailPanel({
             variant="secondary"
             className="ml-auto"
             onClick={() => {
+              // 클릭은 즉시 inline card를 연다.
+              setShowKubiAnalysis(true);
               // API Key가 없으면 seed하지 않는다 — pending seed는 항상 useKubiSession의
               // 일반 ask()로 소비되고, ask()는 isConfigured가 아니면 no_key 에러를 만든다
               // (#286 후속 보완). inline card는 그래도 열어 KubiRunAnalysis가 no-key 안내를
               // 보여주게 한다.
-              if (isConfigured) {
-                seedKubiQuestion(`Run ${runId}의 상태와 실패 원인을 분석해줘.`);
-              }
-              setShowKubiAnalysis(true);
+              if (!isConfigured) return;
+              // 클릭은 "이번 분석 의도"만 접수한다. 실제 seed는 위 effect가 URL이 canonical해진
+              // 뒤 1회 실행한다 — canonical이면 사실상 즉시. thin context로 turn이 고정돼 곧바로
+              // stale로 빠지는 race를 막고(C1), 재분석/에러 후 재시도는 그대로 가능하다.
+              setAnalyzePending(true);
             }}
           >
             이 Run 분석

--- a/src/pages/DatasetDetailPage.tsx
+++ b/src/pages/DatasetDetailPage.tsx
@@ -179,6 +179,46 @@ export function DatasetDetailPage() {
   const selectedQualityResults = qualityResultsForSource(qualityState.data, selectedSource);
   const selectedDrift = qualityState.data?.schema_drift[selectedSource] ?? [];
 
+  // AI 탭에 직접 진입/새로고침해도 tab click 경로(goToTab("ai"))와 동일한 canonical Kubi
+  // context를 만든다. Kubi(KubiContent)는 route의 ?run=&source=&stage=만 문맥으로 읽으므로
+  // (context.ts), 화면이 확정한 선택을 URL에 되반영하지 않으면 AI 탭이 dataset 수준
+  // evidence만 받는다(#319 후속, QualityPage와 동일 패턴). replace로만 갱신하고, 이미
+  // 유효하게 선택된 값·invalid 상태는 건드리지 않아 update loop를 만들지 않는다.
+  useEffect(() => {
+    if (selectedTab !== "ai" || core.status !== "loaded" || invalidRun || invalidSource) return;
+    const next = new URLSearchParams(searchParams);
+    let changed = false;
+    if (selectedRunId && !requestedRun) {
+      next.set("run", selectedRunId);
+      changed = true;
+    }
+    if (stagesState.status === "loaded" && selectedSource) {
+      if (!requestedSource) {
+        next.set("source", selectedSource);
+        changed = true;
+      }
+      if (!requestedStage) {
+        next.set("stage", selectedStage);
+        changed = true;
+      }
+    }
+    if (changed) setSearchParams(next, { replace: true });
+  }, [
+    selectedTab,
+    core.status,
+    invalidRun,
+    invalidSource,
+    stagesState.status,
+    selectedRunId,
+    requestedRun,
+    selectedSource,
+    requestedSource,
+    requestedStage,
+    selectedStage,
+    searchParams,
+    setSearchParams,
+  ]);
+
   // Run 전체 상태("ok"/"failed"/"cancelled")와 선택된 source·stage 상태("completed"/"failed"/
   // "not_run"/"unavailable")는 서로 다른 vocabulary를 쓰는 별개 scope다 — 한 run에 여러 source가
   // 있으면 선택된 source의 stage는 completed/PASS인데 run 전체는 다른 source의 실패로 failed일 수

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -18,7 +18,8 @@ import { listBuilds } from "@/features/runs/api";
 import { SUGGESTED_QUESTIONS } from "@/features/kubi/suggestedQuestions";
 import { useKubiStore } from "@/features/kubi/useKubiSession";
 import { useUIStore } from "@/shared/hooks/useUIStore";
-import type { BuildListItem, BuildRunStatus } from "@/shared/lib/types";
+import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
+import type { BuildListItem } from "@/shared/lib/types";
 import {
   Button,
   Card,
@@ -26,14 +27,13 @@ import {
   LinkButton,
   PageHeader,
   Skeleton,
-  type StatusValue,
 } from "@/shared/ui";
 
 interface DashboardStats {
-  datasetCount: number;
-  buildSuccess: number;
-  validationWarn: number;
-  running: number;
+  datasetCount: number | null;
+  buildSuccess: number | null;
+  validationWarn: number | null;
+  running: number | null;
 }
 
 interface LoadingState {
@@ -50,16 +50,12 @@ interface ApiState {
  * 신규 사용자 여부를 판단한다.
  * dataset/build이 하나도 없으면 신규 사용자로 간주한다.
  */
-function isNewUser(stats: DashboardStats): boolean {
-  return stats.datasetCount === 0 && stats.buildSuccess === 0 && stats.validationWarn === 0 && stats.running === 0;
-}
-
 export function HomePage() {
   const [builds, setBuilds] = useState<BuildListItem[]>([]);
   const [stats, setStats] = useState<DashboardStats>({
     datasetCount: 0,
     buildSuccess: 0,
-    validationWarn: 0,
+    validationWarn: null,
     running: 0,
   });
   const [loading, setLoading] = useState<LoadingState>({
@@ -76,7 +72,12 @@ export function HomePage() {
 
     const fetchData = async () => {
       try {
+        const realBuilder = isRealBuilderEnabled();
         const buildList = await listBuilds();
+        // 비어 있는 목록은 신규 사용자 분기에 충분하며, 불필요한 monitoring 호출로 막지 않는다.
+        const monitoring = realBuilder && buildList.length > 0
+          ? await builderApi.getMonitoringBuilds().catch(() => null)
+          : null;
         if (active) {
           setBuilds(buildList);
           setApiState((prev) => ({ ...prev, builds: "success" }));
@@ -84,15 +85,19 @@ export function HomePage() {
           const succeeded = buildList.filter((b) => b.status === "succeeded").length;
           const running = buildList.filter((b) => b.status === "running" || b.status === "queued").length;
 
+          const monitoredSuccess = monitoring?.availability === "available"
+            ? monitoring.buckets.reduce((sum, bucket) => sum + bucket.success, 0)
+            : null;
           setStats({
-            datasetCount: succeeded,
-            buildSuccess: succeeded,
-            validationWarn: 0,
-            running,
+            datasetCount: realBuilder ? null : succeeded,
+            buildSuccess: realBuilder ? monitoredSuccess : succeeded,
+            validationWarn: null,
+            // GET /builds의 real 계약은 terminal summary만 제공하므로 active 수로 해석하지 않는다.
+            running: realBuilder ? null : running,
           });
           setApiState((prev) => ({ ...prev, stats: "success" }));
         }
-      } catch (error) {
+      } catch {
         if (active) {
           setApiState((prev) => ({ ...prev, builds: "error", stats: "error" }));
         }
@@ -118,7 +123,7 @@ export function HomePage() {
     })
     .slice(0, 5);
 
-  const isNew = stats.datasetCount === 0 && stats.buildSuccess === 0;
+  const isNew = apiState.builds === "success" && builds.length === 0;
 
   return (
     <main className="flex flex-1 flex-col gap-8 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
@@ -266,7 +271,7 @@ function KpiCards({ stats, loading, apiState }: { stats: DashboardStats; loading
   if (apiState === "error") {
     return (
       <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        {["DATASETS", "BUILD SUCCESS", "VALIDATION WARN", "RUNNING"].map((label) => (
+        {["DATASETS", "SUCCEEDED (24H)", "VALIDATION WARN", "RUNNING"].map((label) => (
           <Card key={label} variant="error" className="flex items-center justify-between">
             <span className="text-sm text-muted-foreground">{label}</span>
             <span className="text-xl font-semibold tracking-tight text-muted-foreground">—</span>
@@ -279,7 +284,7 @@ function KpiCards({ stats, loading, apiState }: { stats: DashboardStats; loading
   return (
     <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
       <KpiCard label="DATASETS" value={stats.datasetCount} loading={loading} />
-      <KpiCard label="BUILD SUCCESS" value={stats.buildSuccess} loading={loading} variant="success" />
+      <KpiCard label="SUCCEEDED (24H)" value={stats.buildSuccess} loading={loading} variant="success" />
       <KpiCard label="VALIDATION WARN" value={stats.validationWarn} loading={loading} variant="error" />
       <KpiCard label="RUNNING" value={stats.running} loading={loading} />
     </section>
@@ -293,7 +298,7 @@ function KpiCard({
   variant = "default",
 }: {
   label: string;
-  value: number;
+  value: number | null;
   loading: boolean;
   variant?: "default" | "success" | "error";
 }) {
@@ -314,7 +319,7 @@ function KpiCard({
     <Card className="flex items-center justify-between">
       <span className="text-sm text-muted-foreground">{label}</span>
       <span className={`text-2xl font-semibold tracking-tight ${colorClass}`}>
-        {value}
+        {value === null ? "확인 불가" : value}
       </span>
     </Card>
   );
@@ -380,8 +385,8 @@ function QualitySection() {
       <PageHeader eyebrow="품질" title="품질 경고" className="mb-4" />
       <Card className="p-0">
         <EmptyState
-          title="품질 경고가 없습니다"
-          description="모든 빌드가 정상적으로 완료되었습니다"
+          title="품질 경고 집계 확인 불가"
+          description="Builder monitoring API는 validation warning 집계를 제공하지 않습니다. 각 빌드의 품질 화면에서 확인하세요."
         />
       </Card>
     </section>

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -931,6 +931,11 @@ export function NewBuildPage() {
                 {job.status === "cancelled" ? (
                   <span className="text-sm text-muted-foreground">실행이 취소되었습니다.</span>
                 ) : null}
+                {job.interrupted && job.status !== "cancelled" ? (
+                  <span className="text-sm text-muted-foreground">
+                    요청을 중단했습니다. 서버 빌드 결과는 확인되지 않았습니다.
+                  </span>
+                ) : null}
               </div>
 
               <div className="flex flex-wrap items-center gap-3 border-t border-border pt-4">

--- a/src/pages/NewBuildPage.tsx
+++ b/src/pages/NewBuildPage.tsx
@@ -11,6 +11,11 @@ import { useForm } from "react-hook-form";
 import { useParams, useSearchParams } from "react-router-dom";
 import { clearDraft, hasDraft, loadDraft, saveDraft } from "@/features/build-spec/draftStorage";
 import { parseSourceParams } from "@/features/build-spec/paramsInput";
+import {
+  jsonValueHasRedactedSecret,
+  redactSourceParamsText,
+  sourceParamsHasRedactedSecret,
+} from "@/features/add-data/paramsRedaction";
 import { previewBuild } from "@/features/preview/api";
 import { useBuild } from "@/features/runs/useBuild";
 import { useBuildJob } from "@/features/runs/useBuildJob";
@@ -158,6 +163,14 @@ function toBuildSpec(
   values: BuildFormValues,
   base?: BuildSpec | null,
 ): { spec?: BuildSpec; error?: string } {
+  // 저장된 초안/스펙을 복원했는데 sourceParams의 secret 값이 이미 redaction marker로 지워져
+  // 있으면 fail-closed — marker를 실제 파라미터처럼 Builder에 제출하지 않는다(S07, Add Data
+  // Workbench의 `buildSpecFromDraft`와 동일 정책). 사용자가 값을 다시 입력해야 한다.
+  // `[REDACTED]`(specStore/savedSpecs) · `__KPD_*_REDACTED__`(draft) · `__SCRUBBED_*` 모두 포함.
+  if (sourceParamsHasRedactedSecret(values.sourceParams)) {
+    return { error: "저장된 초안에서 시크릿이 포함된 파라미터 값이 제거되었습니다. 파라미터를 다시 입력해주세요." };
+  }
+
   const parsedParams = parseSourceParams(values.sourceParams);
   if (parsedParams.error) {
     return { error: parsedParams.error };
@@ -179,6 +192,12 @@ function toBuildSpec(
     // 원본 메타데이터를 먼저 펼쳐 폼이 다루지 않는 키를 유지하고, outputPath만 덮어쓴다.
     metadata: { ...base?.metadata, outputPath: values.outputPath },
   };
+
+  // 폼이 편집하지 않는 영역(base의 sources[1+], 원본 metadata)에 redaction marker가 남아
+  // 있으면 여기서 fail-closed — sources[0] sourceParams 검사만으로는 놓치는 경로다.
+  if (jsonValueHasRedactedSecret(candidate)) {
+    return { error: "저장된 스펙에서 시크릿 값이 제거되었습니다. 해당 credential을 다시 입력해주세요." };
+  }
 
   const result = buildSpecSchema.safeParse(candidate);
   if (!result.success) {
@@ -209,6 +228,16 @@ function toFormValues(spec: BuildSpec): BuildFormValues {
     exportFormats: spec.exports.map((e) => e.format),
     outputPath: typeof spec.metadata.outputPath === "string" ? spec.metadata.outputPath : "",
   };
+}
+
+/**
+ * localStorage 초안 저장 경계 정책(S07): sourceParams JSON에 credential-like 값이 들어와도
+ * 평문으로 남지 않도록 redact한다. 저장 직전(saveCurrentDraft)과 복원 직후(restoreDraft의
+ * read-time rewrite) 양쪽에서 같은 함수를 써 초안 저장본이 항상 이 불변식을 만족하게 한다.
+ * Add Data draft(`saveAddDataDraft`)와 동일한 `paramsRedaction` 헬퍼·sentinel을 재사용한다.
+ */
+function redactDraftForStorage(values: BuildFormValues): BuildFormValues {
+  return { ...values, sourceParams: redactSourceParamsText(values.sourceParams).text };
 }
 
 interface PreviewState {
@@ -418,7 +447,10 @@ export function NewBuildPage() {
   // 뜨지 않도록 draftAvailable은 건드리지 않는다(배너는 새 마운트 시 복원용).
   function saveCurrentDraft() {
     const current = getValues();
-    saveDraft(current);
+    // persistence boundary(S07): credential-like 값이 localStorage 초안에 평문으로 남지
+    // 않도록 저장 직전에 redact한다. 화면의 in-memory 폼 상태(current)는 그대로 두므로
+    // 진행 중인 Preview/Build는 영향이 없다.
+    saveDraft(redactDraftForStorage(current));
     reset(current);
     setDraftSaved(true);
   }
@@ -426,7 +458,10 @@ export function NewBuildPage() {
   // 저장된 초안을 복원해 기본 정보 단계로 이동한다.
   function restoreDraft() {
     // 저장된 초안을 버전·스키마로 검증해 복원한다. 버전 불일치/손상 시 null을 받는다(#84).
-    const saved = loadDraft<BuildFormValues>(buildFormValuesSchema);
+    // 과거 버전이 평문 secret을 저장해 둔 초안이면 복원 시점에 redact본으로 다시 저장되고
+    // (loadDraft의 sanitize rewrite), 반환값도 redact된 상태다 — 아래 toBuildSpec 가드가
+    // marker를 감지해 재입력을 요구한다.
+    const saved = loadDraft<BuildFormValues>(buildFormValuesSchema, undefined, redactDraftForStorage);
     if (!saved) {
       // 깨진 값이 남아 배너가 반복되지 않도록 정리하고, 이동/숨김은 하지 않는다.
       clearDraft();

--- a/src/pages/ProviderPage.tsx
+++ b/src/pages/ProviderPage.tsx
@@ -10,7 +10,13 @@
  * - connected/failed/not_configured + latency/checked_at/error category
  * - raw secret DOM/error/log 비노출
  */
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  builderApi,
+  isRealBuilderEnabled,
+  type ProviderSummary,
+  type ProviderTestResponse,
+} from "@/shared/lib/builderApi";
 import {
   Card,
   Button,
@@ -24,15 +30,28 @@ interface ProviderConfig {
   id: string;
   name: string;
   description: string;
-  status: "connected" | "failed" | "not_configured";
+  /** `unknown` = configured/사용 가능하지만 connection을 아직 점검하지 않음. */
+  status: "connected" | "failed" | "not_configured" | "unknown";
   latency?: number;
   checkedAt?: string;
   errorCategory?: string;
 }
 
 interface CredentialForm {
-  providerId: string;
   credential: string;
+}
+
+/** Builder GET /providers 요약을 화면 모델로 변환한다(연결 상태는 별도 status 점검으로 채운다). */
+function mapProviderSummary(summary: ProviderSummary): ProviderConfig {
+  return {
+    id: summary.provider,
+    name: summary.provider,
+    description: summary.requires_credential
+      ? "자격 증명이 필요한 제공 기관입니다."
+      : "자격 증명 없이 사용할 수 있는 제공 기관입니다.",
+    status:
+      summary.requires_credential && !summary.configured ? "not_configured" : "unknown",
+  };
 }
 
 export function ProviderPage() {
@@ -40,53 +59,78 @@ export function ProviderPage() {
   const [selectedProvider, setSelectedProvider] = useState<ProviderConfig | null>(null);
   const [isTesting, setIsTesting] = useState(false);
   const [showCredentialForm, setShowCredentialForm] = useState(false);
-  const [credentialForm, setCredentialForm] = useState<CredentialForm>({
-    providerId: "",
-    credential: "",
-  });
+  const [credentialForm, setCredentialForm] = useState<CredentialForm>({ credential: "" });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    loadProviders();
-  }, []);
-
-  const loadProviders = async () => {
+  const loadProviders = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch("/api/providers");
-      if (!response.ok) {
-        throw new Error("Failed to load providers");
+      if (isRealBuilderEnabled()) {
+        // real mode: GET /providers가 canonical source다. 실패를 mock 성공으로
+        // 위장하지 않는다 — catch에서 명시적 error/빈 목록으로 떨어진다(#S01).
+        const response = await builderApi.listProviders();
+        const mapped = response.providers.map(mapProviderSummary);
+        setProviders(mapped);
+        setSelectedProvider((current) =>
+          current ? mapped.find((p) => p.id === current.id) ?? null : null,
+        );
+      } else {
+        // 명시적 mock/demo mode에서만 mock 목록을 쓴다.
+        setProviders(getMockProviders());
       }
-      const data = await response.json();
-      setProviders(data.providers || []);
-    } catch (err) {
+    } catch {
       setError("Provider 정보를 불러올 수 없습니다");
-      setProviders(getMockProviders());
+      setProviders([]);
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    void loadProviders();
+  }, [loadProviders]);
 
   const handleProviderSelect = (provider: ProviderConfig) => {
     setSelectedProvider(provider);
     setShowCredentialForm(false);
   };
 
+  /** status 점검/테스트 응답을 목록과 선택 상태에 반영한다. */
+  const applyStatus = useCallback((res: ProviderTestResponse) => {
+    const patch: Partial<ProviderConfig> = {
+      status: res.status,
+      latency: res.latency_ms,
+      checkedAt: res.checked_at,
+      errorCategory: res.error_category,
+    };
+    setProviders((list) => list.map((p) => (p.id === res.provider ? { ...p, ...patch } : p)));
+    setSelectedProvider((current) =>
+      current && current.id === res.provider ? { ...current, ...patch } : current,
+    );
+  }, []);
+
   const handleConnectionTest = async () => {
     if (!selectedProvider) return;
+    const provider = selectedProvider.id;
 
     setIsTesting(true);
+    setError(null);
     try {
-      const response = await fetch(`/api/providers/${selectedProvider.id}/test`, {
-        method: "POST",
-      });
-      if (!response.ok) {
-        throw new Error("Connection test failed");
+      if (isRealBuilderEnabled()) {
+        // 연결 테스트는 GET /providers/{provider}/status를 쓴다 — 임의 POST /test가 아니다(#S02).
+        applyStatus(await builderApi.getProviderStatus(provider));
+      } else {
+        applyStatus({
+          provider,
+          status: "connected",
+          configured: true,
+          latency_ms: 42,
+          checked_at: new Date().toISOString(),
+        });
       }
-      await loadProviders();
-    } catch (err) {
+    } catch {
       setError("연결 테스트에 실패했습니다");
     } finally {
       setIsTesting(false);
@@ -94,37 +138,51 @@ export function ProviderPage() {
   };
 
   const handleCredentialSubmit = async () => {
+    if (!selectedProvider || !credentialForm.credential) return;
+    const provider = selectedProvider.id;
+    setError(null);
     try {
-      const response = await fetch(`/api/providers/${credentialForm.providerId}/credentials`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          credential: credentialForm.credential,
-        }),
-      });
-      if (!response.ok) {
-        throw new Error("Failed to save credential");
+      if (isRealBuilderEnabled()) {
+        // PUT /providers/{provider}/credential, body는 { credential } 하나뿐. 원문은
+        // response로 기대하지 않고, 선택된 provider의 canonical id를 URL에 쓴다(#S02).
+        await builderApi.putProviderCredential(provider, credentialForm.credential);
+        setCredentialForm({ credential: "" });
+        setShowCredentialForm(false);
+        await loadProviders();
+      } else {
+        applyStatus({
+          provider,
+          status: "connected",
+          configured: true,
+          latency_ms: 42,
+          checked_at: new Date().toISOString(),
+        });
+        setCredentialForm({ credential: "" });
+        setShowCredentialForm(false);
       }
-      await loadProviders();
-      setCredentialForm({ providerId: "", credential: "" });
-      setShowCredentialForm(false);
-    } catch (err) {
+    } catch {
       setError("Credential 저장에 실패했습니다");
     }
   };
 
   const handleCredentialDelete = async () => {
     if (!selectedProvider) return;
-
+    const provider = selectedProvider.id;
+    setError(null);
     try {
-      const response = await fetch(`/api/providers/${selectedProvider.id}/credentials`, {
-        method: "DELETE",
-      });
-      if (!response.ok) {
-        throw new Error("Failed to delete credential");
+      if (isRealBuilderEnabled()) {
+        await builderApi.deleteProviderCredential(provider);
+        await loadProviders();
+      } else {
+        applyStatus({
+          provider,
+          status: "not_configured",
+          configured: false,
+          latency_ms: 0,
+          checked_at: new Date().toISOString(),
+        });
       }
-      await loadProviders();
-    } catch (err) {
+    } catch {
       setError("Credential 삭제에 실패했습니다");
     }
   };
@@ -140,11 +198,13 @@ export function ProviderPage() {
       connected: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300",
       failed: "bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300",
       not_configured: "bg-muted text-muted-foreground",
+      unknown: "bg-muted text-muted-foreground",
     };
     const labels = {
       connected: "연결됨",
       failed: "연결 실패",
       not_configured: "미설정",
+      unknown: "연결 확인 필요",
     };
     return { className: styles[status], label: labels[status] };
   };

--- a/src/shared/lib/builderApi.schema.ts
+++ b/src/shared/lib/builderApi.schema.ts
@@ -122,6 +122,23 @@ export const artifactsResponseSchema = z.object({
   files: z.array(z.string()),
 });
 
+/** GET /builds/{run_id}/manifest 응답. Builder 계약은 확장 필드를 허용하므로 보존한다. */
+export const buildManifestResponseSchema = z.object({
+  build_id: z.string(),
+  started_at: z.string(),
+  finished_at: z.string(),
+  schema_version: z.string(),
+  status: z.enum(["ok", "failed", "cancelled"]).optional(),
+  partial: z.boolean().optional(),
+  inputs: z.array(z.string()).optional(),
+  outputs: z.array(z.string()).optional(),
+  warnings: z.array(z.string()).optional(),
+  errors: z.array(z.string()).optional(),
+  row_counts: z.record(z.string(), z.number().int()).optional(),
+  inputs_fingerprint: z.string().nullable().optional(),
+  created_by: z.string().nullable().optional(),
+}).loose();
+
 /**
  * Preview 컬럼 스키마 항목
  */
@@ -206,6 +223,7 @@ export type BuildOk = z.infer<typeof buildOkSchema>;
 export type BuildFailed = z.infer<typeof buildFailedSchema>;
 export type BuildResponse = z.infer<typeof buildResponseSchema>;
 export type ArtifactsResponse = z.infer<typeof artifactsResponseSchema>;
+export type BuildManifestResponse = z.infer<typeof buildManifestResponseSchema>;
 export type PreviewColumn = z.infer<typeof previewColumnSchema>;
 export type PreviewDiffItem = z.infer<typeof previewDiffItemSchema>;
 export type PreviewTransformSummary = z.infer<typeof previewTransformSummarySchema>;

--- a/src/shared/lib/builderApi.test.ts
+++ b/src/shared/lib/builderApi.test.ts
@@ -5,6 +5,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { API_BASE } from "@/shared/config/env";
 import { builderApi, setAuthErrorCallback, setAuthTokenProvider } from "./builderApi";
 
 function jsonResponse(status: number, body: unknown): Response {
@@ -145,5 +146,91 @@ describe("auth error callback on 401 (#189, S4)", () => {
 
     await expect(builderApi.version()).rejects.toMatchObject({ status: 403 });
     expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+describe("provider status / credential CRUD contract (#S02)", () => {
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  function callOf(fetchMock: ReturnType<typeof vi.spyOn>) {
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    return { url, init };
+  }
+
+  it("getProviderStatus → GET /providers/{provider}/status", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        provider: "datago",
+        status: "connected",
+        configured: true,
+        latency_ms: 12,
+        checked_at: "2026-08-31T00:00:00.000Z",
+      }),
+    );
+
+    await builderApi.getProviderStatus("datago");
+
+    const { url, init } = callOf(fetchMock);
+    expect(url).toBe(`${API_BASE}/providers/datago/status`);
+    expect(init.method ?? "GET").toBe("GET");
+  });
+
+  it("putProviderCredential → PUT /providers/{provider}/credential with { credential } body", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(200, {}));
+
+    await builderApi.putProviderCredential("datago", "raw-secret");
+
+    const { url, init } = callOf(fetchMock);
+    expect(url).toBe(`${API_BASE}/providers/datago/credential`);
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body as string)).toEqual({ credential: "raw-secret" });
+  });
+
+  it("deleteProviderCredential → DELETE /providers/{provider}/credential with no body", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(200, {}));
+
+    await builderApi.deleteProviderCredential("datago");
+
+    const { url, init } = callOf(fetchMock);
+    expect(url).toBe(`${API_BASE}/providers/datago/credential`);
+    expect(init.method).toBe("DELETE");
+    expect(init.body).toBeUndefined();
+  });
+});
+
+describe("async build cancellation contract (#S03)", () => {
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("cancelBuildJob → POST /builds/{run_id}/cancel", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        run_id: "weather-1",
+        status: "cancelling",
+        created_at: "2026-08-31T00:00:00.000Z",
+        updated_at: "2026-08-31T00:00:01.000Z",
+      }),
+    );
+
+    const job = await builderApi.cancelBuildJob("weather-1");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${API_BASE}/builds/weather-1/cancel`);
+    expect(init.method).toBe("POST");
+    expect(job.status).toBe("cancelling");
+  });
+
+  it("does not retry cancelBuildJob on 5xx (비멱등 side effect)", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(500, { error: "boom" }));
+
+    await expect(builderApi.cancelBuildJob("weather-1")).rejects.toMatchObject({ status: 500 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -490,6 +490,14 @@ export const builderApi = {
   artifacts: (runId: string, signal?: AbortSignal) =>
     apiFetch(`/artifacts/${encodeURIComponent(runId)}`, { signal }, schemas.artifactsResponseSchema),
 
+  /** GET /builds/{runId}/manifest — Builder가 기록한 authoritative manifest 본문. */
+  getBuildManifest: (runId: string, signal?: AbortSignal) =>
+    apiFetch(
+      `/builds/${encodeURIComponent(runId)}/manifest`,
+      { signal },
+      schemas.buildManifestResponseSchema,
+    ),
+
   /** GET /builds — 빌드 이력 목록(#153, builder #250). */
   listBuilds: (limit?: number, signal?: AbortSignal) => {
     const query = limit !== undefined ? `?limit=${limit}` : "";

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -53,7 +53,7 @@ export class ApiError extends Error {
 }
 
 interface RequestOptions {
-  method?: "GET" | "POST";
+  method?: "GET" | "POST" | "PUT" | "DELETE";
   body?: unknown;
   signal?: AbortSignal;
   /** 자동 타임아웃(ms). 미지정 시 DEFAULT_TIMEOUT_MS. 0 이하이면 타임아웃 비활성화. */
@@ -340,8 +340,11 @@ export function formatApiErrorMessage(status: number, parsed: unknown): string {
 export interface BuildSummary {
   /** 빌드 실행 식별자 */
   run_id: string;
-  /** 빌드 상태("ok" | "failed") */
-  status: "ok" | "failed";
+  /**
+   * 빌드 상태. Builder canonical BuildSummary 어휘는 "ok" | "failed" | "cancelled"이다
+   * (취소된 run은 failed가 아니라 cancelled로 온다 — 이력/KPI에서 구분해야 한다).
+   */
+  status: "ok" | "failed" | "cancelled";
   /** 빌드 시작 시각(ISO 8601, null, 또는 생략됨) */
   started_at?: string | null;
   /** 빌드 완료 시각(ISO 8601, null, 또는 생략됨) */
@@ -370,6 +373,8 @@ export type CatalogProvider = schemas.CatalogProvider;
 export type CatalogResponse = schemas.CatalogResponse;
 export type ProviderTestResponse = schemas.ProviderTestResponse;
 export type UploadMetadata = schemas.UploadMetadata;
+export type ProviderSummary = schemas.ProviderSummary;
+export type ProvidersResponse = schemas.ProvidersResponse;
 export type PreviewDiffItem = schemas.PreviewDiffItem;
 export type PreviewTransformSummary = schemas.PreviewTransformSummary;
 export type StageStatus = schemas.StageStatus;
@@ -466,6 +471,18 @@ export const builderApi = {
     apiFetch(
       `/builds/${encodeURIComponent(runId)}`,
       { signal, retries: 1 },
+      schemas.buildJobSchema,
+    ),
+
+  /**
+   * POST /builds/{run_id}/cancel — 진행 중인 async build job의 협조적 취소 요청
+   * (#245, builder #481). queued/running → cancelling/cancelled로 전이한다. 취소는
+   * side effect가 있는 비멱등 요청이므로 재시도하지 않는다. 응답은 최신 job 스냅샷이다.
+   */
+  cancelBuildJob: (runId: string, signal?: AbortSignal) =>
+    apiFetch(
+      `/builds/${encodeURIComponent(runId)}/cancel`,
+      { method: "POST", signal, retries: 0 },
       schemas.buildJobSchema,
     ),
 
@@ -630,6 +647,36 @@ export const builderApi = {
       `/providers/${encodeURIComponent(provider)}/test`,
       { method: "POST", signal, retries: 0 },
       schemas.providerTestResponseSchema,
+    ),
+
+  /**
+   * GET /providers/{provider}/status — 서버에 저장된 credential(또는 무인증 provider)로
+   * 실행하는 lightweight connection 점검 (#259, builder provider credentials API).
+   * credential 원문은 주고받지 않는다. 응답 형태는 POST /providers/{provider}/test와 공통이다.
+   */
+  getProviderStatus: (provider: string, signal?: AbortSignal) =>
+    apiFetch(
+      `/providers/${encodeURIComponent(provider)}/status`,
+      { signal, retries: 1 },
+      schemas.providerTestResponseSchema,
+    ),
+
+  /**
+   * PUT /providers/{provider}/credential — raw credential 등록/교체 (#259).
+   * body는 `{ credential }` 하나뿐이고, 응답에는 원문이 존재하지 않는다(Studio도
+   * 저장/로그/echo하지 않는다). 비멱등 side effect이므로 재시도하지 않는다.
+   */
+  putProviderCredential: (provider: string, credential: string, signal?: AbortSignal) =>
+    apiFetch<unknown>(
+      `/providers/${encodeURIComponent(provider)}/credential`,
+      { method: "PUT", body: { credential }, signal, retries: 0 },
+    ),
+
+  /** DELETE /providers/{provider}/credential — 저장된 credential 제거 (#259). */
+  deleteProviderCredential: (provider: string, signal?: AbortSignal) =>
+    apiFetch<unknown>(
+      `/providers/${encodeURIComponent(provider)}/credential`,
+      { method: "DELETE", signal, retries: 0 },
     ),
 
   /**

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -165,11 +165,11 @@ export interface BuildManifest {
   /** 빌드 종료 시각 ISO 문자열(UTC). 제공되지 않으면 undefined */
   finished_at?: string;
   /** 빌드를 생성한 실행 환경. 캡처하지 못했으면 null */
-  build_environment: ManifestBuildEnvironment | null;
+  build_environment?: ManifestBuildEnvironment | null;
   /** 입력 파일 또는 소스 식별자 목록. 제공되지 않으면 undefined */
   inputs?: string[];
   /** 입력 데이터 전체의 재현성 지문("sha256:..."). 입력이 없으면 null */
-  inputs_fingerprint: string | null;
+  inputs_fingerprint?: string | null;
   /** 생성된 결과물 경로 목록. 제공되지 않으면 undefined */
   outputs?: string[];
   /** 치명적이지 않지만 확인이 필요한 경고 목록. 제공되지 않으면 undefined */
@@ -182,6 +182,7 @@ export interface BuildManifest {
   schema_summaries?: Record<string, ManifestSchemaSummary>;
   /** 소스별 상세 출처(fetch 시각/파라미터/레코드 수/체크섬) 목록. 제공되지 않으면 undefined */
   provenance?: ManifestSourceProvenance[];
+  /** Builder가 additive하게 제공하는 manifest 필드를 손실 없이 유지한다. */
 }
 
 export interface BuildDraft {


### PR DESCRIPTION
## 개요

PR #320의 contextual Kubi UX 개선 위에서, 실제 Builder 연동 및 Real E2E 이후 확인된
Studio의 integration / truthfulness / security 문제를 정리합니다.

이 PR은 stacked PR이며 `feat/kubi-ux-polish`를 base로 합니다.

Depends on #320.

## 주요 변경사항

### Build 실행 경로 정합성

- source 종류에 따라 Builder의 실제 지원 표면을 사용
  - `public_api` / `url` → async `POST /builds`
  - `file` 또는 file이 섞인 spec → sync `POST /build`
- 첫 source만 보고 실행 방식을 결정하지 않고 전체 source를 검사
- async job polling과 canonical status를 유지
- sync `/build`의 client-side abort를 server-side `cancelled`로 위장하지 않음
- 실제 async cancel endpoint를 사용하도록 정리

### Provider 실연동

- real mode에서 `GET /providers`를 canonical source로 사용
- API 실패 시 mock Provider로 fallback하지 않음
- Provider ID를 Builder canonical ID 그대로 사용
- 연결 상태는 실제 Builder status endpoint에서 조회
- credential 등록/삭제를 Builder API와 연결
- raw credential을 Studio 상태/응답에 다시 노출하지 않음

### Secret persistence 방어

- BuildSpec/draft/local storage 경계에서 secret-like 값 redaction
- legacy 저장 데이터도 read 시 sanitize 후 rewrite
- redacted marker가 남은 spec은 필요한 경로에서 fail-closed
- API 호출 전 raw secret 재노출 여부 회귀 테스트 추가
- Kubi evidence / assistant scrub 경계 보강

### Kubi / Run 안정화

- Dataset detail에서 유효하지만 누락된 direct AI context 보완
- Builds → Kubi seed race를 deterministic하게 처리
- Kubi Run 분석 답변 Markdown 렌더링
- `hallucinated_refs`를 응답 status와 무관하게 사용자에게 노출
- multi-source context에서 source가 확정되지 않은 경우 Stage 선택을 fail-closed
- Quality action에서 dataset ↔ run membership을 Builder evidence로 확인

### Dashboard / Manifest 진실성

- Home dashboard의 임의 KPI / synthetic 값 제거
- Builder monitoring 응답을 authoritative source로 사용
- 지원되지 않는 값은 `0` 등으로 합성하지 않고 확인 불가 상태로 표시
- build manifest는 `GET /builds/{run_id}/manifest`를 authoritative source로 사용
- synthetic manifest fallback 제거

## 검증

주요 회귀 범위:

- async/sync Build dispatch
- canonical cancellation semantics
- Provider real API
- secret persistence / redaction
- Dataset ↔ Run membership
- Kubi seed race / evidence / context
- Home monitoring truthfulness
- authoritative Build manifest

검증 결과:

- targeted: 24 files / 216 tests PASS
- `npx tsc --noEmit` PASS
- `npm run build` PASS
- `git diff --check` PASS

Vite native config warning 및 production chunk size warning은 기존 non-blocking warning입니다.

## Scope

이 PR은 Builder 계약을 재설계하지 않습니다.

- Builder OpenAPI / BuildSpec / Manifest를 실제 data semantics SSOT로 사용
- 기존 Kubi BYOK / approval / explicit query execution 정책 유지
- mock mode는 명시적인 demo/mock 경로에서만 유지
- real mode 실패를 mock 성공으로 위장하지 않음

## Dependency

Stack:

1. #319
2. #320
3. **this PR**

#320이 선행되어야 합니다.