### PR TITLE
fix: close remaining Studio integration races

### DIFF
--- a/__tests__/HomePage.test.tsx
+++ b/__tests__/HomePage.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -6,10 +6,17 @@ import { useAssistConfig } from "@/features/assistant/config";
 import { SUGGESTED_QUESTIONS } from "@/features/kubi/suggestedQuestions";
 import { useKubiStore } from "@/features/kubi/useKubiSession";
 import { HomePage } from "@/pages/HomePage";
+import { builderApi } from "@/shared/lib/builderApi";
 import { useUIStore } from "@/shared/hooks/useUIStore";
 import { mswServer } from "../vitest.setup";
 
 const BUILDER_BASE = "http://localhost:8000";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => { resolve = done; });
+  return { promise, resolve };
+}
 
 function mockEmptyBuilds() {
   mswServer.use(http.get(`${BUILDER_BASE}/builds`, () => HttpResponse.json({ builds: [] })));
@@ -102,15 +109,59 @@ describe("HomePage", () => {
         buckets: [{ bucket_start: "2026-08-31T00:00:00Z", bucket_end: "2026-08-31T01:00:00Z", total: 9, success: 7, failed: 1, cancelled: 1 }],
         recent_runs: [],
       })),
+      http.get(`${BUILDER_BASE}/monitoring/summary`, () => HttpResponse.json({
+        generated_at: "2026-08-31T00:00:00Z",
+        status: "healthy",
+        api: { availability: "available", sample_count: 1, p95_latency_ms: 10 },
+        queue: { availability: "available", waiting: 0, running: 3, total: 3 },
+        workers: { availability: "available", active: 1, capacity: 1, utilization: 1 },
+        artifact_store: { availability: "available", last_write_at: null },
+      })),
     );
 
     render(<MemoryRouter><HomePage /></MemoryRouter>);
 
     expect(await screen.findByText("7")).toBeInTheDocument();
-    expect(screen.getAllByText("확인 불가")).toHaveLength(3);
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getAllByText("확인 불가")).toHaveLength(2);
     expect(screen.getByText("품질 경고 집계 확인 불가")).toBeInTheDocument();
     expect(screen.queryByText("품질 경고가 없습니다")).not.toBeInTheDocument();
     expect(screen.queryByText("모든 빌드가 정상적으로 완료되었습니다")).not.toBeInTheDocument();
+  });
+
+  it("renders recent builds before deferred monitoring settles, then uses authoritative KPIs", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    const monitoringBuilds = deferred<Response>();
+    const monitoringSummary = deferred<Response>();
+    mswServer.use(
+      http.get(`${BUILDER_BASE}/builds`, () => HttpResponse.json({ builds: [
+        { run_id: "deferred-run", status: "ok", started_at: "2026-08-31T00:00:00Z", finished_at: null },
+      ] })),
+      http.get(`${BUILDER_BASE}/monitoring/builds`, () => monitoringBuilds.promise),
+      http.get(`${BUILDER_BASE}/monitoring/summary`, () => monitoringSummary.promise),
+    );
+    render(<MemoryRouter><HomePage /></MemoryRouter>);
+    expect(await screen.findByText("deferred-run")).toBeInTheDocument();
+    expect(screen.queryByText(/빌드 목록을 불러오지 못했습니다/)).not.toBeInTheDocument();
+    await act(async () => {
+      monitoringBuilds.resolve(HttpResponse.json({ window: "24h", bucket: "hour", availability: "available", excluded_count: 0, buckets: [{ bucket_start: "2026-08-31T00:00:00Z", bucket_end: "2026-08-31T01:00:00Z", total: 4, success: 4, failed: 0, cancelled: 0 }], recent_runs: [] }));
+      monitoringSummary.resolve(HttpResponse.json({ generated_at: "2026-08-31T00:00:00Z", status: "healthy", api: { availability: "available", sample_count: 1, p95_latency_ms: 1 }, queue: { availability: "available", waiting: 0, running: 3, total: 3 }, workers: { availability: "available", active: 1, capacity: 1, utilization: 1 }, artifact_store: { availability: "available", last_write_at: null } }));
+    });
+    expect(await screen.findByText("4")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("keeps recent builds visible when monitoring fails and marks only KPIs unavailable", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    mswServer.use(
+      http.get(`${BUILDER_BASE}/builds`, () => HttpResponse.json({ builds: [{ run_id: "still-visible", status: "ok", started_at: "2026-08-31T00:00:00Z", finished_at: null }] })),
+    );
+    vi.spyOn(builderApi, "getMonitoringBuilds").mockRejectedValue(new Error("monitoring down"));
+    vi.spyOn(builderApi, "getMonitoringSummary").mockRejectedValue(new Error("monitoring down"));
+    render(<MemoryRouter><HomePage /></MemoryRouter>);
+    expect(await screen.findByText("still-visible")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByText("확인 불가")).toHaveLength(4));
+    expect(screen.queryByText(/빌드 목록을 불러오지 못했습니다/)).not.toBeInTheDocument();
   });
 });
 

--- a/__tests__/asyncBuildJob.test.ts
+++ b/__tests__/asyncBuildJob.test.ts
@@ -259,11 +259,13 @@ describe("async pre-submit cancellation race (F03)", () => {
     expect(cancelSpy).toHaveBeenCalledTimes(1);
     expect(cancelSpy).toHaveBeenCalledWith(AUTHORITATIVE);
     expect(getJobSpy).toHaveBeenCalled();
+    expect(getJobSpy.mock.calls.every(([runId]) => runId === AUTHORITATIVE)).toBe(true);
 
     // cancelling → cancelled polling을 관찰해 최종 상태를 확정한다.
     expect(result.current.builderStatus).toBe("cancelled");
     expect(result.current.status).toBe("cancelled");
     expect(result.current.run?.status).toBe("cancelled");
+    expect(result.current.run?.id).toBe(AUTHORITATIVE);
 
     submitSpy.mockRestore();
     getJobSpy.mockRestore();

--- a/__tests__/buildsKubiSeedRace.test.tsx
+++ b/__tests__/buildsKubiSeedRace.test.tsx
@@ -130,6 +130,28 @@ afterEach(() => {
 });
 
 describe("C1 — Builds Kubi seed vs. context back-fill race", () => {
+  it("closing the inline card discards a pending analysis before context becomes canonical", async () => {
+    vi.spyOn(runsApi, "listBuilds").mockResolvedValue([listItem]);
+    vi.spyOn(datasetsApi, "getBuildQuality").mockResolvedValue(quality);
+    const spec = deferred<BuildSpecSnapshotResponse>();
+    const stages = deferred<RunStagesResponse>();
+    vi.spyOn(runDetailApi, "getBuildSpecSnapshot").mockReturnValue(spec.promise);
+    vi.spyOn(datasetsApi, "listBuildStages").mockReturnValue(stages.promise);
+
+    renderBuilds();
+    fireEvent.click(await screen.findByRole("button", { name: /분석/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "닫기" }));
+    await act(async () => {
+      spec.resolve(specSnapshot);
+      stages.resolve(stagesResponse);
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(useKubiStore.getState().turns).toHaveLength(0);
+    expect(useKubiStore.getState().pendingSeed).toBeNull();
+    expect(streamCalls).toBe(0);
+  });
+
   it("defers the seed until the URL context is canonical, so the fresh turn is not stale-flipped away (spec+stages deferred)", async () => {
     vi.spyOn(runsApi, "listBuilds").mockResolvedValue([listItem]);
     vi.spyOn(datasetsApi, "getBuildQuality").mockResolvedValue(quality);

--- a/__tests__/kubiSession.test.tsx
+++ b/__tests__/kubiSession.test.tsx
@@ -95,6 +95,7 @@ function makeWrapper(initialPath: string) {
 }
 
 beforeEach(() => {
+  vi.stubEnv("VITE_USE_REAL_BUILDER", "false");
   useKubiStore.setState({ turns: [], onboarded: false, pendingSeed: null });
   useAssistConfig.getState().clear();
   navigateRef = null;

--- a/__tests__/providerPage.test.tsx
+++ b/__tests__/providerPage.test.tsx
@@ -217,6 +217,46 @@ describe("ProviderPage real mode (#S01)", () => {
     await waitFor(() => expect(deleteSpy).toHaveBeenCalledWith("datago"));
     await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(2));
   });
+
+  it("keeps provider B credential metadata when a stale provider A success resolves late", async () => {
+    let resolveA!: (value: { configured: boolean; masked: string | null; updated_at: string | null }) => void;
+    const pendingA = new Promise<{ configured: boolean; masked: string | null; updated_at: string | null }>((resolve) => { resolveA = resolve; });
+    vi.spyOn(builderApi, "listProviders").mockResolvedValue({ providers: [
+      { provider: "provider-a", requires_credential: true, configured: true },
+      { provider: "provider-b", requires_credential: true, configured: true },
+    ] });
+    vi.spyOn(builderApi, "getProviderCredential").mockImplementation((provider) =>
+      provider === "provider-a" ? pendingA : Promise.resolve({ configured: true, masked: "B-MASK", updated_at: null }),
+    );
+    renderPage();
+    fireEvent.click(await screen.findByText("provider-a"));
+    fireEvent.click(screen.getByText("provider-b"));
+    expect(await screen.findByText("B-MASK")).toBeInTheDocument();
+    resolveA({ configured: true, masked: "A-MASK", updated_at: null });
+    await Promise.resolve();
+    expect(screen.getByText("B-MASK")).toBeInTheDocument();
+    expect(screen.queryByText("A-MASK")).not.toBeInTheDocument();
+  });
+
+  it("keeps provider B metadata when a stale provider A request rejects late", async () => {
+    let rejectA!: (reason?: unknown) => void;
+    const pendingA = new Promise<{ configured: boolean; masked: string | null; updated_at: string | null }>((_, reject) => { rejectA = reject; });
+    vi.spyOn(builderApi, "listProviders").mockResolvedValue({ providers: [
+      { provider: "provider-a", requires_credential: true, configured: true },
+      { provider: "provider-b", requires_credential: true, configured: true },
+    ] });
+    vi.spyOn(builderApi, "getProviderCredential").mockImplementation((provider) =>
+      provider === "provider-a" ? pendingA : Promise.resolve({ configured: true, masked: "B-MASK", updated_at: null }),
+    );
+    renderPage();
+    fireEvent.click(await screen.findByText("provider-a"));
+    fireEvent.click(screen.getByText("provider-b"));
+    expect(await screen.findByText("B-MASK")).toBeInTheDocument();
+    rejectA(new Error("late A failure"));
+    await Promise.resolve();
+    expect(screen.getByText("B-MASK")).toBeInTheDocument();
+    expect(screen.queryByText(/자격 증명 상태를 불러오지 못했습니다/)).not.toBeInTheDocument();
+  });
 });
 
 describe("ProviderPage mock mode (unchanged)", () => {

--- a/src/features/runs/api/index.ts
+++ b/src/features/runs/api/index.ts
@@ -175,7 +175,7 @@ async function runAsyncBuild(
   onJobStatus?.(submitted.status);
 
   // 제출 직후 이미 terminal인 경우(동일 run_id 재제출 등) 폴링 없이 바로 판정한다.
-  const job = await pollBuildJobUntilTerminal(runId, submitted, signal, (polled) =>
+  const job = await pollBuildJobUntilTerminal(submitted.run_id, submitted, signal, (polled) =>
     onJobStatus?.(polled.status),
   );
 

--- a/src/pages/BuildsPage.tsx
+++ b/src/pages/BuildsPage.tsx
@@ -669,7 +669,13 @@ function RunDetailPanel({
       </Card>
 
       {showKubiAnalysis ? (
-        <KubiRunAnalysis onClose={() => setShowKubiAnalysis(false)} onAskMore={openKubiDrawer} />
+        <KubiRunAnalysis
+          onClose={() => {
+            setAnalyzePending(false);
+            setShowKubiAnalysis(false);
+          }}
+          onAskMore={openKubiDrawer}
+        />
       ) : null}
 
       <Card>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -74,10 +74,19 @@ export function HomePage() {
       try {
         const realBuilder = isRealBuilderEnabled();
         const buildList = await listBuilds();
+        // Recent builds and monitoring have independent authority and latency.
+        if (active) {
+          setBuilds(buildList);
+          setApiState((prev) => ({ ...prev, builds: "success" }));
+          setLoading((prev) => ({ ...prev, builds: false }));
+        }
         // 비어 있는 목록은 신규 사용자 분기에 충분하며, 불필요한 monitoring 호출로 막지 않는다.
-        const monitoring = realBuilder && buildList.length > 0
-          ? await builderApi.getMonitoringBuilds().catch(() => null)
-          : null;
+        const [monitoring, summary] = realBuilder && buildList.length > 0
+          ? await Promise.all([
+              builderApi.getMonitoringBuilds().catch(() => null),
+              builderApi.getMonitoringSummary().catch(() => null),
+            ])
+          : [null, null];
         if (active) {
           setBuilds(buildList);
           setApiState((prev) => ({ ...prev, builds: "success" }));
@@ -89,11 +98,12 @@ export function HomePage() {
             ? monitoring.buckets.reduce((sum, bucket) => sum + bucket.success, 0)
             : null;
           setStats({
-            datasetCount: realBuilder ? null : succeeded,
+            // /datasets has no total; a paginated response length is not a dataset count.
+            datasetCount: null,
             buildSuccess: realBuilder ? monitoredSuccess : succeeded,
             validationWarn: null,
             // GET /builds의 real 계약은 terminal summary만 제공하므로 active 수로 해석하지 않는다.
-            running: realBuilder ? null : running,
+            running: realBuilder ? summary?.queue.running ?? null : running,
           });
           setApiState((prev) => ({ ...prev, stats: "success" }));
         }
@@ -103,7 +113,7 @@ export function HomePage() {
         }
       } finally {
         if (active) {
-          setLoading({ builds: false, stats: false });
+          setLoading((prev) => ({ ...prev, stats: false }));
         }
       }
     };

--- a/src/pages/ProviderPage.tsx
+++ b/src/pages/ProviderPage.tsx
@@ -13,7 +13,7 @@
  * - 세 축을 화면에서 분리한다: (1) provider 사용 가능 여부, (2) 사용자 저장 credential
  *   존재 여부, (3) 연결 테스트 결과.
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   builderApi,
   isRealBuilderEnabled,
@@ -87,6 +87,7 @@ export function ProviderPage() {
   const [showCredentialForm, setShowCredentialForm] = useState(false);
   const [credentialForm, setCredentialForm] = useState<CredentialForm>({ credential: "" });
   const [credentialMeta, setCredentialMeta] = useState<CredentialMetaState>({ status: "idle" });
+  const credentialRequestGeneration = useRef(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -135,14 +136,16 @@ export function ProviderPage() {
    */
   const loadCredentialMeta = useCallback(
     async (provider: ProviderConfig) => {
+      const generation = ++credentialRequestGeneration.current;
       if (!provider.requiresCredential) {
-        setCredentialMeta({ status: "not_applicable" });
+        if (generation === credentialRequestGeneration.current) setCredentialMeta({ status: "not_applicable" });
         return;
       }
       setCredentialMeta({ status: "loading" });
       try {
         if (isRealBuilderEnabled()) {
           const meta = await builderApi.getProviderCredential(provider.id);
+          if (generation !== credentialRequestGeneration.current) return;
           setCredentialMeta({
             status: "loaded",
             configured: meta.configured,
@@ -150,9 +153,11 @@ export function ProviderPage() {
             updatedAt: meta.updated_at,
           });
         } else {
+          if (generation !== credentialRequestGeneration.current) return;
           setCredentialMeta(mockCredentialMeta(provider));
         }
       } catch {
+        if (generation !== credentialRequestGeneration.current) return;
         setCredentialMeta({ status: "error", message: "자격 증명 상태를 불러오지 못했습니다" });
       }
     },
@@ -160,6 +165,7 @@ export function ProviderPage() {
   );
 
   const handleProviderSelect = (provider: ProviderConfig) => {
+    ++credentialRequestGeneration.current;
     setSelectedProvider(provider);
     setShowCredentialForm(false);
     setCredentialForm({ credential: "" });


### PR DESCRIPTION
## 후속 작업

- Dashboard의 DATASETS / Quality warning aggregate는 Builder contract 보강 후 실제 값으로 교체합니다.
- Provider credential store 미설정 상태를 더 명확하게 안내하는 UX는 별도 후속으로 정리합니다.

## 개요

PR #322 위에서 Real Builder 통합 검증 중 확인된 마지막 race condition과 Dashboard truthfulness 문제를 정리합니다.

이 PR은 `fix/final-post-e2e-truthfulness` 위에 쌓인 stacked PR입니다.

## 주요 변경

### Async build authoritative run ID

- async build submit 이후 polling도 Builder가 반환한 `submitted.run_id`를 사용
- cancel handle / polling / final BuildRun이 동일한 authoritative run ID를 사용
- client-generated candidate run ID가 이후 lifecycle에 남지 않도록 정리

### Provider credential stale-response race

Provider A의 credential metadata 요청 중 Provider B로 이동했을 때,
A의 늦은 success/error가 B 상태를 덮을 수 있던 race를 차단했습니다.

- request generation guard 추가
- stale success 무시
- stale error 무시
- 현재 선택 Provider의 metadata만 UI에 반영

회귀 테스트:
- A stale success → B metadata 유지
- A stale error → B metadata 및 UI 유지

### Home Dashboard 요청 분리

- `/builds` 성공 결과를 monitoring 완료 전에 즉시 렌더
- monitoring 지연/실패가 Recent Builds를 skeleton/error 상태로 되돌리지 않음
- `SUCCEEDED (24H)`는 monitoring builds 기반
- `RUNNING`은 `/monitoring/summary.queue.running` 기반
- authoritative aggregate가 없는 DATASETS / VALIDATION WARN은 임의 숫자를 생성하지 않음

### Kubi pending analysis race

- `이 Run 분석`을 누른 뒤 context canonicalization을 기다리는 동안 card를 닫으면 pending intent도 함께 폐기
- 이후 spec/stage context가 settle되어도 닫힌 분석이 뒤늦게 seed되지 않음

### Test isolation

- `kubiSession.test.tsx`의 mock Builder 전제를 명시적으로 고정
- 다른 real-mode 테스트의 환경 변수가 parallel suite에 누출되지 않도록 보강

## 검증

주요 focused regression:

- ProviderPage: `11/11 PASS`
- HomePage: `12/12 PASS`
- Builds Kubi seed race: `9/9 PASS`
- Kubi session: `20/20 PASS`
- 기존 Add Data / New Build full-suite timeout 발생 파일 6개는 모두 isolated PASS

정적 검증:

- TypeScript typecheck: PASS
- ESLint: 0 errors
- Production build: PASS
- `git diff --check`: PASS

Full Vitest parallel 실행에서는 React-heavy 테스트가 5초 timeout에 걸리는 기존 resource-contention flake가 관측됐으며, 해당 실패 파일들은 모두 단독 실행에서 통과했습니다.

## 범위

- Builder contract 재설계 없음
- mock fallback으로 real failure를 숨기지 않음
- synthetic KPI/status 추가 없음
- 기존 secret persistence / Kubi grounding / cancellation semantics 유지

## Dependency

Stack:

1. #323 `fix/post-e2e-bug-sweep`
2. #322 `fix/final-post-e2e-truthfulness`
3. **this PR**