### PR TITLE
fix: finalize pre-cloud Studio workflows, onboarding, and integration stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,32 +199,60 @@ src/
 | [PRD.md](./PRD.md) | 제품 요구사항 |
 | [ROADMAP.md](./ROADMAP.md) | 개발 로드맵 |
 
-### Keycloak OIDC authentication (real Builder)
+### Keycloak OIDC 인증 (실연동 Builder)
 
-The real Builder flow authenticates humans through a self-hosted Keycloak realm using
-Authorization Code Flow + PKCE (S256). Studio is a public SPA — there is **no client
-secret** in the frontend. Email/password sign-in, verification, password reset, token
-refresh and logout are Keycloak's responsibility; Studio never sees or stores a password.
+실연동 Builder 흐름은 self-hosted Keycloak realm을 통해 사람 사용자를 인증한다 —
+Authorization Code Flow + PKCE(S256). Studio는 public SPA이므로 프런트엔드에 **client
+secret이 없다**. 이메일/비밀번호 로그인, 이메일 인증, 비밀번호 재설정, 토큰 갱신,
+로그아웃은 모두 Keycloak의 책임이며 Studio는 비밀번호를 보거나 저장하지 않는다.
+
+실연동 `/login`에서는 두 가지 로그인 경로를 제공한다.
+
+- **Google로 계속하기**: `keycloakLogin(returnTo, "google")`을 사용해 Keycloak의
+  Google Identity Broker를 통해 인증한다.
+- **KPubData 계정으로 로그인**: `keycloakLogin(returnTo)`을 사용해 Keycloak이
+  제공하는 로그인 화면으로 이동한다.
+
+두 경로 모두 Keycloak을 Authorization Server로 사용하며, Google 인증을 Studio가
+직접 처리하거나 Google 토큰을 Builder에 직접 전달하지 않는다.
+mock/demo 모드(`VITE_USE_REAL_BUILDER` 미설정)에서는 기존 이메일/비밀번호 폼을 그대로 쓴다.
 
 ```dotenv
-# Studio .env.local (do not commit)
+# Studio .env.local (커밋 금지)
 VITE_USE_REAL_BUILDER=true
 VITE_BUILDER_API_URL=http://localhost:8000
 VITE_OIDC_ISSUER=http://localhost:8080/realms/kpubdata
 VITE_OIDC_CLIENT_ID=kpubdata-studio
 ```
 
-Keycloak client (`kpubdata-studio`): public client (client auth OFF), Standard Flow ON,
-Direct Access Grants OFF, PKCE `S256` required, valid redirect URI + web origin
-`http://localhost:5173`, and access-token audience `kpubdata-builder`.
+Keycloak client(`kpubdata-studio`) 설정: public client(client auth OFF), Standard Flow ON,
+Direct Access Grants OFF, PKCE `S256` 필수, access-token audience `kpubdata-builder`,
+Google를 Identity Provider로 연결.
 
-- `VITE_OIDC_ISSUER` is the full issuer URL (`.../realms/<realm>`); Studio derives the
-  Keycloak base URL and realm from it. A missing or malformed issuer/client id fails
-  closed with a visible error — Studio never assumes the user is authenticated.
-- Access tokens live only in the `keycloak-js` in-memory session. Studio attaches
-  `Authorization: Bearer <token>` at the shared Builder request boundary and refreshes
-  near-expiry tokens there; nothing is written to `localStorage`/`sessionStorage` or logs.
-- The existing `X-API-Key` path on the Builder is unaffected.
+**Valid Redirect URIs / Web Origins (로컬 개발 기준):**
+
+- Web Origins: `http://localhost:5173`
+- Valid Redirect URIs에는 다음 두 가지가 모두 매칭돼야 한다:
+  - **로그인 callback** — `keycloakLogin`이 `/login?returnTo=...`로 돌아온다.
+  - **silent SSO callback** — `initKeycloak()`이 숨은 iframe으로 세션을 조용히 확인할 때
+    `redirect_uri`로 `/silent-check-sso.html`(앱 `BASE_URL` 하위)을 보낸다. 이 경로가
+    Valid Redirect URI에 없으면 최초 silent SSO 확인이 거부되어 Studio가 인증 오류
+    화면에 머문다.
+- 로컬에서는 `http://localhost:5173/silent-check-sso.html`과 로그인 callback의
+  query string까지 허용하는 패턴(예: `http://localhost:5173/login*`)을 등록하거나,
+  개발 편의상 `http://localhost:5173/*` 하나로 둘 다 커버할 수 있다.
+- **production에서는 넓은 wildcard(`https://<host>/*` 또는 `*`)를 기본값으로 쓰지 않는다.**
+  production 배포 origin에 대해 실제로 사용하는 silent SSO callback과 로그인 callback만
+  허용하고, 로그인 callback에 필요한 경우 `/login*`처럼 가능한 좁은 범위의 패턴을 사용한다.
+  sub-path 배포라면 `BASE_URL`도 포함한다.
+
+- `VITE_OIDC_ISSUER`는 전체 issuer URL(`.../realms/<realm>`)이다. Studio가 여기서
+  Keycloak base URL과 realm을 파생한다. issuer/client id가 없거나 형식이 잘못되면
+  화면에 보이는 오류로 fail-closed된다 — Studio는 사용자가 인증됐다고 가정하지 않는다.
+- access token은 `keycloak-js`의 메모리 세션에만 존재한다. Studio는 공유 Builder 요청
+  경계에서 `Authorization: Bearer <token>`을 붙이고 만료 임박 토큰을 그 자리에서 갱신한다.
+  `localStorage`/`sessionStorage`나 로그에는 아무것도 쓰지 않는다.
+- Builder의 기존 `X-API-Key` 경로는 영향받지 않는다.
 
 #### Builder side (real OIDC verification)
 

--- a/__tests__/BuildArtifactsPage.test.tsx
+++ b/__tests__/BuildArtifactsPage.test.tsx
@@ -4,18 +4,22 @@
  * undefined와 빈 배열이 서로 다른 문구로 표시되는지 검증한다.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, cleanup } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import type { BuildManifest } from "@/shared/lib/types";
 import { BuildArtifactsPage } from "@/pages/BuildArtifactsPage";
 import * as artifactsApi from "@/features/artifacts/api";
 
 const mockGetBuildManifest = vi.spyOn(artifactsApi, "getBuildManifest");
+const mockListArtifactFiles = vi.spyOn(artifactsApi, "listArtifactFiles");
+const mockDownloadArtifact = vi.spyOn(artifactsApi, "downloadArtifact");
+const mockSaveBlobAsFile = vi.spyOn(artifactsApi, "saveBlobAsFile").mockImplementation(() => {});
 
-function renderWithManifest(manifest: BuildManifest) {
+function renderWithManifest(manifest: BuildManifest, runId = "test-id", files: string[] = []) {
   mockGetBuildManifest.mockResolvedValue(manifest);
+  mockListArtifactFiles.mockResolvedValue(files);
   return render(
-    <MemoryRouter initialEntries={["/builds/test-id/artifacts"]}>
+    <MemoryRouter initialEntries={[`/builds/${runId}/artifacts`]}>
       <Routes>
         <Route path="/builds/:buildId/artifacts" element={<BuildArtifactsPage />} />
       </Routes>
@@ -29,20 +33,7 @@ afterEach(() => {
 });
 
 describe("BuildArtifactsPage - Issue #119: undefined vs empty array", () => {
-  it("outputs: undefined → '파일 정보 미제공', outputs: [] → '생성된 파일이 없습니다'", async () => {
-    const withUndefined: BuildManifest = {
-      schema_version: "1.0.0",
-      build_id: "test-undefined",
-      build_environment: null,
-      inputs_fingerprint: null,
-    };
-
-    renderWithManifest(withUndefined);
-    await waitFor(() => expect(screen.getByText("파일 정보 미제공")).toBeInTheDocument());
-    expect(screen.getByText("파일 정보 미제공")).toBeInTheDocument();
-    expect(screen.queryByText("생성된 파일이 없습니다")).not.toBeInTheDocument();
-    cleanup();
-
+  it("canonical 파일 목록이 비면 표에 '생성된 파일이 없습니다'를 보여준다", async () => {
     const withEmpty: BuildManifest = {
       schema_version: "1.0.0",
       build_id: "test-empty",
@@ -51,10 +42,9 @@ describe("BuildArtifactsPage - Issue #119: undefined vs empty array", () => {
       outputs: [],
     };
 
-    renderWithManifest(withEmpty);
+    renderWithManifest(withEmpty, "test-id", []);
     await waitFor(() => expect(screen.getByText("생성된 파일이 없습니다")).toBeInTheDocument());
     expect(screen.getByText("생성된 파일이 없습니다")).toBeInTheDocument();
-    expect(screen.queryByText("파일 정보 미제공")).not.toBeInTheDocument();
   });
 
   it("formats: undefined → '미제공', formats: [] → '출력 형식 없음'", async () => {
@@ -135,6 +125,122 @@ describe("BuildArtifactsPage - Issue #119: undefined vs empty array", () => {
     expect(screen.getByText("jsonl, parquet")).toBeInTheDocument();
     expect(screen.getByText("datago.air-quality")).toBeInTheDocument();
     expect(screen.getByText("100")).toBeInTheDocument();
+  });
+});
+
+describe("BuildArtifactsPage - artifact 실제 다운로드", () => {
+  const emptyManifest = (): BuildManifest => ({
+    schema_version: "1.0.0",
+    build_id: "run-dl",
+    build_environment: null,
+    inputs_fingerprint: null,
+    outputs: [],
+  });
+
+  /** 표는 canonical `GET /artifacts/{run_id}` 목록(= listArtifactFiles)에서만 온다. */
+  function renderArtifacts(files: string[], runId = "test-id") {
+    return renderWithManifest(emptyManifest(), runId, files);
+  }
+
+  it("각 canonical 파일 row에 '다운로드' 버튼을 보여준다('연동 예정' 아님)", async () => {
+    renderArtifacts(["silver/datago.air_quality/table.parquet", "manifest.json"]);
+    await waitFor(() => expect(screen.getByText("table.parquet")).toBeInTheDocument());
+
+    expect(screen.getAllByRole("button", { name: "다운로드" })).toHaveLength(2);
+    expect(screen.queryByText(/연동 예정/)).not.toBeInTheDocument();
+  });
+
+  it("클릭 시 exact run_id + canonical run-relative 경로로 wrapper를 호출하고 Blob을 저장한다", async () => {
+    const blob = new Blob(["parquet-bytes"], { type: "application/octet-stream" });
+    mockDownloadArtifact.mockResolvedValue({ blob, filename: "table.parquet" });
+
+    renderArtifacts(["silver/datago.air_quality/table.parquet"], "air-quality-20260621");
+    await waitFor(() => expect(screen.getByText("table.parquet")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "다운로드" }));
+
+    await waitFor(() => expect(mockDownloadArtifact).toHaveBeenCalledTimes(1));
+    expect(mockDownloadArtifact).toHaveBeenCalledWith(
+      "air-quality-20260621",
+      "silver/datago.air_quality/table.parquet",
+    );
+    await waitFor(() => expect(mockSaveBlobAsFile).toHaveBeenCalledWith(blob, "table.parquet"));
+  });
+
+  it("output_root prefix나 '\\'가 붙은 storage 경로를 요청에 쓰지 않는다", async () => {
+    mockDownloadArtifact.mockResolvedValue({ blob: new Blob(["x"]), filename: "raw_records.jsonl" });
+
+    // canonical 목록은 run-relative POSIX 경로만 준다.
+    renderArtifacts(["bronze/datago.air_quality/9f/raw_records.jsonl"], "run-x");
+    await waitFor(() => expect(screen.getByText("raw_records.jsonl")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "다운로드" }));
+
+    await waitFor(() => expect(mockDownloadArtifact).toHaveBeenCalledTimes(1));
+    const [, pathArg] = mockDownloadArtifact.mock.calls[0];
+    expect(pathArg).toBe("bronze/datago.air_quality/9f/raw_records.jsonl");
+    expect(pathArg).not.toMatch(/\\/);
+    expect(pathArg).not.toMatch(/dist-new-user-preview|output_root|^([A-Za-z]:|\/)/);
+  });
+
+  it("다운로드 중 중복 클릭을 막는다", async () => {
+    let resolve!: (v: { blob: Blob; filename: string }) => void;
+    mockDownloadArtifact.mockReturnValue(new Promise((r) => { resolve = r; }));
+
+    renderArtifacts(["manifest.json"]);
+    await waitFor(() => expect(screen.getByRole("button", { name: "다운로드" })).toBeInTheDocument());
+
+    const button = screen.getByRole("button", { name: "다운로드" });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(mockDownloadArtifact).toHaveBeenCalledTimes(1);
+    resolve({ blob: new Blob(["x"]), filename: "manifest.json" });
+  });
+
+  it("다운로드 실패는 해당 row에만 표시하고 페이지 전체를 실패로 만들지 않는다", async () => {
+    mockDownloadArtifact.mockRejectedValue(new Error("파일을 찾을 수 없습니다 (404)"));
+
+    renderArtifacts(["silver/datago.air_quality/table.parquet"]);
+    await waitFor(() => expect(screen.getByText("table.parquet")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "다운로드" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("파일을 찾을 수 없습니다 (404)");
+    expect(mockSaveBlobAsFile).not.toHaveBeenCalled();
+    expect(screen.getByText("Manifest 요약")).toBeInTheDocument();
+    expect(screen.queryByText("결과물을 불러오지 못했습니다")).not.toBeInTheDocument();
+  });
+
+  it("다른 Run의 artifact 경로와 섞이지 않는다", async () => {
+    mockDownloadArtifact.mockResolvedValue({ blob: new Blob(["x"]), filename: "data.jsonl" });
+
+    renderArtifacts(["gold/datago.air_quality/out/data.jsonl"], "run-A");
+    await waitFor(() => expect(screen.getByText("data.jsonl")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "다운로드" }));
+
+    await waitFor(() =>
+      expect(mockDownloadArtifact).toHaveBeenCalledWith("run-A", "gold/datago.air_quality/out/data.jsonl"),
+    );
+    expect(mockDownloadArtifact).not.toHaveBeenCalledWith("test-id", expect.anything());
+  });
+
+  it("파일 목록 조회가 실패해도 페이지 전체는 정상이고 표에만 안내를 보여준다", async () => {
+    mockGetBuildManifest.mockResolvedValue(emptyManifest());
+    mockListArtifactFiles.mockRejectedValue(new Error("목록 조회 실패"));
+
+    render(
+      <MemoryRouter initialEntries={["/builds/test-id/artifacts"]}>
+        <Routes>
+          <Route path="/builds/:buildId/artifacts" element={<BuildArtifactsPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("파일 목록을 불러오지 못했습니다")).toBeInTheDocument();
+    expect(screen.getByText("Manifest 요약")).toBeInTheDocument();
+    expect(screen.queryByText("결과물을 불러오지 못했습니다")).not.toBeInTheDocument();
   });
 });
 

--- a/__tests__/HomePage.test.tsx
+++ b/__tests__/HomePage.test.tsx
@@ -1,11 +1,12 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAssistConfig } from "@/features/assistant/config";
-import { SUGGESTED_QUESTIONS } from "@/features/kubi/suggestedQuestions";
+import { START_QUESTIONS } from "@/features/kubi/suggestedQuestions";
 import { useKubiStore } from "@/features/kubi/useKubiSession";
 import { HomePage } from "@/pages/HomePage";
+import { KubiPage } from "@/pages/KubiPage";
 import { builderApi } from "@/shared/lib/builderApi";
 import { API_BASE } from "@/shared/config/env";
 import { useUIStore } from "@/shared/hooks/useUIStore";
@@ -147,9 +148,7 @@ describe("HomePage", () => {
     expect(await screen.findByText("7")).toBeInTheDocument();
     expect(screen.getByText("3")).toBeInTheDocument();
     expect(screen.getAllByText("확인 불가")).toHaveLength(2);
-    expect(
-      screen.getByText("개별 품질 경고 목록은 아직 제공되지 않습니다"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("일부 품질 정보를 확인할 수 없습니다")).toBeInTheDocument();
     expect(screen.queryByText("품질 경고가 없습니다")).not.toBeInTheDocument();
     expect(screen.queryByText("모든 빌드가 정상적으로 완료되었습니다")).not.toBeInTheDocument();
   });
@@ -192,9 +191,21 @@ describe("HomePage", () => {
   });
 });
 
-const HERO_HEADING = "Kubi에게 필요한 데이터를 물어보세요";
+const HERO_HEADING = "어디서 시작할지 모르겠다면 Kubi에게 물어보세요";
 
-describe("Home Kubi Hero (#Phase2 UI polish)", () => {
+/** Home과 /kubi를 함께 마운트해 Home hero의 이동 대상을 관측한다. */
+function renderHomeWithKubiRoute() {
+  return render(
+    <MemoryRouter initialEntries={["/"]}>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/kubi" element={<div>KUBI ROUTE STUB</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("Home Kubi Hero (#Phase2 UI polish, #S-kubi-suggest)", () => {
   beforeEach(() => {
     useKubiStore.setState({ turns: [], onboarded: false, pendingSeed: null });
     useAssistConfig.getState().clear();
@@ -227,66 +238,78 @@ describe("Home Kubi Hero (#Phase2 UI polish)", () => {
     expect(await screen.findAllByRole("heading", { name: HERO_HEADING })).toHaveLength(1);
   });
 
-  it("configured: submitting a question seeds it into the shared Kubi store and opens the drawer", async () => {
+  it("configured: submitting a question seeds it and navigates to /kubi (not the drawer)", async () => {
     useEmptyBuildsRealMode();
     configureKey();
-    render(
-      <MemoryRouter>
-        <HomePage />
-      </MemoryRouter>,
-    );
+    renderHomeWithKubiRoute();
     const input = await screen.findByLabelText("Kubi에게 자연어로 데이터 물어보기");
     fireEvent.change(input, { target: { value: "서울 대기오염 데이터로 뭘 할 수 있어?" } });
     fireEvent.submit(input.closest("form")!);
 
+    expect(await screen.findByText("KUBI ROUTE STUB")).toBeInTheDocument();
     expect(useKubiStore.getState().pendingSeed).toBe("서울 대기오염 데이터로 뭘 할 수 있어?");
-    expect(useUIStore.getState().isKubiDrawerOpen).toBe(true);
+    expect(useUIStore.getState().isKubiDrawerOpen).toBe(false);
   });
 
-  it("not configured: submitting opens the drawer but does not seed a question or create a no_key turn", async () => {
+  it("not configured: navigates to /kubi without seeding a question or creating a no_key turn", async () => {
     useEmptyBuildsRealMode();
-    render(
-      <MemoryRouter>
-        <HomePage />
-      </MemoryRouter>,
-    );
+    renderHomeWithKubiRoute();
     const input = await screen.findByLabelText("Kubi에게 자연어로 데이터 물어보기");
     fireEvent.change(input, { target: { value: "서울 대기오염 데이터로 뭘 할 수 있어?" } });
     fireEvent.submit(input.closest("form")!);
 
-    expect(useUIStore.getState().isKubiDrawerOpen).toBe(true);
+    expect(await screen.findByText("KUBI ROUTE STUB")).toBeInTheDocument();
+    expect(useUIStore.getState().isKubiDrawerOpen).toBe(false);
     expect(useKubiStore.getState().pendingSeed).toBeNull();
     expect(useKubiStore.getState().turns).toHaveLength(0);
   });
 
-  it("configured: clicking a suggested-question chip seeds that shared question and opens the drawer", async () => {
+  it("configured: clicking a suggested-question chip seeds it and navigates to /kubi", async () => {
     useEmptyBuildsRealMode();
     configureKey();
+    renderHomeWithKubiRoute();
+    const chip = await screen.findByRole("button", { name: START_QUESTIONS[0] });
+    fireEvent.click(chip);
+
+    expect(await screen.findByText("KUBI ROUTE STUB")).toBeInTheDocument();
+    expect(useKubiStore.getState().pendingSeed).toBe(START_QUESTIONS[0]);
+    expect(useUIStore.getState().isKubiDrawerOpen).toBe(false);
+  });
+
+  it("hero chips no longer surface Quality/Build-failure/SQL questions with no context", async () => {
+    useEmptyBuildsRealMode();
     render(
       <MemoryRouter>
         <HomePage />
       </MemoryRouter>,
     );
-    const chip = await screen.findByRole("button", { name: SUGGESTED_QUESTIONS[0] });
-    fireEvent.click(chip);
-
-    expect(useKubiStore.getState().pendingSeed).toBe(SUGGESTED_QUESTIONS[0]);
-    expect(useUIStore.getState().isKubiDrawerOpen).toBe(true);
+    await screen.findByRole("heading", { name: HERO_HEADING });
+    expect(screen.queryByRole("button", { name: /Build.*실패/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Quality 이슈/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: START_QUESTIONS[0] })).toBeInTheDocument();
   });
 
   it("empty/whitespace query: does not seed a question or create a turn", async () => {
     useEmptyBuildsRealMode();
     configureKey();
-    render(
-      <MemoryRouter>
-        <HomePage />
-      </MemoryRouter>,
-    );
+    renderHomeWithKubiRoute();
     const input = await screen.findByLabelText("Kubi에게 자연어로 데이터 물어보기");
     fireEvent.change(input, { target: { value: "   " } });
     fireEvent.submit(input.closest("form")!);
 
     expect(useKubiStore.getState().pendingSeed).toBeNull();
     expect(useKubiStore.getState().turns).toHaveLength(0);
+  });
+
+  it("seeded question renders as a user turn once the Kubi page mounts", async () => {
+    useEmptyBuildsRealMode();
+    useKubiStore.setState({ turns: [], onboarded: false, pendingSeed: "서울 대기오염 데이터로 뭘 할 수 있어?" });
+    render(
+      <MemoryRouter initialEntries={["/kubi"]}>
+        <KubiPage />
+      </MemoryRouter>,
+    );
+    // BYOK 미설정이라 no_key 에러 turn이 되지만, 질문 자체는 user turn으로 표시된다(네트워크 없음).
+    expect(await screen.findByText("서울 대기오염 데이터로 뭘 할 수 있어?")).toBeInTheDocument();
   });
 });

--- a/__tests__/HomePage.test.tsx
+++ b/__tests__/HomePage.test.tsx
@@ -7,10 +7,13 @@ import { SUGGESTED_QUESTIONS } from "@/features/kubi/suggestedQuestions";
 import { useKubiStore } from "@/features/kubi/useKubiSession";
 import { HomePage } from "@/pages/HomePage";
 import { builderApi } from "@/shared/lib/builderApi";
+import { API_BASE } from "@/shared/config/env";
 import { useUIStore } from "@/shared/hooks/useUIStore";
 import { mswServer } from "../vitest.setup";
 
-const BUILDER_BASE = "http://localhost:8000";
+// 클라이언트가 실제로 부르는 base와 동일해야 한다(로컬 .env.local이 127.0.0.1로
+// 덮어써도 msw 핸들러가 매칭되도록 하드코딩 대신 API_BASE에서 파생).
+const BUILDER_BASE = API_BASE;
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -23,14 +26,33 @@ function mockEmptyBuilds() {
 }
 
 /**
+ * dataset total / quality summary aggregate를 미지원(구버전 Builder)으로 고정한다.
+ * 두 KPI는 "확인 불가"가 되어야 하며 임의 0/PASS로 합성되면 안 된다. real 모드에서
+ * HomePage가 항상 이 둘을 조회하므로, 다른 KPI를 검증하는 테스트도 명시적으로 stub한다.
+ */
+function mockDashboardAggregatesUnsupported() {
+  mswServer.use(
+    http.get(`${BUILDER_BASE}/datasets`, () => HttpResponse.json({ datasets: [] })),
+    http.get(`${BUILDER_BASE}/quality/summary`, () => new HttpResponse(null, { status: 404 })),
+  );
+}
+
+/**
  * mock 모드(`VITE_USE_REAL_BUILDER` 미설정)의 `listBuilds()`는 결정적 데모 데이터
  * (DEMO_DATASETS, 항상 succeeded 빌드 포함)를 반환하고 msw를 아예 거치지 않는다
  * (features/runs/api/index.ts) — 그래서 신규 사용자(빌드 0개) 상태를 결정적으로 재현하려면
  * 실제 Builder 연동 모드로 전환해 `/builds` 응답 자체를 msw로 통제해야 한다.
+ *
+ * 신규 사용자 = 빌드 0개 **그리고** authoritative dataset total 0. real 모드에서는
+ * dataset total이 확인돼야(GET /datasets `total: 0`) NewUserHome이 렌더된다 —
+ * total을 확인할 수 없으면 빈 build만으로 신규 사용자로 추측하지 않기 때문이다.
  */
 function useEmptyBuildsRealMode() {
   vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
   mockEmptyBuilds();
+  mswServer.use(
+    http.get(`${BUILDER_BASE}/datasets`, () => HttpResponse.json({ datasets: [], total: 0 })),
+  );
 }
 
 function configureKey() {
@@ -118,13 +140,16 @@ describe("HomePage", () => {
         artifact_store: { availability: "available", last_write_at: null },
       })),
     );
+    mockDashboardAggregatesUnsupported();
 
     render(<MemoryRouter><HomePage /></MemoryRouter>);
 
     expect(await screen.findByText("7")).toBeInTheDocument();
     expect(screen.getByText("3")).toBeInTheDocument();
     expect(screen.getAllByText("확인 불가")).toHaveLength(2);
-    expect(screen.getByText("품질 경고 집계 확인 불가")).toBeInTheDocument();
+    expect(
+      screen.getByText("개별 품질 경고 목록은 아직 제공되지 않습니다"),
+    ).toBeInTheDocument();
     expect(screen.queryByText("품질 경고가 없습니다")).not.toBeInTheDocument();
     expect(screen.queryByText("모든 빌드가 정상적으로 완료되었습니다")).not.toBeInTheDocument();
   });
@@ -140,6 +165,7 @@ describe("HomePage", () => {
       http.get(`${BUILDER_BASE}/monitoring/builds`, () => monitoringBuilds.promise),
       http.get(`${BUILDER_BASE}/monitoring/summary`, () => monitoringSummary.promise),
     );
+    mockDashboardAggregatesUnsupported();
     render(<MemoryRouter><HomePage /></MemoryRouter>);
     expect(await screen.findByText("deferred-run")).toBeInTheDocument();
     expect(screen.queryByText(/빌드 목록을 불러오지 못했습니다/)).not.toBeInTheDocument();
@@ -156,6 +182,7 @@ describe("HomePage", () => {
     mswServer.use(
       http.get(`${BUILDER_BASE}/builds`, () => HttpResponse.json({ builds: [{ run_id: "still-visible", status: "ok", started_at: "2026-08-31T00:00:00Z", finished_at: null }] })),
     );
+    mockDashboardAggregatesUnsupported();
     vi.spyOn(builderApi, "getMonitoringBuilds").mockRejectedValue(new Error("monitoring down"));
     vi.spyOn(builderApi, "getMonitoringSummary").mockRejectedValue(new Error("monitoring down"));
     render(<MemoryRouter><HomePage /></MemoryRouter>);

--- a/__tests__/HomePage.test.tsx
+++ b/__tests__/HomePage.test.tsx
@@ -140,6 +140,7 @@ describe("HomePage", () => {
         workers: { availability: "available", active: 1, capacity: 1, utilization: 1 },
         artifact_store: { availability: "available", last_write_at: null },
       })),
+      http.get(`${BUILDER_BASE}/builds/ok-run/quality`, () => new HttpResponse(null, { status: 404 })),
     );
     mockDashboardAggregatesUnsupported();
 

--- a/__tests__/SignupPage.test.tsx
+++ b/__tests__/SignupPage.test.tsx
@@ -1,28 +1,21 @@
-/**
- * SignupPage (#263 → #Phase2 UI polish) — ADR 0015 §5(public signup 기본 OFF)에 맞춰
- * 자체 회원가입 폼 대신 계정 발급 안내 화면으로 바뀌었다. 폼/email verification 관련
- * 이전 테스트는 더 이상 유효하지 않다 — 안내 화면과 로그인 링크만 확인한다.
- */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { SignupPage } from "@/pages/SignupPage";
 
 function renderSignup() {
-  return render(
-    <MemoryRouter>
-      <SignupPage />
-    </MemoryRouter>,
-  );
+  return render(<MemoryRouter><SignupPage /></MemoryRouter>);
 }
 
+afterEach(() => vi.unstubAllEnvs());
+
 describe("SignupPage", () => {
-  it("does not offer a self-serve signup form — shows a policy notice and a link back to login", () => {
+  it("delegates signup to Keycloak instead of rendering a local credential form", () => {
     renderSignup();
-    expect(screen.getByRole("heading", { name: "계정 발급 안내" })).toBeInTheDocument();
-    expect(screen.getByText("공개 회원가입을 제공하지 않습니다", { exact: false })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "계정 만들기" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "KPubData 계정 만들기" })).toBeInTheDocument();
+    expect(screen.getByText("Keycloak 화면에서 처리합니다", { exact: false })).toBeInTheDocument();
     expect(screen.queryByLabelText("이메일", { exact: false })).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "로그인하러 가기" })).toHaveAttribute("href", "/login");
+    expect(screen.queryByLabelText("비밀번호", { exact: false })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "로그인으로 돌아가기" })).toHaveAttribute("href", "/login");
   });
 });

--- a/__tests__/addDataCredentialPrerequisite.test.tsx
+++ b/__tests__/addDataCredentialPrerequisite.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Add Data → Provider 왕복 통합 테스트 (#S-add-data §3, §4).
+ *
+ * credential이 필요한 Public API Dataset을 선택했는데 provider가 미설정이면
+ * Preview까지 가지 않고 Configure 단계에서 미리 막는다. "API 연결하기"는 기존
+ * draft persistence를 재사용해 초안을 저장한 뒤 `/provider?provider=…&returnTo=/add`로
+ * 이동한다 — provider id/safe return destination만 URL에 싣는다.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AddDataPage } from "@/pages/AddDataPage";
+import { ProviderPage } from "@/pages/ProviderPage";
+import { loadAddDataDraft } from "@/features/add-data/draftStorage";
+import { API_BASE } from "@/shared/config/env";
+import { mswServer } from "../vitest.setup";
+
+function renderApp() {
+  return render(
+    <MemoryRouter initialEntries={["/add"]}>
+      <Routes>
+        <Route path="/add" element={<AddDataPage />} />
+        <Route path="/provider" element={<ProviderPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function next() {
+  fireEvent.click(screen.getByRole("button", { name: "다음" }));
+}
+
+function useAirQualityCatalog() {
+  mswServer.use(
+    http.get(`${API_BASE}/catalog`, () =>
+      HttpResponse.json({
+        providers: [
+          {
+            name: "datago",
+            datasets: [
+              {
+                name: "air_quality",
+                title: "대기오염",
+                description: null,
+                tags: [],
+                source_url: null,
+                representation: "api_json",
+                operations: [],
+                query_support: null,
+                requires_service_key: true,
+                request_parameters: [
+                  { name: "sidoName", required: true, description: "조회할 시·도", example: "서울" },
+                ],
+                application: { required: true, url: "https://www.data.go.kr/data/15073861/openapi.do" },
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+  );
+}
+
+async function selectAirQuality() {
+  fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
+  next();
+  await screen.findByText("API 사용 준비");
+  fireEvent.change(screen.getByLabelText(/제공자 \(Provider\)/), { target: { value: "datago" } });
+  await waitFor(() => expect(screen.getByLabelText(/데이터셋 \(Dataset\)/)).not.toBeDisabled());
+  fireEvent.change(screen.getByLabelText(/데이터셋 \(Dataset\)/), { target: { value: "air_quality" } });
+  await screen.findByText("이 Dataset의 요청 파라미터");
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  localStorage.clear();
+});
+
+describe("Add Data credential prerequisite (real 모드)", () => {
+  it("provider가 미설정이면 Configure에서 막고, API 연결하기로 draft를 보존한 채 Provider로 이동한다", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    useAirQualityCatalog();
+    mswServer.use(
+      http.get(`${API_BASE}/providers`, () =>
+        HttpResponse.json({ providers: [{ provider: "datago", requires_credential: true, configured: false }] }),
+      ),
+      http.get(`${API_BASE}/providers/datago/credential`, () =>
+        HttpResponse.json({ configured: false, masked: null, updated_at: null }),
+      ),
+    );
+    renderApp();
+    await selectAirQuality();
+    fireEvent.change(screen.getByLabelText(/요청 파라미터/), { target: { value: '{"sidoName":"서울"}' } });
+
+    expect(await screen.findByText("API 연결이 필요합니다")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "API 연결하기" }));
+
+    // Provider 화면으로 이동하고, provider가 자동 선택되며 복귀 안내가 보인다.
+    expect(await screen.findByText("데이터 추가를 계속하려면 API 연결을 완료하세요.")).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "등록하기" })).toBeInTheDocument();
+
+    // draft가 저장돼 있다 — provider/dataset/사용자가 입력한 요청 파라미터까지 보존된다.
+    const saved = loadAddDataDraft();
+    expect(saved?.publicApi.provider).toBe("datago");
+    expect(saved?.publicApi.dataset).toBe("air_quality");
+    expect(saved?.publicApi.sourceParams).toContain("서울");
+  });
+
+  it("provider가 configured면 막지 않고 Preview 요청을 진행한다", async () => {
+    vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+    useAirQualityCatalog();
+    mswServer.use(
+      http.get(`${API_BASE}/providers`, () =>
+        HttpResponse.json({ providers: [{ provider: "datago", requires_credential: true, configured: true }] }),
+      ),
+      http.post(`${API_BASE}/preview`, () =>
+        HttpResponse.json({ previews: [], transforms: [], diff: null }),
+      ),
+      http.post(`${API_BASE}/validate`, () => HttpResponse.json({ valid: true, errors: [] })),
+    );
+    renderApp();
+    await selectAirQuality();
+    fireEvent.change(screen.getByLabelText(/요청 파라미터/), { target: { value: '{"sidoName":"서울"}' } });
+
+    await waitFor(() => expect(screen.queryByText("API 연결이 필요합니다")).not.toBeInTheDocument());
+
+    next();
+    await screen.findByRole("heading", { name: /Preview · 검증/ });
+    expect(screen.queryByText("API 연결이 필요합니다")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/addDataCredentialPrerequisite.test.tsx
+++ b/__tests__/addDataCredentialPrerequisite.test.tsx
@@ -66,8 +66,14 @@ async function selectAirQuality() {
   fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
   next();
   await screen.findByText("API 사용 준비");
+  // "API 사용 준비" heading은 catalog loading 중에도 렌더된다. 느린 러너(Node 20)에서
+  // provider option이 아직 DOM에 없을 때 select value를 바꾸면 무시되어 Dataset select가
+  // 계속 disabled로 남는다. sleep 대신 실제 selectable state — datago option이 렌더된
+  // 것 — 를 기준으로 기다린다.
+  await screen.findByRole("option", { name: "datago" });
   fireEvent.change(screen.getByLabelText(/제공자 \(Provider\)/), { target: { value: "datago" } });
-  await waitFor(() => expect(screen.getByLabelText(/데이터셋 \(Dataset\)/)).not.toBeDisabled());
+  // provider 선택이 반영되면 Dataset select가 열리고 해당 provider의 dataset option이 붙는다.
+  await screen.findByRole("option", { name: "대기오염 (air_quality)" });
   fireEvent.change(screen.getByLabelText(/데이터셋 \(Dataset\)/), { target: { value: "air_quality" } });
   await screen.findByText("이 Dataset의 요청 파라미터");
 }

--- a/__tests__/addDataPreviewRace.test.tsx
+++ b/__tests__/addDataPreviewRace.test.tsx
@@ -82,7 +82,7 @@ describe("Add Data Workbench — Preview latest-request race (#283 후속 리뷰
 
     fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
     next();
-    await screen.findByText("제공자 연결");
+    await screen.findByLabelText("제공자 (Provider)");
     await screen.findByRole("option", { name: "datago" });
     fireEvent.change(screen.getByLabelText(/제공자 \(Provider\)/), { target: { value: "datago" } });
     await waitFor(() => expect(screen.getByLabelText(/데이터셋 \(Dataset\)/)).not.toBeDisabled());

--- a/__tests__/addDataWizard.test.tsx
+++ b/__tests__/addDataWizard.test.tsx
@@ -10,6 +10,7 @@
  * 삼는다 — `fillIdentity()`는 "고급 설정에서 자동 생성값을 수정하는" 시나리오에서만
  * 쓰고, 기본 happy path는 자동 생성값 그대로 다음 단계까지 진행 가능함을 검증한다.
  */
+import { StrictMode } from "react";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { MemoryRouter, Route, Routes, useParams } from "react-router-dom";
@@ -31,6 +32,23 @@ function renderWizard(initialEntries: string[] = ["/add"]) {
         <Route path="/builds/:buildId" element={<BuildDetailStub />} />
       </Routes>
     </MemoryRouter>,
+  );
+}
+
+/**
+ * 실제 진입점(`src/main.tsx`)처럼 StrictMode로 감싼다 — setState updater가 두 번
+ * 호출되는 조건에서도 회귀하지 않는지 검증하기 위함(#S-stale-params).
+ */
+function renderWizardStrict(initialEntries: string[] = ["/add"]) {
+  return render(
+    <StrictMode>
+      <MemoryRouter initialEntries={initialEntries}>
+        <Routes>
+          <Route path="/add" element={<AddDataPage />} />
+          <Route path="/builds/:buildId" element={<BuildDetailStub />} />
+        </Routes>
+      </MemoryRouter>
+    </StrictMode>,
   );
 }
 
@@ -59,9 +77,9 @@ afterEach(() => {
 describe("Add Data Workbench — Source 선택 (#250)", () => {
   it("Source를 선택하지 않으면 다음 단계로 넘어가지 않는다", () => {
     renderWizard();
-    expect(screen.getByRole("heading", { name: "Source 선택" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "데이터 선택" })).toBeInTheDocument();
     next();
-    expect(screen.getByRole("heading", { name: "Source 선택" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "데이터 선택" })).toBeInTheDocument();
   });
 });
 
@@ -71,7 +89,7 @@ describe("Add Data Workbench — Public API happy path (mock 모드, #250 amendm
 
     fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
     next();
-    await screen.findByText("제공자 연결");
+    await screen.findByText("API 사용 준비");
 
     // mock catalog는 provider "datago" / dataset "apt_trade"를 제공한다(features/add-data/api.ts).
     fireEvent.change(screen.getByLabelText(/제공자 \(Provider\)/), { target: { value: "datago" } });
@@ -83,12 +101,12 @@ describe("Add Data Workbench — Public API happy path (mock 모드, #250 amendm
     expect(screen.getByText(/ID: datago-apt-trade/)).toBeInTheDocument();
 
     next();
-    await screen.findByRole("heading", { name: /미리보기 · 검증/ });
+    await screen.findByRole("heading", { name: "Preview · 검증" });
     fireEvent.click(screen.getByRole("button", { name: "Preview 새로고침" }));
     await waitFor(() => expect(screen.getAllByText(/./).length).toBeGreaterThan(0));
 
     next();
-    await screen.findByRole("heading", { name: /검토 · 빌드/ });
+    await screen.findByRole("heading", { name: "검토 · Build" });
     expect(screen.getByText(/실제 제출될 canonical BuildSpec/)).toBeInTheDocument();
     expect(screen.getByText(/"dataset_id": "datago-apt-trade"/)).toBeInTheDocument();
     expect(screen.getByText(/"title": "아파트 실거래가"/)).toBeInTheDocument();
@@ -104,7 +122,7 @@ describe("Add Data Workbench — Public API happy path (mock 모드, #250 amendm
     renderWizard();
     fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
     next();
-    await screen.findByText("제공자 연결");
+    await screen.findByText("API 사용 준비");
 
     fireEvent.change(screen.getByLabelText(/제공자 \(Provider\)/), { target: { value: "datago" } });
     await waitFor(() => expect(screen.getByLabelText(/데이터셋 \(Dataset\)/)).not.toBeDisabled());
@@ -122,7 +140,7 @@ describe("Add Data Workbench — Public API happy path (mock 모드, #250 amendm
     renderWizard();
     fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
     next();
-    await screen.findByText("제공자 연결");
+    await screen.findByText("API 사용 준비");
     fireEvent.change(screen.getByLabelText(/제공자 \(Provider\)/), { target: { value: "datago" } });
     await waitFor(() => expect(screen.getByLabelText(/데이터셋 \(Dataset\)/)).not.toBeDisabled());
     fireEvent.change(screen.getByLabelText(/데이터셋 \(Dataset\)/), { target: { value: "apt_trade" } });
@@ -131,11 +149,11 @@ describe("Add Data Workbench — Public API happy path (mock 모드, #250 amendm
     await overrideIdentityInAdvancedSettings({ datasetId: "custom-id", title: "커스텀 제목" });
 
     next();
-    await screen.findByRole("heading", { name: /미리보기 · 검증/ });
+    await screen.findByRole("heading", { name: "Preview · 검증" });
     fireEvent.click(screen.getByRole("button", { name: "Preview 새로고침" }));
     await waitFor(() => expect(screen.getAllByText(/./).length).toBeGreaterThan(0));
     next();
-    await screen.findByRole("heading", { name: /검토 · 빌드/ });
+    await screen.findByRole("heading", { name: "검토 · Build" });
     expect(screen.getByText(/"dataset_id": "custom-id"/)).toBeInTheDocument();
     expect(screen.getByText(/"title": "커스텀 제목"/)).toBeInTheDocument();
   });
@@ -146,7 +164,7 @@ describe("Add Data Workbench — touched metadata 정책 (#250 최종 검증 §1
     renderWizard();
     fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
     next();
-    await screen.findByText("제공자 연결");
+    await screen.findByText("API 사용 준비");
     fireEvent.change(screen.getByLabelText(/제공자 \(Provider\)/), { target: { value: "datago" } });
     await waitFor(() => expect(screen.getByLabelText(/데이터셋 \(Dataset\)/)).not.toBeDisabled());
     fireEvent.change(screen.getByLabelText(/데이터셋 \(Dataset\)/), { target: { value: "apt_trade" } });
@@ -164,7 +182,7 @@ describe("Add Data Workbench — touched metadata 정책 (#250 최종 검증 §1
     renderWizard();
     fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
     next();
-    await screen.findByText("제공자 연결");
+    await screen.findByText("API 사용 준비");
     // catalog option이 실제 DOM에 나타날 때까지 기다린 뒤에 provider를 선택한다
     // (Node 20 CI에서 catalog fetch가 아직 준비되지 않아 dataset select가 disabled로
     // 남아 timeout하던 문제 수정, #283 CI #342 §8) — 같은 파일의 mixed preview
@@ -237,7 +255,7 @@ describe("Add Data Workbench — touched metadata 정책 (#250 최종 검증 §1
     renderWizard();
     fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
     next();
-    await screen.findByText("제공자 연결");
+    await screen.findByText("API 사용 준비");
     fireEvent.change(screen.getByLabelText(/제공자 \(Provider\)/), { target: { value: "datago" } });
     await waitFor(() => expect(screen.getByLabelText(/데이터셋 \(Dataset\)/)).not.toBeDisabled());
     fireEvent.change(screen.getByLabelText(/데이터셋 \(Dataset\)/), { target: { value: "apt_trade" } });
@@ -255,12 +273,145 @@ describe("Add Data Workbench — touched metadata 정책 (#250 최종 검증 §1
   });
 });
 
+describe("Add Data Workbench — Dataset 변경 시 요청 파라미터 초기화", () => {
+  const paramsField = () => screen.getByLabelText(/요청 파라미터/) as HTMLTextAreaElement;
+
+  async function gotoConfigurePublicApi(renderFn: typeof renderWizard = renderWizard) {
+    const result = renderFn();
+    fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
+    next();
+    await screen.findByText("API 사용 준비");
+    await screen.findByRole("option", { name: "datago" });
+    fireEvent.change(screen.getByLabelText(/제공자 \(Provider\)/), { target: { value: "datago" } });
+    await waitFor(() => expect(screen.getByLabelText(/데이터셋 \(Dataset\)/)).not.toBeDisabled());
+    return result;
+  }
+
+  function selectDataset(name: string) {
+    fireEvent.change(screen.getByLabelText(/데이터셋 \(Dataset\)/), { target: { value: name } });
+  }
+
+  function selectProvider(name: string) {
+    fireEvent.change(screen.getByLabelText(/제공자 \(Provider\)/), { target: { value: name } });
+  }
+
+  async function pickAirQualityWithExample() {
+    selectDataset("air_quality");
+    await screen.findByText(/ID: datago-air-quality/);
+    fireEvent.click(screen.getByRole("button", { name: "예시값 적용" }));
+    await waitFor(() => expect(paramsField().value).toContain("sidoName"));
+    expect(paramsField().value).toContain("서울");
+    expect(screen.getByText("이 Dataset의 요청 파라미터")).toBeInTheDocument();
+  }
+
+  it("Case 1 — 다른 Dataset을 고르면 이전 Dataset 전용 요청 파라미터가 `{}`로 초기화된다", async () => {
+    await gotoConfigurePublicApi();
+    await pickAirQualityWithExample();
+
+    // 다른 Dataset(apt_trade)으로 교체 — canonical Dataset selection 변경.
+    selectDataset("apt_trade");
+    await screen.findByText(/ID: datago-apt-trade/);
+
+    expect(paramsField().value).toBe("{}");
+    expect(screen.queryByText(/sidoName/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/서울/)).not.toBeInTheDocument();
+    // air_quality 전용 required-param 안내도 사라진다(apt_trade는 metadata 없음).
+    expect(screen.queryByText("이 Dataset의 요청 파라미터")).not.toBeInTheDocument();
+  });
+
+  it("Case 1b — 실제 진입점처럼 StrictMode로 감싸도 요청 파라미터가 `{}`로 초기화된다", async () => {
+    // 이전 수정(identity useEffect의 sourceChanged 분기에서 reset)이 브라우저에서
+    // 실패한 조건 재현: StrictMode에서 setDraft updater가 두 번 호출되면, ref를
+    // mutate하는 effect updater는 두 번째 호출에서 sourceChanged=false가 되어
+    // reset 결과가 버려졌다. select onChange의 atomic reset은 여기서도 성립한다.
+    await gotoConfigurePublicApi(renderWizardStrict);
+    await pickAirQualityWithExample();
+
+    selectDataset("apt_trade");
+    await screen.findByText(/ID: datago-apt-trade/);
+
+    expect(paramsField().value).toBe("{}");
+    expect(screen.queryByText(/서울/)).not.toBeInTheDocument();
+  });
+
+  it("Case 1c — Provider를 실제로 바꾸면 dataset과 요청 파라미터가 같은 update에서 비워진다", async () => {
+    await gotoConfigurePublicApi();
+    await pickAirQualityWithExample();
+
+    // Provider selection을 실제로 바꾼다(datago -> 미선택). dataset도 무효가 되므로
+    // sourceParams가 같은 update에서 "{}"로 비워져야 한다.
+    selectProvider("");
+    expect(paramsField().value).toBe("{}");
+    expect(screen.getByLabelText(/데이터셋 \(Dataset\)/)).toHaveValue("");
+
+    // 다시 datago -> air_quality를 골라도 이전 "서울" 값이 되살아나지 않는다.
+    selectProvider("datago");
+    await waitFor(() => expect(screen.getByLabelText(/데이터셋 \(Dataset\)/)).not.toBeDisabled());
+    selectDataset("air_quality");
+    await screen.findByText(/ID: datago-air-quality/);
+    expect(paramsField().value).toBe("{}");
+  });
+
+  it("Case 2 — 같은 Dataset에서 Preview로 갔다 Configure로 돌아오면 요청 파라미터가 유지된다", async () => {
+    await gotoConfigurePublicApi();
+
+    selectDataset("air_quality");
+    await screen.findByText(/ID: datago-air-quality/);
+    fireEvent.change(paramsField(), { target: { value: '{"sidoName":"부산"}' } });
+
+    next(); // Configure -> Preview
+    await screen.findByRole("heading", { name: "Preview · 검증" });
+    fireEvent.click(screen.getByRole("button", { name: "이전" })); // Preview -> Configure
+    await screen.findByText("API 사용 준비");
+
+    expect(paramsField().value).toBe('{"sidoName":"부산"}');
+  });
+
+  it("Case 3 — 초안 저장/복원으로 같은 Dataset이 되돌아오면 요청 파라미터가 유지된다", async () => {
+    const first = await gotoConfigurePublicApi();
+    selectDataset("air_quality");
+    await screen.findByText(/ID: datago-air-quality/);
+    fireEvent.change(paramsField(), { target: { value: '{"sidoName":"부산"}' } });
+    fireEvent.click(screen.getByRole("button", { name: "초안 저장" }));
+    first.unmount();
+
+    renderWizard();
+    fireEvent.click(await screen.findByRole("button", { name: "불러오기" }));
+    fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
+    next();
+    await screen.findByText("API 사용 준비");
+    await screen.findByText(/ID: datago-air-quality/);
+
+    expect(paramsField().value).toBe('{"sidoName":"부산"}');
+    expect(screen.getByText("이 Dataset의 요청 파라미터")).toBeInTheDocument();
+  });
+
+  it("Case 4 — 새 Dataset도 metadata가 있으면 초기화된 값 위에 새 Dataset metadata가 렌더된다", async () => {
+    await gotoConfigurePublicApi();
+
+    // apt_trade(요청 파라미터 metadata 없음) → air_quality(sidoName 필수).
+    selectDataset("apt_trade");
+    await screen.findByText(/ID: datago-apt-trade/);
+    fireEvent.change(paramsField(), { target: { value: '{"legacyParam":"stale"}' } });
+
+    selectDataset("air_quality");
+    await screen.findByText(/ID: datago-air-quality/);
+
+    expect(paramsField().value).toBe("{}");
+    expect(screen.queryByText(/legacyParam/)).not.toBeInTheDocument();
+    // 새 Dataset(air_quality)의 metadata가 표시된다.
+    expect(screen.getByText("이 Dataset의 요청 파라미터")).toBeInTheDocument();
+    expect(screen.getByText("sidoName")).toBeInTheDocument();
+    expect(screen.getByText('예: {"sidoName":"서울"}')).toBeInTheDocument();
+  });
+});
+
 describe("Add Data Workbench — YAML Apply explicit metadata (#283 후속 리뷰 §6)", () => {
   it("YAML Apply로 넣은 custom dataset_id/title/description이 identity effect에 덮이지 않고, 그 뒤 실제 GUI dataset 선택에서는 touched가 reset된다", async () => {
     renderWizard();
     fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
     next();
-    await screen.findByText("제공자 연결");
+    await screen.findByText("API 사용 준비");
     await screen.findByRole("option", { name: "datago" });
     fireEvent.change(screen.getByLabelText(/제공자 \(Provider\)/), { target: { value: "datago" } });
     await waitFor(() => expect(screen.getByLabelText(/데이터셋 \(Dataset\)/)).not.toBeDisabled());
@@ -310,25 +461,25 @@ describe("Add Data Workbench — stale preview (#250 §2/§6)", () => {
     renderWizard();
     fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
     next();
-    await screen.findByText("제공자 연결");
+    await screen.findByText("API 사용 준비");
     fireEvent.change(screen.getByLabelText(/제공자 \(Provider\)/), { target: { value: "datago" } });
     await waitFor(() => expect(screen.getByLabelText(/데이터셋 \(Dataset\)/)).not.toBeDisabled());
     fireEvent.change(screen.getByLabelText(/데이터셋 \(Dataset\)/), { target: { value: "apt_trade" } });
     next();
-    await screen.findByRole("heading", { name: /미리보기 · 검증/ });
+    await screen.findByRole("heading", { name: "Preview · 검증" });
     fireEvent.click(screen.getByRole("button", { name: "Preview 새로고침" }));
     next();
-    await screen.findByRole("heading", { name: /검토 · 빌드/ });
+    await screen.findByRole("heading", { name: "검토 · Build" });
     await waitFor(() => expect(screen.getByRole("button", { name: "Build 시작" })).toBeEnabled());
 
     // Configure로 돌아가 파라미터를 바꾼다 — 이전 Preview/Validation은 stale이어야 한다.
     fireEvent.click(screen.getByRole("button", { name: "이전" }));
     fireEvent.click(screen.getByRole("button", { name: "이전" }));
-    await screen.findByText("제공자 연결");
+    await screen.findByText("API 사용 준비");
     fireEvent.change(screen.getByLabelText(/요청 파라미터/), { target: { value: '{"region":"busan"}' } });
     next();
     next();
-    await screen.findByRole("heading", { name: /검토 · 빌드/ });
+    await screen.findByRole("heading", { name: "검토 · Build" });
 
     expect(screen.getByRole("button", { name: "Build 시작" })).toBeDisabled();
     expect(screen.getByText(/이전 Preview·Validation 결과를 재사용할 수 없습니다/)).toBeInTheDocument();
@@ -353,9 +504,9 @@ describe("Add Data Workbench — File source (#250, #498, amendment 2)", () => {
     expect(screen.getByText("2026 Apt Trades")).toBeInTheDocument();
 
     next();
-    await screen.findByRole("heading", { name: /미리보기 · 검증/ });
+    await screen.findByRole("heading", { name: "Preview · 검증" });
     next();
-    await screen.findByRole("heading", { name: /검토 · 빌드/ });
+    await screen.findByRole("heading", { name: "검토 · Build" });
     expect(screen.getByText(/"kind": "file"/)).toBeInTheDocument();
     expect(screen.getByText(/"dataset_id": "2026-apt-trades"/)).toBeInTheDocument();
   });
@@ -381,9 +532,9 @@ describe("Add Data Workbench — URL source (#250, #498, Auth=None, amendment 2)
     expect(within(summaryId.closest("div")!).queryByText(/busan/i)).not.toBeInTheDocument();
 
     next();
-    await screen.findByRole("heading", { name: /미리보기 · 검증/ });
+    await screen.findByRole("heading", { name: "Preview · 검증" });
     next();
-    await screen.findByRole("heading", { name: /검토 · 빌드/ });
+    await screen.findByRole("heading", { name: "검토 · Build" });
     expect(screen.getByText(/"kind": "url"/)).toBeInTheDocument();
     // 비민감 query parameter는 canonical BuildSpec preview에 그대로 보인다.
     expect(screen.getByText(/"endpoint": "https:\/\/api\.example\.org\/v1\/air-quality\?region=busan"/)).toBeInTheDocument();
@@ -403,9 +554,9 @@ describe("Add Data Workbench — URL source (#250, #498, Auth=None, amendment 2)
     await screen.findByText(/ID: api-example-org-v1-air-quality/);
 
     next();
-    await screen.findByRole("heading", { name: /미리보기 · 검증/ });
+    await screen.findByRole("heading", { name: "Preview · 검증" });
     next();
-    await screen.findByRole("heading", { name: /검토 · 빌드/ });
+    await screen.findByRole("heading", { name: "검토 · Build" });
 
     // 원문 secret은 화면 어디에도(Source summary/canonical BuildSpec preview) 나타나지 않는다.
     expect(document.body.textContent ?? "").not.toContain("SECRETVALUE1234567890");
@@ -476,7 +627,7 @@ describe("Add Data Workbench — mixed/partial preview (#250 §3)", () => {
     renderWizard();
     fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
     next();
-    await screen.findByText("제공자 연결");
+    await screen.findByText("API 사용 준비");
     // "제공자 연결" 텍스트 렌더는 catalog loaded를 보장하지 않는다 — catalog option이
     // 실제 DOM에 나타날 때까지 기다린 뒤에 provider를 선택한다(test race 수정).
     await screen.findByRole("option", { name: "datago" });
@@ -485,7 +636,7 @@ describe("Add Data Workbench — mixed/partial preview (#250 §3)", () => {
     fireEvent.change(screen.getByLabelText(/데이터셋 \(Dataset\)/), { target: { value: "air_quality" } });
 
     next();
-    await screen.findByRole("heading", { name: /미리보기 · 검증/ });
+    await screen.findByRole("heading", { name: "Preview · 검증" });
     fireEvent.click(screen.getByRole("button", { name: "Preview 새로고침" }));
 
     // 두 source 모두 tab으로 보인다 — 첫 source만 남기고 버리지 않는다.
@@ -505,7 +656,7 @@ describe("Add Data Workbench — mixed/partial preview (#250 §3)", () => {
     expect(screen.getByText("서울")).toBeInTheDocument();
 
     next();
-    await screen.findByRole("heading", { name: /검토 · 빌드/ });
+    await screen.findByRole("heading", { name: "검토 · Build" });
     // Review에도 source별 상태가 남아 있다 — 하나의 PASS로 뭉개지지 않는다.
     const reviewSection = screen.getByText("Source별 Preview/Validation").closest("div")!;
     expect(within(reviewSection).getByText("ok-source")).toBeInTheDocument();
@@ -546,17 +697,17 @@ describe("Add Data Workbench — Review == submission, 실제 run_id 사용 (rea
     renderWizard();
     fireEvent.click(screen.getByRole("button", { name: /Public API/ }));
     next();
-    await screen.findByText("제공자 연결");
+    await screen.findByText("API 사용 준비");
     fireEvent.change(screen.getByLabelText(/제공자 \(Provider\)/), { target: { value: "datago" } });
     await waitFor(() => expect(screen.getByLabelText(/데이터셋 \(Dataset\)/)).not.toBeDisabled());
     fireEvent.change(screen.getByLabelText(/데이터셋 \(Dataset\)/), { target: { value: "air_quality" } });
     await screen.findByText(/ID: datago-air-quality/);
     next();
-    await screen.findByRole("heading", { name: /미리보기 · 검증/ });
+    await screen.findByRole("heading", { name: "Preview · 검증" });
     fireEvent.click(screen.getByRole("button", { name: "Preview 새로고침" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "다음" })).toBeEnabled());
     next();
-    await screen.findByRole("heading", { name: /검토 · 빌드/ });
+    await screen.findByRole("heading", { name: "검토 · Build" });
 
     const reviewedSpecText = screen.getByText(/"dataset_id": "datago-air-quality"/).closest("pre")!.textContent!;
     const reviewedSpec = JSON.parse(reviewedSpecText);

--- a/__tests__/buildPublishPage.test.tsx
+++ b/__tests__/buildPublishPage.test.tsx
@@ -3,9 +3,11 @@ import { http, HttpResponse } from "msw";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BuildPublishPage } from "@/pages/BuildPublishPage";
+import { API_BASE } from "@/shared/config/env";
 import { mswServer } from "../vitest.setup";
 
-const BUILDER_BASE = "http://localhost:8000";
+// builderApi가 실제로 쓰는 API base와 동일하게 파생한다(하드코딩된 host에 종속되지 않도록).
+const BUILDER_BASE = API_BASE;
 
 afterEach(() => vi.unstubAllEnvs());
 

--- a/__tests__/buildPublishPage.test.tsx
+++ b/__tests__/buildPublishPage.test.tsx
@@ -36,6 +36,26 @@ describe("BuildPublishPage readiness (audit #4)", () => {
     expect(screen.getByText(/Bronze stage가 실패해/)).toBeInTheDocument();
   });
 
+  it("?dataset= 없이 exact run_id만으로 들어와도 Dataset identity와 Build 완료를 표시한다", async () => {
+    // 이전에는 URL에 ?dataset=이 없으면 Dataset/Build 완료가 "확인되지 않음"이었다
+    // (Builds/Runs·Artifacts·딥링크 진입 경로 전부). 이제 canonical run 해석으로 채운다.
+    renderPublish("air-quality-20260621");
+
+    const runCard = (await screen.findByText("선택한 Run")).closest("div");
+    expect(runCard).toHaveTextContent("대기오염 정보");
+    expect(runCard).toHaveTextContent("완료");
+    expect(runCard).not.toHaveTextContent("확인되지 않음");
+  });
+
+  it("Run마다 자기 Dataset identity를 표시하고 다른 Run과 섞이지 않는다", async () => {
+    renderPublish("dur-older-adult-caution-20260618");
+
+    const runCard = (await screen.findByText("선택한 Run")).closest("div");
+    expect(runCard).toHaveTextContent("노인주의 의약품");
+    expect(runCard).not.toHaveTextContent("대기오염 정보");
+    expect(runCard).toHaveTextContent("dur-older-adult-caution-20260618");
+  });
+
   it("ready:false인데 blockers가 비어 있으면 'blocker가 있다'고 잘못 단정하지 않는다", async () => {
     vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
     mswServer.use(

--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -53,6 +53,7 @@ const EXPECTED_OPERATIONS = [
   "putProviderCredential",
   "deleteProviderCredential",
   "uploadFile",
+  "downloadArtifactFile",
 ] as const;
 
 describe("Builder API contract conformance (#36)", () => {

--- a/__tests__/contractConformance.test.ts
+++ b/__tests__/contractConformance.test.ts
@@ -45,6 +45,7 @@ const EXPECTED_OPERATIONS = [
   "getBuildEvents",
   "getMonitoringSummary",
   "getMonitoringBuilds",
+  "getQualitySummary",
   "listProviders",
   "testProviderConnection",
   "getProviderStatus",

--- a/__tests__/kubiDrawer.test.tsx
+++ b/__tests__/kubiDrawer.test.tsx
@@ -35,7 +35,7 @@ describe("global Kubi drawer (#247)", () => {
 
     const dialog = screen.getByRole("dialog", { name: "Kubi AI Assistant" });
     // PAGE는 프로토타입처럼 grid cell이 아니라 보조 캡션으로만 표시된다(#256 review).
-    expect(within(dialog).getByText("현재 화면 · Quality")).toBeInTheDocument();
+    expect(within(dialog).getByText(/현재 Context · Quality/)).toBeInTheDocument();
     // context bar는 프로토타입 구조(DATASET/RUN/STAGE/QUALITY)를 따른다.
     expect(within(dialog).getByText("DATASET")).toBeInTheDocument();
     expect(within(dialog).getByText("QUALITY")).toBeInTheDocument();

--- a/__tests__/layout.test.tsx
+++ b/__tests__/layout.test.tsx
@@ -50,6 +50,34 @@ describe("Layout sidebar accessibility", () => {
   });
 });
 
+describe("Layout 제품 문구 중복 제거", () => {
+  beforeEach(() => {
+    act(() =>
+      useUIStore.setState({
+        theme: "light",
+        isMobileSidebarOpen: false,
+        isDesktopSidebarCollapsed: false,
+        isKubiDrawerOpen: false,
+      }),
+    );
+  });
+
+  it("sidebar에는 제품명만 남기고 tagline은 두지 않는다", () => {
+    renderLayout();
+    const aside = screen.getByRole("navigation").closest("aside")!;
+
+    expect(within(aside).getByRole("link", { name: "KPubData Studio" })).toBeInTheDocument();
+    expect(within(aside).queryByText("공공데이터를 데이터셋으로 만드는 워크스페이스")).not.toBeInTheDocument();
+  });
+
+  it("topbar에는 workspace context tagline이 그대로 남는다", () => {
+    renderLayout();
+    const header = screen.getByRole("banner");
+
+    expect(within(header).getByText("공공데이터를 데이터셋으로 만드는 워크스페이스")).toBeInTheDocument();
+  });
+});
+
 describe("Layout desktop sidebar collapse (#247)", () => {
   beforeEach(() => {
     act(() =>

--- a/__tests__/mocks/handlers.ts
+++ b/__tests__/mocks/handlers.ts
@@ -5,8 +5,12 @@
  * contract/builder-api.yaml의 SSOT와 정합하도록 작성.
  */
 import { http, HttpResponse } from "msw";
+import { API_BASE } from "@/shared/config/env";
 
-const BASE = "http://localhost:8000";
+// builderApi가 실제로 요청을 보내는 base와 동일하게 파생한다(로컬 .env.local의
+// VITE_BUILDER_API_URL 유무와 무관하게 핸들러가 매칭되도록). 특정 host 문자열에
+// 다시 종속시키지 않는다.
+const BASE = API_BASE;
 
 export const handlers = [
   http.get(`${BASE}/healthz`, () =>

--- a/__tests__/navigation.test.tsx
+++ b/__tests__/navigation.test.tsx
@@ -47,7 +47,7 @@ describe("grouped sidebar navigation (#247)", () => {
       "Quality (품질)": "/quality",
       Kubi: "/kubi",
       "Reports (리포트)": "/reports",
-      "Provider (제공기관)": "/provider",
+      "Provider / API 연결": "/provider",
       "Monitoring (모니터링)": "/monitoring",
       "Settings (설정)": "/settings",
     };

--- a/__tests__/newIaPages.test.tsx
+++ b/__tests__/newIaPages.test.tsx
@@ -71,7 +71,7 @@ describe("새 IA placeholder 화면 (#247)", () => {
     renderPage(<AddDataPage />);
     expect(screen.getByRole("heading", { name: "데이터 추가" })).toBeInTheDocument();
     expect(screen.queryByText("아직 준비 중인 화면입니다")).not.toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Source 선택" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "데이터 선택" })).toBeInTheDocument();
   });
 
   it("Dataset Detail loads the dataset identified by the route param", async () => {

--- a/__tests__/providerPage.test.tsx
+++ b/__tests__/providerPage.test.tsx
@@ -3,7 +3,9 @@
  *
  * - real mode는 GET /providers를 canonical source로 쓰고, 실패를 mock 성공으로
  *   위장하지 않는다(명시적 error + 빈 목록).
- * - 연결 테스트는 GET /providers/{provider}/status(임의 POST /test 아님).
+ * - generic Provider probe(POST /test · GET /status)는 임의의 첫 Dataset을 필수
+ *   파라미터 없이 호출하므로 신뢰할 수 없어 화면에서 제거됐다 — 실제 사용 가능
+ *   여부는 Preview가 확인한다(#S-provider-probe).
  * - "사용자 저장 credential" 유무/마스킹은 GET /providers/{provider}/credential
  *   메타데이터로만 판정한다 — GET /providers 요약의 `configured`(effective provider
  *   configuration)와 분리한다.
@@ -25,14 +27,6 @@ function renderPage() {
     </MemoryRouter>,
   );
 }
-
-const STATUS_OK = {
-  provider: "datago",
-  status: "connected" as const,
-  configured: true,
-  latency_ms: 120,
-  checked_at: "2026-08-31T00:00:00.000Z",
-};
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -71,25 +65,26 @@ describe("ProviderPage real mode (#S01)", () => {
     expect(screen.getByText("등록된 Provider가 없습니다")).toBeInTheDocument();
   });
 
-  it("connection test calls GET /providers/{provider}/status (not POST /test)", async () => {
+  it("does NOT call the generic Provider probe (POST /test or GET /status)", async () => {
     vi.spyOn(builderApi, "listProviders").mockResolvedValue({
       providers: [{ provider: "datago", requires_credential: true, configured: true }],
     });
     vi.spyOn(builderApi, "getProviderCredential").mockResolvedValue({
-      configured: false,
-      masked: null,
+      configured: true,
+      masked: "dg••••99",
       updated_at: null,
     });
-    const statusSpy = vi
-      .spyOn(builderApi, "getProviderStatus")
-      .mockResolvedValue(STATUS_OK);
+    const statusSpy = vi.spyOn(builderApi, "getProviderStatus");
+    const testSpy = vi.spyOn(builderApi, "testProviderConnection");
 
     renderPage();
     fireEvent.click(await screen.findByText("datago"));
-    fireEvent.click(screen.getByRole("button", { name: "연결 테스트" }));
 
-    await waitFor(() => expect(statusSpy).toHaveBeenCalledWith("datago"));
-    expect((await screen.findAllByText("연결됨")).length).toBeGreaterThan(0);
+    // credential readiness만 표시하고 generic live probe 버튼은 없다.
+    expect(await screen.findByText("dg••••99")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "연결 테스트" })).not.toBeInTheDocument();
+    expect(statusSpy).not.toHaveBeenCalled();
+    expect(testSpy).not.toHaveBeenCalled();
   });
 
   it("requires_credential=false → no masked key, no Delete, no register form", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@playwright/test": "1.62.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/dom": "^10.0.0",
-        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^26",
         "@types/react": "^19",
@@ -1351,9 +1351,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
-      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1365,18 +1365,9 @@
         "redent": "^3.0.0"
       },
       "engines": {
-        "node": ">=22",
+        "node": ">=14",
         "npm": ">=6",
         "yarn": ">=1"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=10 <11",
-        "vitest": ">= 0.32"
-      },
-      "peerDependenciesMeta": {
-        "vitest": {
-          "optional": true
-        }
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@playwright/test": "1.62.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.0.0",
-    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^26",
     "@types/react": "^19",

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -138,7 +138,7 @@ const navGroups: NavGroup[] = [
       {
         to: "/datasets",
         label: "Dataset Catalog (데이터셋)",
-        description: "발행된 데이터셋 검색",
+        description: "빌드된 데이터셋 검색",
         icon: (
           <SidebarIcon name="datasets">
             <ellipse cx="12" cy="5" rx="7" ry="3" />
@@ -202,8 +202,8 @@ const navGroups: NavGroup[] = [
     items: [
       {
         to: "/provider",
-        label: "Provider (제공기관)",
-        description: "Provider 연결·자격 증명",
+        label: "Provider / API 연결",
+        description: "API Key·자격 증명 등록",
         icon: (
           <SidebarIcon name="provider">
             <path d="M4 21V7l8-4 8 4v14M8 10h.01M12 10h.01M16 10h.01M8 14h.01M12 14h.01M16 14h.01" />
@@ -323,7 +323,8 @@ export function Layout() {
           />
         ) : null}
 
-        <aside
+          <aside
+            data-tour="sidebar"
           className={[
             "fixed inset-y-0 left-0 z-40 flex w-72 shrink-0 flex-col overflow-y-auto border-r border-border bg-card px-4 py-5 transition-all lg:static lg:translate-x-0",
             isMobileSidebarOpen ? "translate-x-0" : "-translate-x-full",
@@ -346,14 +347,8 @@ export function Layout() {
                   KPubData Studio
                 </Link>
               </div>
-              <p
-                className={[
-                  "mt-3 text-sm leading-relaxed text-muted-foreground",
-                  isDesktopSidebarCollapsed ? "lg:sr-only" : "",
-                ].join(" ")}
-              >
-                데이터 탐색부터 빌드, 품질, Kubi 분석까지 한 흐름으로 진행하세요.
-              </p>
+              {/* tagline은 Topbar가 workspace/product context를 담당하므로 Sidebar에서는
+                  제품명/로고만 유지한다(중복 제거). */}
             </div>
             <button
               aria-label="사이드바 닫기"
@@ -463,7 +458,7 @@ export function Layout() {
                     KPubData Studio
                   </p>
                   <h1 className="truncate text-base font-semibold tracking-tight">
-                    공공데이터 탐색·빌드·품질·Kubi 워크플로
+                    공공데이터를 데이터셋으로 만드는 워크스페이스
                   </h1>
                 </div>
               </div>

--- a/src/features/add-data/api.ts
+++ b/src/features/add-data/api.ts
@@ -23,6 +23,7 @@ const MOCK_CATALOG: CatalogResponse = {
           operations: ["list"],
           query_support: null,
           requires_service_key: true,
+          request_parameters: [],
         },
         {
           name: "air_quality",
@@ -34,6 +35,13 @@ const MOCK_CATALOG: CatalogResponse = {
           operations: ["list"],
           query_support: null,
           requires_service_key: true,
+          request_parameters: [
+            { name: "sidoName", required: true, description: "조회할 시·도", example: "서울" },
+          ],
+          application: {
+            required: true,
+            url: "https://www.data.go.kr/data/15073861/openapi.do",
+          },
         },
       ],
     },
@@ -47,14 +55,32 @@ export async function fetchCatalog(signal?: AbortSignal): Promise<CatalogRespons
 }
 
 /**
- * POST /providers/{provider}/test — "연결 테스트" 버튼(#492). mock 모드에서는 항상
- * connected를 반환해 네트워크 없이 UI를 검증할 수 있게 한다.
+ * POST /providers/{provider}/test 래퍼(#492). generic Provider probe는 임의의 첫
+ * Dataset을 필수 파라미터 없이 호출하므로 "연결 성공 여부"로 신뢰할 수 없어 Add
+ * Data user flow에서 제거됐다(#S-provider-probe). Builder contract는 유지되므로
+ * 래퍼 자체는 남겨 둔다(직접 진단용). mock 모드에서는 항상 connected를 반환한다.
  */
 export async function testProvider(provider: string, signal?: AbortSignal): Promise<ProviderTestResponse> {
   if (!isRealBuilderEnabled()) {
     return { provider, status: "connected", configured: true, latency_ms: 42, checked_at: new Date().toISOString() };
   }
   return builderApi.testProviderConnection(provider, signal);
+}
+
+/**
+ * GET /providers 요약에서 provider별 "effective credential 구성 여부"만 추린다
+ * (#S-add-data). Add Data의 credential prerequisite가 이 값을 authoritative
+ * source로 재사용한다 — `configured`는 user credential > server default > 없음을
+ * 반영한 effective 값이며(ADR 0012), Studio가 별도로 credential 존재를 추측하지
+ * 않는다. mock 모드는 `testProvider`(위)와 마찬가지로 항상 connected/configured로
+ * 취급해 네트워크 없이 나머지 mock 흐름을 막지 않는다 — prerequisite UX 자체는
+ * `ConfigureStep`에 `providerConfigured` prop을 직접 주입하는 컴포넌트 테스트로
+ * 검증한다.
+ */
+export async function fetchProviderConfigured(signal?: AbortSignal): Promise<Record<string, boolean>> {
+  if (!isRealBuilderEnabled()) return { datago: true };
+  const response = await builderApi.listProviders(signal);
+  return Object.fromEntries(response.providers.map((p) => [p.provider, p.configured]));
 }
 
 /**

--- a/src/features/add-data/components/ConfigureStep.test.tsx
+++ b/src/features/add-data/components/ConfigureStep.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Configure 단계 — credential prerequisite / readiness(#S-add-data,
+ * #S-provider-probe)와 Dataset 필수 요청 파라미터 UX 회귀 테스트.
+ *
+ * generic Provider probe("Provider 연결 확인" 버튼)는 신뢰할 수 없어 제거됐다 —
+ * Add Data는 authoritative prerequisite(requires credential AND configured=false)만
+ * 쓰고, 실제 사용 가능 여부는 Preview가 확인한다.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ConfigureStep, type CatalogState } from "./ConfigureStep";
+import { INITIAL_DRAFT, type AddDataDraft } from "@/features/add-data/model";
+import type { CatalogProvider } from "@/shared/lib/builderApi";
+
+const PROVIDERS: CatalogProvider[] = [
+  {
+    name: "datago",
+    datasets: [
+      {
+        name: "air_quality",
+        title: "대기오염",
+        description: "측정망 시간자료",
+        tags: [],
+        source_url: null,
+        representation: "api_json",
+        operations: ["list"],
+        query_support: null,
+        requires_service_key: true,
+        request_parameters: [
+          { name: "sidoName", required: true, description: "조회할 시·도", example: "서울" },
+          { name: "numOfRows", required: false, description: null, example: null },
+        ],
+        application: { required: true, url: "https://www.data.go.kr/data/15073861/openapi.do" },
+      },
+      {
+        name: "free_form",
+        title: "자유입력",
+        description: null,
+        tags: [],
+        source_url: null,
+        representation: "api_json",
+        operations: ["list"],
+        query_support: null,
+        requires_service_key: true,
+        request_parameters: [],
+      },
+    ],
+  },
+];
+
+function renderStep(overrides: {
+  draft?: Partial<AddDataDraft>;
+  providerConfigured?: Record<string, boolean> | null;
+  updateDraft?: (patch: Partial<AddDataDraft>) => void;
+  onConnectProvider?: (provider: string) => void;
+}) {
+  const draft: AddDataDraft = {
+    ...INITIAL_DRAFT,
+    sourceKind: "public_api",
+    publicApi: { provider: "datago", dataset: "air_quality", sourceParams: "{}" },
+    ...overrides.draft,
+  };
+  const catalog: CatalogState = { status: "loaded", providers: PROVIDERS };
+  render(
+    <ConfigureStep
+      draft={draft}
+      updateDraft={overrides.updateDraft ?? vi.fn()}
+      catalog={catalog}
+      upload={{ status: "idle" }}
+      onUploadFile={vi.fn()}
+      providerConfigured={overrides.providerConfigured ?? null}
+      onConnectProvider={overrides.onConnectProvider ?? vi.fn()}
+      yamlText=""
+      onApplyYaml={vi.fn()}
+    />,
+  );
+}
+
+describe("ConfigureStep — generic Provider probe 제거", () => {
+  it("'Provider 연결 확인' 같은 generic live probe 버튼을 더 이상 보여주지 않는다", () => {
+    renderStep({ providerConfigured: { datago: true } });
+    expect(screen.queryByRole("button", { name: "Provider 연결 확인" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /연결 테스트/ })).not.toBeInTheDocument();
+  });
+
+  it("provider가 configured면 인증 정보 준비 상태와 Preview 안내만 보여준다", () => {
+    renderStep({ providerConfigured: { datago: true } });
+    expect(screen.getByText("인증 정보 준비됨")).toBeInTheDocument();
+    expect(screen.getByText(/실제 데이터 인출 가능 여부는\s*다음 단계 Preview에서 확인/)).toBeInTheDocument();
+  });
+
+  it("configured 여부를 아직 모르면(null) 준비됨도 막힘도 보여주지 않는다", () => {
+    renderStep({ providerConfigured: null });
+    expect(screen.queryByText("인증 정보 준비됨")).not.toBeInTheDocument();
+    expect(screen.queryByText("API 연결이 필요합니다")).not.toBeInTheDocument();
+  });
+});
+
+describe("ConfigureStep — 필수 요청 파라미터 UX", () => {
+  it("선택 Dataset metadata의 필수 파라미터를 예시와 함께 보여준다", () => {
+    renderStep({});
+    expect(screen.getByText("이 Dataset의 요청 파라미터")).toBeInTheDocument();
+    expect(screen.getByText("sidoName")).toBeInTheDocument();
+    expect(screen.getByText("조회할 시·도", { exact: false })).toBeInTheDocument();
+    expect(screen.getAllByText(/예: 서울/).length).toBeGreaterThan(0);
+    // 구체 예시가 generic 예시를 대체한다.
+    expect(screen.getByText('예: {"sidoName":"서울"}')).toBeInTheDocument();
+  });
+
+  it("metadata가 없는 Dataset은 중립 예시만 보여주고 필수 안내는 없다", () => {
+    renderStep({
+      draft: { publicApi: { provider: "datago", dataset: "free_form", sourceParams: "{}" } },
+    });
+    expect(screen.queryByText("이 Dataset의 요청 파라미터")).not.toBeInTheDocument();
+    expect(screen.getByText('예: {"region": "seoul"}')).toBeInTheDocument();
+  });
+
+  it("예시값 적용 버튼을 누르면 example 값을 채우고, 이미 입력된 값은 덮어쓰지 않는다", () => {
+    const updateDraft = vi.fn();
+    renderStep({
+      draft: { publicApi: { provider: "datago", dataset: "air_quality", sourceParams: '{"numOfRows":"10"}' } },
+      updateDraft,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "예시값 적용" }));
+
+    expect(updateDraft).toHaveBeenCalledTimes(1);
+    const patch = updateDraft.mock.calls[0][0] as { publicApi: { sourceParams: string } };
+    const merged = JSON.parse(patch.publicApi.sourceParams) as Record<string, string>;
+    expect(merged.sidoName).toBe("서울");
+    expect(merged.numOfRows).toBe("10"); // 기존 입력값을 덮어쓰지 않는다.
+  });
+
+  it("example이 없는 Dataset은 예시값 적용 버튼을 보여주지 않는다", () => {
+    renderStep({
+      draft: { publicApi: { provider: "datago", dataset: "free_form", sourceParams: "{}" } },
+    });
+    expect(screen.queryByRole("button", { name: "예시값 적용" })).not.toBeInTheDocument();
+  });
+});
+
+describe("ConfigureStep — API 연결 credential prerequisite", () => {
+  it("credential이 필요한 Dataset인데 provider가 미설정이면 진행을 막고 안내한다", () => {
+    const onConnectProvider = vi.fn();
+    renderStep({ providerConfigured: { datago: false }, onConnectProvider });
+
+    expect(screen.getByText("API 연결이 필요합니다")).toBeInTheDocument();
+    expect(screen.getByText(/API Key가 필요한 Provider를 사용합니다/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "API 연결하기" }));
+    expect(onConnectProvider).toHaveBeenCalledWith("datago");
+  });
+
+  it("provider가 이미 configured면 막지 않는다", () => {
+    renderStep({ providerConfigured: { datago: true } });
+    expect(screen.queryByText("API 연결이 필요합니다")).not.toBeInTheDocument();
+  });
+
+  it("configured 여부를 아직 알 수 없으면(null) 추측해서 막지 않는다", () => {
+    renderStep({ providerConfigured: null });
+    expect(screen.queryByText("API 연결이 필요합니다")).not.toBeInTheDocument();
+  });
+});
+
+describe("ConfigureStep — Dataset 활용신청 안내", () => {
+  it("application.required면 활용신청 안내와 공식 페이지 링크를 보여준다", () => {
+    renderStep({});
+    expect(screen.getByText("데이터 활용신청을 확인해주세요")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /공식 페이지에서 확인/ });
+    expect(link).toHaveAttribute("href", "https://www.data.go.kr/data/15073861/openapi.do");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("application metadata가 없는 Dataset은 활용신청 안내를 보여주지 않는다", () => {
+    renderStep({
+      draft: { publicApi: { provider: "datago", dataset: "free_form", sourceParams: "{}" } },
+    });
+    expect(screen.queryByText("데이터 활용신청을 확인해주세요")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/add-data/components/ConfigureStep.tsx
+++ b/src/features/add-data/components/ConfigureStep.tsx
@@ -9,8 +9,9 @@
  * metadata" collapsible을 연다. Output은 기존처럼 kind와 무관하게 항상 함께 보여준다.
  */
 import { useState } from "react";
-import type { ProviderTestResponse } from "@/shared/lib/builderApi";
 import { exportFormatSchema } from "@/shared/lib/schemas";
+import { exampleParamsText, hasExampleParams, mergeExampleParams } from "@/features/add-data/requiredParams";
+import { CREDENTIAL_PREREQUISITE_MESSAGE, checkCredentialPrerequisite } from "@/features/add-data/credentialPrerequisite";
 import { findDataset, findProvider } from "@/features/add-data/identity";
 import type { AddDataDraft } from "@/features/add-data/model";
 import type { SourceFormat } from "@/shared/lib/types";
@@ -26,12 +27,6 @@ export type CatalogState =
   | { status: "loaded"; providers: readonly CatalogProvider[]; error?: undefined }
   | { status: "error"; providers: readonly CatalogProvider[]; error: string };
 
-export interface ProviderTestState {
-  status: "idle" | "testing" | "tested";
-  result?: ProviderTestResponse;
-  error?: string;
-}
-
 export interface UploadState {
   status: "idle" | "uploading" | "done" | "error";
   error?: string;
@@ -41,10 +36,12 @@ export interface ConfigureStepProps {
   draft: AddDataDraft;
   updateDraft: (patch: Partial<AddDataDraft>) => void;
   catalog: CatalogState;
-  providerTest: ProviderTestState;
-  onTestProvider: () => void;
   upload: UploadState;
   onUploadFile: (file: File) => void;
+  /** GET /providers 요약의 effective 구성 여부(provider -> configured). null = 아직 알 수 없음. */
+  providerConfigured: Record<string, boolean> | null;
+  /** "API 연결하기" CTA — draft를 저장하고 Provider 화면(returnTo=/add)으로 이동한다. */
+  onConnectProvider: (provider: string) => void;
   specError?: string;
   yamlText: string;
   yamlEditError?: string;
@@ -55,10 +52,10 @@ export function ConfigureStep({
   draft,
   updateDraft,
   catalog,
-  providerTest,
-  onTestProvider,
   upload,
   onUploadFile,
+  providerConfigured,
+  onConnectProvider,
   specError,
   yamlText,
   yamlEditError,
@@ -68,15 +65,29 @@ export function ConfigureStep({
   const [yamlDraft, setYamlDraft] = useState(yamlText);
 
   const selectedDataset = findDataset(catalog.providers, draft.publicApi.provider, draft.publicApi.dataset);
+  const requestParameters = selectedDataset?.request_parameters ?? [];
+  const credentialPrerequisite = checkCredentialPrerequisite(
+    selectedDataset,
+    providerConfigured,
+    draft.publicApi.provider,
+  );
+  const application = selectedDataset?.application ?? null;
+  // generic Provider probe는 임의의 첫 Dataset을 필수 파라미터 없이 호출하므로
+  // "연결 성공 여부"로 쓰지 않는다(#S-provider-probe). authoritative prerequisite
+  // (requires credential AND configured === false)만 사용하고, 실제 사용 가능
+  // 여부는 Preview가 확인한다.
+  const providerReady =
+    !!selectedDataset?.requires_service_key &&
+    providerConfigured?.[draft.publicApi.provider] === true;
 
   return (
     <div className="space-y-6">
-      <h3 className="text-xl font-semibold tracking-tight">설정 (Configure)</h3>
+      <h3 className="text-xl font-semibold tracking-tight">가져오기 설정</h3>
 
       {draft.sourceKind === "public_api" ? (
         <div className="grid gap-4 lg:grid-cols-2">
           <div className="space-y-4">
-            <div className="section-title text-sm font-semibold text-muted-foreground">제공자 연결</div>
+            <div className="section-title text-sm font-semibold text-muted-foreground">API 사용 준비</div>
             {catalog.status === "loading" ? (
               <p className="text-sm text-muted-foreground">Builder catalog를 불러오는 중입니다...</p>
             ) : null}
@@ -91,11 +102,22 @@ export function ConfigureStep({
                 <Select
                   {...field}
                   value={draft.publicApi.provider}
-                  onChange={(e) =>
+                  onChange={(e) => {
+                    // canonical Provider selection이 실제로 바뀌면 기존 Dataset도
+                    // 무효가 되므로, 같은 update에서 dataset과 이전 Dataset 전용
+                    // 요청 파라미터까지 atomic하게 초기화한다(후행 effect에 의존하지
+                    // 않는다 — #S-stale-params).
+                    const nextProvider = e.target.value;
+                    const providerChanged = nextProvider !== draft.publicApi.provider;
                     updateDraft({
-                      publicApi: { ...draft.publicApi, provider: e.target.value, dataset: "" },
-                    })
-                  }
+                      publicApi: {
+                        ...draft.publicApi,
+                        provider: nextProvider,
+                        dataset: "",
+                        sourceParams: providerChanged ? "{}" : draft.publicApi.sourceParams,
+                      },
+                    });
+                  }}
                 >
                   <option value="">제공자 선택…</option>
                   {catalog.providers.map((p) => (
@@ -110,7 +132,20 @@ export function ConfigureStep({
                   {...field}
                   disabled={!draft.publicApi.provider}
                   value={draft.publicApi.dataset}
-                  onChange={(e) => updateDraft({ publicApi: { ...draft.publicApi, dataset: e.target.value } })}
+                  onChange={(e) => {
+                    // 실제 다른 Dataset을 고르는 순간 이전 Dataset 전용 요청 파라미터를
+                    // 같은 update에서 비운다 — 새 Dataset의 request_parameters 안내/
+                    // 예시는 이 초기화된 값 위에서 렌더된다(#S-stale-params).
+                    const nextDataset = e.target.value;
+                    const datasetChanged = nextDataset !== draft.publicApi.dataset;
+                    updateDraft({
+                      publicApi: {
+                        ...draft.publicApi,
+                        dataset: nextDataset,
+                        sourceParams: datasetChanged ? "{}" : draft.publicApi.sourceParams,
+                      },
+                    });
+                  }}
                 >
                   <option value="">Dataset 선택…</option>
                   {findProvider(catalog.providers, draft.publicApi.provider)?.datasets.map((d) => (
@@ -119,24 +154,22 @@ export function ConfigureStep({
                 </Select>
               )}
             </FormField>
-            {draft.publicApi.provider ? (
-              <div className="flex items-center gap-3">
-                <Button variant="secondary" size="sm" loading={providerTest.status === "testing"} onClick={onTestProvider}>
-                  연결 테스트
+            {credentialPrerequisite.blocked ? (
+              <Card variant="error" className="space-y-3">
+                <p className="font-semibold">{CREDENTIAL_PREREQUISITE_MESSAGE.title}</p>
+                <p className="whitespace-pre-line text-sm">{CREDENTIAL_PREREQUISITE_MESSAGE.body}</p>
+                <Button size="sm" onClick={() => onConnectProvider(draft.publicApi.provider)}>
+                  {CREDENTIAL_PREREQUISITE_MESSAGE.cta}
                 </Button>
-                {providerTest.status === "tested" && providerTest.result?.status === "connected" ? (
-                  <span className="text-sm text-accent-subtle-foreground">연결됨 ({providerTest.result.latency_ms}ms)</span>
-                ) : null}
-                {providerTest.status === "tested" && providerTest.result?.status === "not_configured" ? (
-                  <span role="alert" className="text-sm text-amber-700 dark:text-amber-300">
-                    이 provider는 자격 증명이 필요합니다. Provider 설정에서 연결하세요.
-                  </span>
-                ) : null}
-                {providerTest.status === "tested" && providerTest.result?.status === "failed" ? (
-                  <span role="alert" className="text-sm text-red-700 dark:text-red-300">연결 실패</span>
-                ) : null}
-                {providerTest.error ? <span role="alert" className="text-sm text-red-700 dark:text-red-300">{providerTest.error}</span> : null}
-              </div>
+              </Card>
+            ) : providerReady ? (
+              <Card variant="dashed" className="space-y-1 p-3 text-sm">
+                <p className="font-semibold text-foreground">인증 정보 준비됨</p>
+                <p className="text-muted-foreground">
+                  이 Provider를 사용하는 인증 정보가 설정되어 있습니다. 실제 데이터 인출 가능 여부는
+                  다음 단계 Preview에서 확인합니다.
+                </p>
+              </Card>
             ) : null}
           </div>
 
@@ -154,15 +187,74 @@ export function ConfigureStep({
                 ) : null}
               </Card>
             ) : null}
-            <FormField id="add-data-params" label="요청 파라미터 (JSON)" help='예: {"region": "seoul"}'>
+            {requestParameters.length > 0 ? (
+              <div className="rounded-lg border border-border bg-muted/40 p-3 text-xs">
+                <p className="font-semibold text-foreground">이 Dataset의 요청 파라미터</p>
+                <ul className="mt-1.5 space-y-1">
+                  {requestParameters.map((p) => (
+                    <li key={p.name} className="text-muted-foreground">
+                      <span className="font-medium text-foreground">{p.name}</span>
+                      {p.required ? (
+                        <span className="ml-1 font-medium text-red-600 dark:text-red-400">필수</span>
+                      ) : (
+                        <span className="ml-1">선택</span>
+                      )}
+                      {p.description ? <span> — {p.description}</span> : null}
+                      {p.example ? <span className="ml-1 text-muted-foreground">예: {p.example}</span> : null}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            {application?.required ? (
+              <Card variant="dashed" className="space-y-2 p-3 text-xs">
+                <p className="font-semibold text-foreground">데이터 활용신청을 확인해주세요</p>
+                <p className="text-muted-foreground">
+                  API Key 등록과 별도로 이 Dataset은 제공기관에서 활용신청 또는 승인이 필요할 수
+                  있습니다. 신청 상태는 KPubData가 자동으로 확인하지 않습니다.
+                </p>
+                <a
+                  href={application.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex text-sm font-medium text-accent-subtle-foreground underline underline-offset-2"
+                >
+                  공식 페이지에서 확인 · 신청 ↗
+                </a>
+              </Card>
+            ) : null}
+            <FormField
+              id="add-data-params"
+              label="요청 파라미터 (JSON)"
+              help={`예: ${exampleParamsText(requestParameters)}`}
+            >
               {(field) => (
-                <Textarea
-                  {...field}
-                  mono
-                  rows={6}
-                  value={draft.publicApi.sourceParams}
-                  onChange={(e) => updateDraft({ publicApi: { ...draft.publicApi, sourceParams: e.target.value } })}
-                />
+                <div className="space-y-2">
+                  {hasExampleParams(requestParameters) ? (
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() =>
+                        updateDraft({
+                          publicApi: {
+                            ...draft.publicApi,
+                            sourceParams: mergeExampleParams(draft.publicApi.sourceParams, requestParameters),
+                          },
+                        })
+                      }
+                    >
+                      예시값 적용
+                    </Button>
+                  ) : null}
+                  <Textarea
+                    {...field}
+                    mono
+                    rows={6}
+                    value={draft.publicApi.sourceParams}
+                    onChange={(e) => updateDraft({ publicApi: { ...draft.publicApi, sourceParams: e.target.value } })}
+                  />
+                </div>
               )}
             </FormField>
           </div>

--- a/src/features/add-data/components/PreviewValidationStep.test.tsx
+++ b/src/features/add-data/components/PreviewValidationStep.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * PreviewValidationStep — stale 결과 경고 (감사 후속 1-2).
+ *
+ * Dataset/params가 직전 Preview 이후 바뀌면(AddDataPage의 isStale) Step 자체에서
+ * "남아 있는 결과가 현재 설정과 다르다"는 사실을 보여줘야 한다. Build 차단은
+ * ReviewBuildStep의 기존 stale guard가 담당하므로 여기서는 표시만 검증한다.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PreviewValidationStep, type PreviewState } from "./PreviewValidationStep";
+
+const LOADED: PreviewState = {
+  status: "loaded",
+  response: { dataset_id: "dataset-1", previews: [] },
+};
+
+function renderStep(overrides: Partial<React.ComponentProps<typeof PreviewValidationStep>>) {
+  return render(
+    <MemoryRouter>
+      <PreviewValidationStep
+        preview={LOADED}
+        limit={5}
+        sampleMode="first"
+        columns="key"
+        onChangeLimit={vi.fn()}
+        onChangeSampleMode={vi.fn()}
+        onChangeColumns={vi.fn()}
+        onRefresh={vi.fn()}
+        view="sample"
+        onChangeView={vi.fn()}
+        {...overrides}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("PreviewValidationStep — stale 결과 경고", () => {
+  it("isStale이면 남아 있는 Preview 결과가 현재 설정과 다르다고 알린다", () => {
+    renderStep({ isStale: true });
+    expect(screen.getByText(/설정이 변경되었습니다.*Preview를 다시 실행/)).toBeInTheDocument();
+  });
+
+  it("isStale이 아니면 경고를 표시하지 않는다", () => {
+    renderStep({ isStale: false });
+    expect(screen.queryByText(/설정이 변경되었습니다/)).not.toBeInTheDocument();
+  });
+
+  it("Preview를 아직 실행하지 않았으면(idle) stale이어도 경고하지 않는다", () => {
+    renderStep({ isStale: true, preview: { status: "idle" } });
+    expect(screen.queryByText(/설정이 변경되었습니다/)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/add-data/components/PreviewValidationStep.tsx
+++ b/src/features/add-data/components/PreviewValidationStep.tsx
@@ -41,6 +41,12 @@ export interface PreviewValidationStepProps {
   onChangeSampleMode: (mode: PreviewSampleMode) => void;
   onChangeColumns: (columns: PreviewColumnView) => void;
   onRefresh: () => void;
+  /**
+   * 직전 Preview 실행 이후 Dataset/params 등 설정이 바뀌었는지 여부(AddDataPage의 stale
+   * signature와 동일 값). true면 화면에 남아 있는 sample/검증 결과가 현재 설정과 다르다는
+   * 사실을 알린다 — Build는 ReviewBuildStep의 기존 stale guard가 계속 차단한다.
+   */
+  isStale?: boolean;
   view: "sample" | "diff";
   onChangeView: (view: "sample" | "diff") => void;
 }
@@ -64,6 +70,7 @@ export function PreviewValidationStep({
   onChangeSampleMode,
   onChangeColumns,
   onRefresh,
+  isStale = false,
   view,
   onChangeView,
 }: PreviewValidationStepProps) {
@@ -81,18 +88,32 @@ export function PreviewValidationStep({
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h3 className="text-xl font-semibold tracking-tight">미리보기 · 검증 (Preview & Validate)</h3>
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h3 className="text-xl font-semibold tracking-tight">Preview · 검증</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            현재 인증 정보와 요청 파라미터로 Dataset API를 호출해 실제 데이터를 확인합니다.
+          </p>
+        </div>
         <Button variant="secondary" size="sm" loading={preview.status === "loading"} onClick={onRefresh}>
           Preview 새로고침
         </Button>
       </div>
 
       {preview.status === "idle" ? (
-        <EmptyState title="현재 설정으로 샘플 데이터를 확인하세요" description="'Preview 새로고침'을 누르면 Builder가 반환한 샘플 행과 검증 결과가 표시됩니다." />
+        <EmptyState title="실제 데이터 미리보기" description="'Preview 새로고침'을 누르면 현재 설정으로 Dataset API를 호출하고, 샘플 행과 검증 결과를 표시합니다." />
       ) : null}
       {preview.status === "error" ? (
         <EmptyState title="Preview 요청에 실패했습니다" description={preview.error} />
+      ) : null}
+
+      {isStale && preview.status === "loaded" ? (
+        <p
+          role="status"
+          className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200"
+        >
+          설정이 변경되었습니다. 아래 결과는 이전 설정 기준이며, 현재 설정으로 Preview를 다시 실행해주세요.
+        </p>
       ) : null}
 
       {previews.length > 1 ? (

--- a/src/features/add-data/components/ReviewBuildStep.tsx
+++ b/src/features/add-data/components/ReviewBuildStep.tsx
@@ -114,7 +114,7 @@ export function ReviewBuildStep({
 
   return (
     <div className="space-y-4">
-      <h3 className="text-xl font-semibold tracking-tight">검토 · 빌드 (Review & Build)</h3>
+      <h3 className="text-xl font-semibold tracking-tight">검토 · Build</h3>
 
       <div className="grid gap-3 sm:grid-cols-4">
         <Card className="p-4">

--- a/src/features/add-data/components/SourceStep.tsx
+++ b/src/features/add-data/components/SourceStep.tsx
@@ -27,7 +27,7 @@ export interface SourceStepProps {
 export function SourceStep({ selected, onSelect }: SourceStepProps) {
   return (
     <div className="space-y-4">
-      <h3 className="text-xl font-semibold tracking-tight">Source 선택</h3>
+      <h3 className="text-xl font-semibold tracking-tight">데이터 선택</h3>
       <p className="text-sm text-muted-foreground">
         데이터를 어디서 가져올지 선택하세요. 이후 단계는 선택한 source에 맞는 입력만 보여줍니다.
       </p>

--- a/src/features/add-data/credentialPrerequisite.ts
+++ b/src/features/add-data/credentialPrerequisite.ts
@@ -1,0 +1,38 @@
+/**
+ * Public API Dataset 선택 후 credential prerequisite를 preview 이전에 확인한다
+ * (#S-add-data). 뒤늦게 Preview에서 credential 오류로 실패하지 않도록, Configure
+ * 단계에서 미리 안내한다.
+ *
+ * 확정 조건(둘 다 참일 때만 막는다):
+ *   1. 선택한 Dataset/Provider가 credential을 요구한다(`CatalogDataset.requires_service_key`
+ *      — provider 인증 필요 여부와 dataset의 `service_key_param` 존재 여부를 Builder가
+ *      이미 합쳐서 계산한 값이다).
+ *   2. `GET /providers` 요약의 effective `configured`(user credential > server default >
+ *      없음, ADR 0012)로 확인했을 때 이 provider가 미설정이다.
+ *
+ * `providerConfigured`가 아직 로딩 중이거나(null) 이 provider 항목 자체가 없으면
+ * (조회 실패 등) 막지 않는다 — Studio가 credential 존재 여부를 추측하지 않는다는
+ * 원칙(요구사항 §3)에 따라, "확실히 미설정"으로 확인된 경우에만 진행을 막는다.
+ */
+import type { CatalogDataset } from "@/shared/lib/builderApi";
+
+export interface CredentialPrerequisite {
+  /** true면 이 Dataset을 계속 진행하기 전에 API 연결이 필요하다. */
+  blocked: boolean;
+}
+
+export function checkCredentialPrerequisite(
+  dataset: CatalogDataset | undefined,
+  providerConfigured: Record<string, boolean> | null,
+  provider: string,
+): CredentialPrerequisite {
+  if (!dataset?.requires_service_key) return { blocked: false };
+  if (!providerConfigured || !(provider in providerConfigured)) return { blocked: false };
+  return { blocked: providerConfigured[provider] === false };
+}
+
+export const CREDENTIAL_PREREQUISITE_MESSAGE = {
+  title: "API 연결이 필요합니다",
+  body: "이 Dataset은 API Key가 필요한 Provider를 사용합니다.\n먼저 Provider / API 연결에서 자격 증명을 등록한 뒤 계속하세요.",
+  cta: "API 연결하기",
+} as const;

--- a/src/features/add-data/requiredParams.test.ts
+++ b/src/features/add-data/requiredParams.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { CatalogRequestParameter } from "@/shared/lib/builderApi";
+import { checkRequiredParams, exampleParamsText, requiredParamNames } from "./requiredParams";
+
+const sido: CatalogRequestParameter = {
+  name: "sidoName",
+  required: true,
+  description: "조회할 시·도",
+  example: "서울",
+};
+
+describe("checkRequiredParams", () => {
+  it("metadata가 없으면 항상 통과한다(기존 자유 JSON 입력 유지)", () => {
+    expect(checkRequiredParams("{}", undefined)).toEqual({});
+    expect(checkRequiredParams("{}", [])).toEqual({});
+  });
+
+  it("필수 파라미터가 비면 사용자 친화적 오류를 돌려준다", () => {
+    expect(checkRequiredParams("{}", [sido]).error).toBe(
+      "sidoName 필수 요청 파라미터를 입력해주세요.",
+    );
+  });
+
+  it("빈 문자열/공백만 있는 값도 누락으로 취급한다", () => {
+    expect(checkRequiredParams('{"sidoName": ""}', [sido]).error).toContain("sidoName");
+    expect(checkRequiredParams('{"sidoName": "   "}', [sido]).error).toContain("sidoName");
+  });
+
+  it("값이 있으면 통과한다", () => {
+    expect(checkRequiredParams('{"sidoName": "서울"}', [sido])).toEqual({});
+  });
+
+  it("JSON 구문 오류는 여기서 만들지 않는다(별도 경로가 처리)", () => {
+    expect(checkRequiredParams("{not json", [sido])).toEqual({});
+  });
+
+  it("선택 파라미터는 강제하지 않는다", () => {
+    const optional: CatalogRequestParameter = { ...sido, name: "numOfRows", required: false };
+    expect(checkRequiredParams("{}", [optional])).toEqual({});
+  });
+});
+
+describe("requiredParamNames / exampleParamsText", () => {
+  it("required 파라미터 이름만 추린다", () => {
+    expect(requiredParamNames([sido, { ...sido, name: "pageNo", required: false }])).toEqual([
+      "sidoName",
+    ]);
+  });
+
+  it("metadata가 있으면 구체 예시, 없으면 중립 예시를 만든다", () => {
+    expect(exampleParamsText([sido])).toBe('{"sidoName":"서울"}');
+    expect(exampleParamsText([])).toBe('{"region": "seoul"}');
+    expect(exampleParamsText(undefined)).toBe('{"region": "seoul"}');
+  });
+});

--- a/src/features/add-data/requiredParams.ts
+++ b/src/features/add-data/requiredParams.ts
@@ -1,0 +1,107 @@
+/**
+ * Preview 전 usability preflight — 선택한 Dataset의 metadata(`request_parameters`)로
+ * 필수 요청 파라미터를 아는 경우에만 동작한다.
+ *
+ * - JSON 구문 오류는 여기서 만들지 않는다(그 경로는 `buildSpecFromDraft`가 이미
+ *   담당) — 필수 key 누락만 사용자 문구로 돌려준다.
+ * - 빈 문자열/공백만 있는 값도 누락으로 취급한다(공공데이터 API 다수가 빈 값을
+ *   "미전달"로 처리하고, 실제 E2E에서도 `{}` → NO_MANDATORY_REQUEST_PARAMETERS).
+ * - Builder/Core validation을 대체하지 않는다 — 어디까지나 사전 안내다.
+ */
+import type { CatalogRequestParameter } from "@/shared/lib/builderApi";
+
+export interface RequiredParamsCheck {
+  /** 사용자에게 보여줄 오류(없으면 통과). */
+  error?: string;
+}
+
+export function requiredParamNames(
+  requestParameters: readonly CatalogRequestParameter[] | undefined,
+): string[] {
+  return (requestParameters ?? []).filter((p) => p.required).map((p) => p.name);
+}
+
+export function checkRequiredParams(
+  sourceParamsText: string,
+  requestParameters: readonly CatalogRequestParameter[] | undefined,
+): RequiredParamsCheck {
+  const required = requiredParamNames(requestParameters);
+  if (required.length === 0) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(sourceParamsText.trim() || "{}");
+  } catch {
+    // JSON 오류는 별도 경로에서 안내한다.
+    return {};
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
+  const obj = parsed as Record<string, unknown>;
+
+  const missing = required.filter((name) => {
+    const value = obj[name];
+    return value === undefined || value === null || (typeof value === "string" && value.trim() === "");
+  });
+  if (missing.length === 0) return {};
+  return { error: `${missing.join(", ")} 필수 요청 파라미터를 입력해주세요.` };
+}
+
+/**
+ * 요청 파라미터 입력 도움말/placeholder에 쓸 예시 JSON 텍스트.
+ * metadata가 있으면 그 파라미터로 구체 예시를, 없으면 중립 예시를 만든다.
+ */
+export function exampleParamsText(
+  requestParameters: readonly CatalogRequestParameter[] | undefined,
+): string {
+  const params = requestParameters ?? [];
+  if (params.length === 0) return '{"region": "seoul"}';
+  // 예시는 "필수 최소치"를 보여준다 — 필수가 하나도 없으면 전체를 쓴다.
+  const shown = params.some((p) => p.required) ? params.filter((p) => p.required) : params;
+  const entries = shown.map((p) => [p.name, p.example ?? ""] as const);
+  return JSON.stringify(Object.fromEntries(entries));
+}
+
+/** "예시값 적용" 버튼에 표시할 대상이 있는지 — example이 있는 파라미터가 하나라도 있어야 한다. */
+export function hasExampleParams(
+  requestParameters: readonly CatalogRequestParameter[] | undefined,
+): boolean {
+  return (requestParameters ?? []).some((p) => p.example);
+}
+
+/**
+ * "예시값 적용" 버튼 동작 — metadata의 example 값을 요청 파라미터 JSON에 채운다.
+ *
+ * - secret parameter는 애초에 Builder `/catalog`가 request_parameters에 담지
+ *   않으므로(serviceKey 등 allowlist에서 제외) 여기서 생성할 값 자체가 없다.
+ * - example이 없는 parameter에 임의 값을 만들지 않는다 — example이 있는 항목만 채운다.
+ * - 사용자가 이미 입력한 값은 덮어쓰지 않는다(이미 채워진 key는 건드리지 않는 안전한
+ *   merge) — 버튼을 눌러도 기존 입력을 잃지 않는다.
+ * - 기존 텍스트가 유효한 JSON object가 아니면(빈 값 포함) example만으로 새로 만든다.
+ */
+export function mergeExampleParams(
+  currentText: string,
+  requestParameters: readonly CatalogRequestParameter[] | undefined,
+): string {
+  const withExample = (requestParameters ?? []).filter(
+    (p): p is CatalogRequestParameter & { example: string } => Boolean(p.example),
+  );
+  if (withExample.length === 0) return currentText;
+
+  let base: Record<string, unknown> = {};
+  try {
+    const parsed: unknown = JSON.parse(currentText.trim() || "{}");
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      base = { ...(parsed as Record<string, unknown>) };
+    }
+  } catch {
+    // 기존 텍스트가 JSON이 아니면 example만으로 새로 만든다.
+  }
+
+  for (const p of withExample) {
+    const existing = base[p.name];
+    const isEmpty = existing === undefined || existing === null || (typeof existing === "string" && existing.trim() === "");
+    if (isEmpty) base[p.name] = p.example;
+  }
+
+  return JSON.stringify(base, null, 2);
+}

--- a/src/features/artifacts/api/index.ts
+++ b/src/features/artifacts/api/index.ts
@@ -118,3 +118,62 @@ export async function getBuildManifest(
   const result = await builderApi.getBuildManifest(buildId, signal);
   return result as AuthoritativeBuildManifest;
 }
+
+/**
+ * 다운로드 가능한 산출물 파일 목록을 조회한다 — `GET /artifacts/{run_id}`.
+ *
+ * 이 목록의 각 경로가 **canonical artifact identifier**다: exact run 워크스페이스 기준
+ * POSIX 상대 경로이고, output_root/절대경로/OS 구분자를 포함하지 않는다. 다운로드는
+ * 반드시 이 값을 써야 한다 — `manifest.outputs`는 filesystem storage 경로(절대경로 +
+ * OS 구분자)라 다운로드 식별자로 쓸 수 없다.
+ *
+ * @returns run 디렉터리 기준 상대 파일 경로 배열.
+ */
+export async function listArtifactFiles(
+  runId: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  if (!isRealBuilderEnabled()) {
+    // mock 모드: 실제 워크스페이스가 없으므로 결정적 fixture manifest의 output 목록을
+    // 그대로 쓴다(이미 상대 POSIX 경로 형태다).
+    return mockManifest(runId).outputs ?? [];
+  }
+  const result = await builderApi.artifacts(runId, signal);
+  return result.files;
+}
+
+/**
+ * 특정 실행의 개별 산출물 파일을 인증된 Builder 요청으로 받아온다.
+ *
+ * `filePath`는 반드시 `listArtifactFiles`(= `GET /artifacts/{run_id}`)가 준 canonical
+ * run-relative POSIX 경로여야 한다 — Studio에서 경로 문자열을 변형하지 않는다.
+ * `builderApi.downloadArtifactFile`이 세그먼트별로만 URL 인코딩한다. mock 모드에는
+ * 실제 파일이 없으므로 지어내지 않고 명시적으로 지원하지 않음을 알린다.
+ */
+export async function downloadArtifact(
+  runId: string,
+  filePath: string,
+  signal?: AbortSignal,
+): Promise<{ blob: Blob; filename: string }> {
+  if (!isRealBuilderEnabled()) {
+    throw new Error(
+      "Mock 모드에서는 산출물 파일 다운로드를 시뮬레이션하지 않습니다. 실연동 모드에서 확인하세요.",
+    );
+  }
+  return builderApi.downloadArtifactFile(runId, filePath, signal);
+}
+
+/** Blob을 받아 원래 파일명으로 브라우저 다운로드를 트리거하고 object URL을 정리한다. */
+export function saveBlobAsFile(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  try {
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/src/features/auth/init.ts
+++ b/src/features/auth/init.ts
@@ -83,11 +83,12 @@ function syncIdentity(authenticated: boolean): void {
   }
 
   const claims = getKeycloak().tokenParsed as
-    | { email?: string; name?: string; preferred_username?: string }
+    | { sub?: string; email?: string; name?: string; preferred_username?: string }
     | undefined;
   store.setOidcIdentity({
     email: claims?.email ?? null,
     name: claims?.name ?? claims?.preferred_username ?? null,
+    userId: claims?.sub ?? null,
   });
   store.setOidcStatus("authenticated");
 }

--- a/src/features/auth/store.ts
+++ b/src/features/auth/store.ts
@@ -39,6 +39,7 @@ interface AuthState {
   email: string | null;
   /** 표시용 이름. Google 로그인은 이름을 제공하지 않아 null(#263). */
   name: string | null;
+  userId: string | null;
   /** 이 세션을 만든 provider. 미로그인이면 null(#263). */
   providerId: AuthProviderId | null;
   /** OIDC 부트스트랩 상태. mock/데모에서는 "disabled". */
@@ -51,7 +52,7 @@ interface AuthState {
    * Keycloak 세션에서 확인한 사용자 신원(표시용)만 저장한다. raw access token은
    * store에 넣지 않는다(위 `token` 주석 참고).
    */
-  setOidcIdentity: (identity: { email: string | null; name: string | null }) => void;
+  setOidcIdentity: (identity: { email: string | null; name: string | null; userId: string | null }) => void;
   /** OIDC 부트스트랩 상태 전이. */
   setOidcStatus: (status: OidcStatus) => void;
   /** 로그아웃 — 세션 전체를 폐기(OIDC 부트스트랩 상태는 호출부가 별도로 관리). */
@@ -62,21 +63,23 @@ export const useAuthStore = create<AuthState>((set) => ({
   token: null,
   email: null,
   name: null,
+  userId: null,
   providerId: null,
   oidcStatus: "disabled",
   setToken: (token, email = null) =>
-    set({ token, email, name: null, providerId: token ? "google" : null }),
+    set({ token, email, name: null, userId: null, providerId: token ? "google" : null }),
   setSession: (session) =>
     set({
       token: session.token,
       email: session.email,
       name: session.name,
+      userId: null,
       providerId: session.provider,
     }),
-  setOidcIdentity: ({ email, name }) =>
-    set({ token: null, email, name, providerId: "keycloak" }),
+  setOidcIdentity: ({ email, name, userId }) =>
+    set({ token: null, email, name, userId, providerId: "keycloak" }),
   setOidcStatus: (oidcStatus) => set({ oidcStatus }),
-  clear: () => set({ token: null, email: null, name: null, providerId: null }),
+  clear: () => set({ token: null, email: null, name: null, userId: null, providerId: null }),
 }));
 
 /**

--- a/src/features/kubi/KubiContent.tsx
+++ b/src/features/kubi/KubiContent.tsx
@@ -9,11 +9,11 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { SpecDiff } from "@/features/build-spec/components/SpecDiff";
 import { useAssistConfig } from "@/features/assistant/config";
-import { Button, Card, Disclosure, Textarea } from "@/shared/ui";
+import { Button, Card, Disclosure, TermHelp, Textarea } from "@/shared/ui";
 import { describeAction } from "./actions";
 import { relatedCatalogDatasets } from "./relatedDatasets";
 import type { KubiAction } from "./schema";
-import { SUGGESTED_QUESTIONS } from "./suggestedQuestions";
+import { getSuggestedQuestions } from "./suggestedQuestions";
 import { summarizeKubiQuality } from "./types";
 import type { KubiActionRunState, KubiContext, KubiErrorState, KubiQueryState, KubiTurn } from "./types";
 import { useKubiSession } from "./useKubiSession";
@@ -42,7 +42,7 @@ function ContextBar({ context, pageLabel, qualityLabel, sources, onContextChange
   const stageSelectDisabled = !context.runId || (sources.length > 1 && !context.source);
   return (
     <div>
-      <p className="mb-1.5 text-[10px] text-muted-foreground">현재 화면 · {pageLabel}</p>
+      <p className="mb-1.5 inline-flex items-center gap-1 text-[10px] text-muted-foreground">현재 Context · {pageLabel}<TermHelp term="context" /></p>
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
         {cells.map((cell) => (
           <div key={cell.label} className="rounded-lg border border-border bg-muted/40 px-2.5 py-2">
@@ -275,7 +275,7 @@ function ActionCard({
           {turn.response && turn.response.evidenceRefs.length > 0 ? (
             <div className="mt-2">
               <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                연결된 Evidence
+                연결된 Evidence <TermHelp term="evidence" />
               </p>
               <ul className="mt-1 flex flex-wrap gap-1.5">
                 {turn.response.evidenceRefs.map((ref) => (
@@ -487,7 +487,7 @@ function TurnCard({ turn, session, collapsed = false, onToggle }: { turn: KubiTu
 
             {turn.response.generatedSql ? (
               <div className="min-w-0">
-                <div className="flex items-center justify-between gap-2"><p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Generated SQL · {turn.response.generatedSql.stage}</p><Button size="sm" variant="ghost" aria-label="Generated SQL 복사" onClick={() => void navigator.clipboard?.writeText(turn.response!.generatedSql!.sql).catch(() => {})}>복사</Button></div>
+                <div className="flex items-center justify-between gap-2"><p className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Generated SQL · {turn.response.generatedSql.stage}<TermHelp term="generatedSql" /></p><Button size="sm" variant="ghost" aria-label="Generated SQL 복사" onClick={() => void navigator.clipboard?.writeText(turn.response!.generatedSql!.sql).catch(() => {})}>복사</Button></div>
                 <pre className="mt-1 max-w-full overflow-x-auto whitespace-pre rounded-lg bg-muted/70 p-2 font-mono text-[11px]">{formatSqlForDisplay(turn.response.generatedSql.sql)}</pre>
                 <Button
                   size="sm"
@@ -563,13 +563,17 @@ export function KubiContent({ compact = false }: KubiContentProps) {
   // 과거 turn/LLM/quality 결과는 live source 후보를 만들 근거로 사용하지 않는다.
   const contextSources = useLiveRunSources(session.liveContext.runId);
 
-  const suggestedQuestions = useMemo(() => {
-    if (session.liveContext.stage === "gold" || session.liveContext.stage === "silver") return ["사용할 수 있는 컬럼을 알려줘.", "이 데이터를 집계하는 SQL을 만들어줘."];
-    if (session.liveContext.page === "quality") return ["Quality 결과를 요약해줘.", "FAIL/WARN의 원인을 알려줘."];
-    if (session.liveContext.runId) return ["이 Run 상태를 요약해줘.", "실패 원인이 있으면 알려줘."];
-    if (session.liveContext.datasetId) return ["이 Dataset의 특징을 알려줘."];
-    return SUGGESTED_QUESTIONS;
-  }, [session.liveContext]);
+  // 추천 질문은 현재 context와 최근 대화에서 deterministic하게 고른다(LLM 추가 호출
+  // 없음, suggestedQuestions.ts). turns가 바뀌면(첫 질문 후 등) 곧바로 갱신된다.
+  const suggestedQuestions = useMemo(
+    () =>
+      getSuggestedQuestions({
+        context: session.liveContext,
+        turns: session.turns,
+        isStale: session.isStale,
+      }),
+    [session.liveContext, session.turns, session.isStale],
+  );
 
   function changeContext(key: "stage" | "source", value?: string) {
     const params = new URLSearchParams(location.search);

--- a/src/features/kubi/suggestedQuestions.test.ts
+++ b/src/features/kubi/suggestedQuestions.test.ts
@@ -1,0 +1,159 @@
+/**
+ * 추천 질문 선택 로직 회귀 (#S-kubi-suggest).
+ *
+ * - context가 없으면 Quality/Build 실패/SQL 질문을 강제로 노출하지 않는다.
+ * - Dataset/Run/Quality context가 실제로 있을 때만 그에 맞는 질문을 노출한다.
+ * - 최근 답변 turn이 있으면 그 구조화 단서로 follow-up을 바꾼다(LLM 재호출 없음).
+ */
+import { describe, expect, it } from "vitest";
+import { START_QUESTIONS, getSuggestedQuestions } from "./suggestedQuestions";
+import type { KubiContext, KubiEvidence, KubiTurn } from "./types";
+
+/** 필수 필드만 채운 최소 evidence(테스트가 지정한 조각을 덮어쓴다). */
+function evidence(partial: Partial<KubiEvidence>): KubiEvidence {
+  return {
+    fetchedAt: "2026-09-02T00:00:00Z",
+    context: { page: "kubi" },
+    deepLinks: {},
+    partial: false,
+    unavailable: [],
+    ...partial,
+  };
+}
+
+function turn(overrides: Partial<KubiTurn>): KubiTurn {
+  return {
+    id: "t1",
+    question: "q",
+    context: { page: "kubi" },
+    createdAt: "2026-09-02T00:00:00Z",
+    status: "ok",
+    query: { status: "idle" },
+    actionStates: {},
+    response: { answer: "a", evidenceRefs: [], generatedSql: null, suggestedActions: [] },
+    ...overrides,
+  };
+}
+
+const ask = (context: KubiContext, turns: KubiTurn[] = []) =>
+  getSuggestedQuestions({ context, turns });
+
+describe("getSuggestedQuestions — context별 초기 추천", () => {
+  it("A. Dataset/Run/Quality가 없으면 시작 질문만 노출한다", () => {
+    const result = ask({ page: "kubi" });
+    expect(result).toEqual(START_QUESTIONS);
+    const joined = result.join(" ");
+    expect(joined).not.toMatch(/Quality/);
+    expect(joined).not.toMatch(/실패/);
+    expect(joined).not.toMatch(/SQL/);
+  });
+
+  it("home context도 시작 질문을 준다", () => {
+    expect(ask({ page: "home" })).toEqual(START_QUESTIONS);
+  });
+
+  it("B. Dataset context가 있으면 Dataset 질문을 노출한다", () => {
+    const result = ask({ page: "dataset-detail", datasetId: "ds-1" });
+    expect(result.some((q) => q.includes("데이터셋의 구조"))).toBe(true);
+    expect(result).not.toEqual(START_QUESTIONS);
+  });
+
+  it("C. Run context가 있으면 Run 질문을 노출한다", () => {
+    const result = ask({ page: "build-detail", runId: "run-1" });
+    expect(result.some((q) => q.includes("Run 결과를 요약"))).toBe(true);
+  });
+
+  it("C. Run이 없으면 실패/경고 단계 질문을 강제로 넣지 않는다", () => {
+    const result = ask({ page: "kubi" });
+    expect(result.some((q) => q.includes("실패한 단계"))).toBe(false);
+  });
+
+  it("D. Quality page라도 run/dataset이 없으면 Quality-specific을 넣지 않는다", () => {
+    expect(ask({ page: "quality" })).toEqual(START_QUESTIONS);
+  });
+
+  it("D. Quality page + run이 있으면 Quality 질문을 노출한다", () => {
+    const result = ask({ page: "quality", runId: "run-1" });
+    expect(result.some((q) => q.includes("Quality 이슈의 원인"))).toBe(true);
+  });
+
+  it("silver/gold stage면 컬럼/SQL 질문을 노출한다", () => {
+    const result = ask({ page: "build-detail", runId: "run-1", stage: "gold" });
+    expect(result.some((q) => q.includes("컬럼"))).toBe(true);
+    expect(result.some((q) => q.includes("SQL"))).toBe(true);
+  });
+
+  it("최대 4개, 중복 없음", () => {
+    const result = ask({ page: "kubi" });
+    expect(result.length).toBeLessThanOrEqual(4);
+    expect(new Set(result).size).toBe(result.length);
+  });
+});
+
+describe("getSuggestedQuestions — 최근 대화 기반 follow-up", () => {
+  it("첫 turn 전 추천과 answered turn 후 추천이 달라진다", () => {
+    const context: KubiContext = { page: "kubi" };
+    const before = ask(context);
+    const after = getSuggestedQuestions({
+      context,
+      turns: [turn({ evidence: evidence({ catalog: { providers: ["datago"], datasetsByProvider: {} } }) })],
+    });
+    expect(after).not.toEqual(before);
+    expect(after.some((q) => q.includes("Add Data로 가져오는"))).toBe(true);
+  });
+
+  it("generatedSql이 있으면 SQL 해석 follow-up을 준다", () => {
+    const after = getSuggestedQuestions({
+      context: { page: "kubi", runId: "run-1", stage: "gold" },
+      turns: [
+        turn({
+          response: {
+            answer: "a",
+            evidenceRefs: [],
+            generatedSql: { sql: "SELECT 1", stage: "gold" },
+            suggestedActions: [],
+          },
+        }),
+      ],
+    });
+    expect(after.some((q) => q.includes("SQL 결과를 어떻게 해석"))).toBe(true);
+  });
+
+  it("quality 이슈가 있는 turn 뒤에는 우선순위 follow-up을 준다", () => {
+    const after = getSuggestedQuestions({
+      context: { page: "quality", runId: "run-1" },
+      turns: [
+        turn({
+          evidence: evidence({
+            quality: {
+              availability: "available",
+              evaluatedChecks: 3,
+              results: [
+                { id: "r1", source: "s", category: "c", rule: "x", column: null, status: "fail", actual: 1, threshold: 0, detail: null },
+              ],
+              schemaDrift: [],
+            },
+          }),
+        }),
+      ],
+    });
+    expect(after.some((q) => q.includes("먼저 고쳐야 할 품질 문제"))).toBe(true);
+  });
+
+  it("stale한 최근 turn은 follow-up 근거로 쓰지 않는다(초기 추천으로 fallback)", () => {
+    const result = getSuggestedQuestions({
+      context: { page: "kubi" },
+      turns: [turn({ evidence: evidence({ catalog: { providers: ["datago"], datasetsByProvider: {} } }) })],
+      isStale: () => true,
+    });
+    expect(result).toEqual(START_QUESTIONS);
+  });
+
+  it("구조화 단서가 없는 turn 뒤에는 generic follow-up으로 fallback한다", () => {
+    const after = getSuggestedQuestions({
+      context: { page: "dataset-detail", datasetId: "ds-1" },
+      turns: [turn({ evidence: undefined })],
+    });
+    expect(after.some((q) => q.includes("자세히 설명"))).toBe(true);
+  });
+});

--- a/src/features/kubi/suggestedQuestions.ts
+++ b/src/features/kubi/suggestedQuestions.ts
@@ -1,8 +1,35 @@
 /**
- * Kubi 예시/추천 질문 목록.
+ * Kubi 추천 질문 — "사용자가 다음으로 물어볼 만한 질문"을 현재 context와 최근 대화에서
+ * deterministic하게 고른다(#S-kubi-suggest). LLM을 추가로 호출하지 않는다.
  *
- * `KubiContent`(onboarding 칩 + 추천 질문 패널)와 Home의 Kubi hero(#Phase2 UI polish)가
- * 이 목록을 공유한다 — 실제로 seed 가능한 질문만 담아 두 화면에서 복붙되지 않게 한다.
+ * `KubiContent`(우측 추천 질문 패널 + 첫 질문 전 onboarding 칩)와 Home Kubi hero가 이
+ * helper를 공유한다 — 고정 문자열 배열을 그대로 UI에 노출하지 않는다.
+ *
+ * 원칙:
+ * - 현재 context(dataset/run/quality/stage)로 실제로 답할 수 있는 질문만 노출한다.
+ * - Dataset/Run/Quality가 없으면 Quality·Build 실패·SQL 질문을 강제로 넣지 않는다.
+ * - 최근 turn이 있으면 그 turn의 **구조화된 단서**(response.generatedSql /
+ *   evidence.quality / evidence.catalog / evidence.dataset / suggestedActions)로
+ *   follow-up을 고른다. assistant prose를 NLP parsing하거나 임의 문자열 매칭하지 않는다.
+ * - 구조적 단서가 부족하면 최근 질문을 구체화하는 generic follow-up으로 fallback한다.
+ * - Suggested Action(실행/이동)과 역할을 섞지 않는다 — 여기서는 전부 "다음 질문"만.
+ */
+import type { KubiContext, KubiTurn } from "./types";
+
+/**
+ * Dataset/Run/Quality context가 하나도 없을 때(Home hero, 빈 /kubi) 보여줄 시작 질문.
+ * Quality/Build 실패/SQL 질문을 포함하지 않는다.
+ */
+export const START_QUESTIONS = [
+  "어떤 공공데이터부터 찾아볼 수 있어?",
+  "원하는 데이터셋을 찾는 방법을 알려줘.",
+  "Public API 데이터를 추가하려면 어떻게 해야 해?",
+  "KPubData의 전체 작업 흐름을 설명해줘.",
+];
+
+/**
+ * @deprecated UI에 직접 노출하지 않는다 — `getSuggestedQuestions`를 쓴다. 기존 import
+ * 호환을 위해 남겨 둔 값으로, 내용은 "context가 있을 때"의 요약/품질/실패/SQL 질문이다.
  */
 export const SUGGESTED_QUESTIONS = [
   "현재 화면 문맥을 요약해줘.",
@@ -10,3 +37,155 @@ export const SUGGESTED_QUESTIONS = [
   "이 Build가 실패했다면 원인을 분석해줘.",
   "이 데이터로 어떤 걸 SQL로 확인할 수 있을지 제안해줘.",
 ];
+
+export interface SuggestedQuestionsInput {
+  /** 지금 이 순간의 route context. */
+  context: KubiContext;
+  /** 현재 세션의 대화 turn 목록(가장 오래된 것부터). */
+  turns: KubiTurn[];
+  /**
+   * turn이 현재 context와 어긋나면(다른 화면 기준) follow-up 근거로 쓰지 않는다.
+   * 생략하면 모든 turn을 유효한 것으로 본다.
+   */
+  isStale?: (turn: KubiTurn) => boolean;
+  /** 최대 노출 개수(기본 4). */
+  limit?: number;
+}
+
+function dedupe(list: string[]): string[] {
+  return Array.from(new Set(list));
+}
+
+/** context만으로 고르는 초기 추천(대화 turn이 아직 없을 때). */
+function initialQuestions(context: KubiContext): string[] {
+  // D. Quality context가 "실제로" 있을 때만 Quality-specific.
+  if (context.page === "quality" && (context.runId || context.datasetId)) {
+    return [
+      "현재 Quality 이슈의 원인을 설명해줘.",
+      "가장 먼저 확인해야 할 문제는 뭐야?",
+      "WARN/FAIL 항목을 어떻게 개선할 수 있어?",
+    ];
+  }
+  // Silver/Gold stage — 컬럼/SQL.
+  if (context.stage === "silver" || context.stage === "gold") {
+    return [
+      "사용할 수 있는 컬럼을 알려줘.",
+      "이 데이터를 집계하는 SQL을 만들어줘.",
+      "이 단계 데이터로 어떤 분석을 할 수 있어?",
+    ];
+  }
+  // C. Run context가 있을 때만 Run/실패 질문.
+  if (context.runId) {
+    return [
+      "이 Run 결과를 요약해줘.",
+      "경고되거나 실패한 단계가 있어?",
+      "이 Run의 Quality 결과를 설명해줘.",
+      "다음에 어떤 작업을 해야 해?",
+    ];
+  }
+  // B. Dataset context가 있을 때만 Dataset-specific.
+  if (context.datasetId) {
+    return [
+      "이 데이터셋의 구조를 요약해줘.",
+      "이 데이터에서 확인할 품질 문제는 뭐야?",
+      "이 데이터로 어떤 분석을 할 수 있어?",
+      "Silver/Gold 단계에서는 어떻게 활용할 수 있어?",
+    ];
+  }
+  // A. 아무 context도 없음.
+  return START_QUESTIONS;
+}
+
+/** 가장 최근의, 현재 context와 어긋나지 않은 "답변 완료" turn. */
+function lastAnsweredTurn(
+  turns: KubiTurn[],
+  isStale?: (turn: KubiTurn) => boolean,
+): KubiTurn | undefined {
+  for (let i = turns.length - 1; i >= 0; i -= 1) {
+    const turn = turns[i];
+    if (turn.status !== "ok" || !turn.response) continue;
+    if (isStale && isStale(turn)) continue;
+    return turn;
+  }
+  return undefined;
+}
+
+/** 최근 turn의 구조화된 단서로 고르는 follow-up 질문. */
+function followUpQuestions(turn: KubiTurn, context: KubiContext): string[] {
+  const response = turn.response;
+  const evidence = turn.evidence;
+  const out: string[] = [];
+
+  if (response?.generatedSql) {
+    out.push(
+      "이 SQL 결과를 어떻게 해석하면 돼?",
+      "조건을 바꿔서 다시 집계해줘.",
+      "결과에서 눈에 띄는 값이 있으면 짚어줘.",
+    );
+  }
+
+  const quality = evidence?.quality;
+  const hasQualityIssue =
+    !!quality &&
+    quality.availability !== "unavailable" &&
+    quality.results.some((result) => result.status === "warn" || result.status === "fail");
+  if (hasQualityIssue) {
+    out.push(
+      "가장 먼저 고쳐야 할 품질 문제는 뭐야?",
+      "이 품질 문제가 다음 단계에 어떤 영향을 줘?",
+    );
+  }
+
+  // 데이터 탐색/추천 성격 — catalog 근거가 있거나 아직 dataset/run을 안 정한 상태.
+  if (evidence?.catalog || (!context.datasetId && !context.runId)) {
+    out.push(
+      "추천한 데이터셋 중 어떤 걸 먼저 보는 게 좋아?",
+      "이 데이터를 Add Data로 가져오는 방법을 알려줘.",
+      "지역별로 비교하려면 어떤 데이터가 적합해?",
+      "분석을 시작하려면 다음 단계가 뭐야?",
+    );
+  }
+
+  if (evidence?.dataset) {
+    out.push(
+      "이 데이터셋으로 어떤 분석을 할 수 있어?",
+      "다음으로 어떤 단계를 진행하면 돼?",
+    );
+  }
+
+  if (evidence?.stage || (evidence?.recentRuns?.length ?? 0) > 0 || context.runId) {
+    out.push(
+      "이 결과에서 다음으로 확인할 건 뭐야?",
+      "경고되거나 실패한 단계가 있어?",
+    );
+  }
+
+  // 구조적 단서가 부족하면 최근 질문을 구체화하는 generic follow-up.
+  if (out.length === 0) {
+    out.push(
+      "방금 답변을 좀 더 자세히 설명해줘.",
+      "이걸 바탕으로 다음 단계를 추천해줘.",
+      "관련해서 더 확인할 데이터가 있어?",
+    );
+  }
+
+  return out;
+}
+
+/**
+ * 현재 context와 최근 대화에서 다음 질문 후보를 고른다.
+ *
+ * - 최근에 답변 완료된(그리고 stale하지 않은) turn이 있으면 그 대화 맥락을 우선한다.
+ * - 없으면 context(dataset/run/quality/stage)별 초기 추천을 준다.
+ * - 결과는 중복 제거 후 `limit`(기본 4)개로 자른다.
+ */
+export function getSuggestedQuestions(input: SuggestedQuestionsInput): string[] {
+  const { context, turns, isStale, limit = 4 } = input;
+
+  const recent = lastAnsweredTurn(turns, isStale);
+  const questions = recent
+    ? followUpQuestions(recent, context)
+    : initialQuestions(context);
+
+  return dedupe(questions).slice(0, limit);
+}

--- a/src/features/onboarding/FirstRunTour.test.tsx
+++ b/src/features/onboarding/FirstRunTour.test.tsx
@@ -1,0 +1,28 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { FirstRunTour, ONBOARDING_STORAGE_KEY, resetFirstRunTour } from "./FirstRunTour";
+
+describe("FirstRunTour", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("미완료 상태에서 표시하고 Skip을 저장해 reload 자동 표시를 막는다", () => {
+    const first = render(<FirstRunTour />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "건너뛰기" }));
+    expect(localStorage.getItem(ONBOARDING_STORAGE_KEY)).toBe("complete");
+    first.unmount();
+    render(<FirstRunTour />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("Finish 저장 후 다시 보기 action으로 재실행한다", () => {
+    render(<FirstRunTour />);
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    fireEvent.click(screen.getByRole("button", { name: "완료" }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    act(() => resetFirstRunTour());
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/src/features/onboarding/FirstRunTour.test.tsx
+++ b/src/features/onboarding/FirstRunTour.test.tsx
@@ -1,28 +1,30 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
-import { FirstRunTour, ONBOARDING_STORAGE_KEY, resetFirstRunTour } from "./FirstRunTour";
+import { FirstRunTour, onboardingStorageKey, resetFirstRunTour } from "./FirstRunTour";
+
+const USER_ID = "keycloak-subject-1";
 
 describe("FirstRunTour", () => {
   beforeEach(() => localStorage.clear());
 
   it("미완료 상태에서 표시하고 Skip을 저장해 reload 자동 표시를 막는다", () => {
-    const first = render(<FirstRunTour />);
+    const first = render(<FirstRunTour userId={USER_ID} />);
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "건너뛰기" }));
-    expect(localStorage.getItem(ONBOARDING_STORAGE_KEY)).toBe("complete");
+    expect(localStorage.getItem(onboardingStorageKey(USER_ID))).toBe("complete");
     first.unmount();
-    render(<FirstRunTour />);
+    render(<FirstRunTour userId={USER_ID} />);
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("Finish 저장 후 다시 보기 action으로 재실행한다", () => {
-    render(<FirstRunTour />);
+    render(<FirstRunTour userId={USER_ID} />);
     fireEvent.click(screen.getByRole("button", { name: "다음" }));
     fireEvent.click(screen.getByRole("button", { name: "다음" }));
     fireEvent.click(screen.getByRole("button", { name: "다음" }));
     fireEvent.click(screen.getByRole("button", { name: "완료" }));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    act(() => resetFirstRunTour());
+    act(() => resetFirstRunTour(USER_ID));
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 });

--- a/src/features/onboarding/FirstRunTour.tsx
+++ b/src/features/onboarding/FirstRunTour.tsx
@@ -2,7 +2,12 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Button } from "@/shared/ui/Button";
 
-export const ONBOARDING_STORAGE_KEY = "kpubdata:onboarding:v1";
+export const ONBOARDING_STORAGE_KEY_PREFIX = "kpubdata:onboarding:v2";
+const ONBOARDING_STORAGE_KEY = "kpubdata:onboarding:v1";
+
+export function onboardingStorageKey(userId: string): string {
+  return `${ONBOARDING_STORAGE_KEY_PREFIX}:${userId}`;
+}
 
 const steps = [
   { target: "sidebar", title: "작업 공간 둘러보기", copy: "왼쪽 메뉴에서 데이터 탐색, Build·Quality 확인, Kubi와 Provider 설정으로 이동할 수 있습니다." },
@@ -11,27 +16,31 @@ const steps = [
   { target: "kubi-helper", title: "막히면 Kubi에게 물어보세요", copy: "Kubi는 현재 화면의 Dataset·Run·Stage와 Builder Evidence를 바탕으로 분석을 돕습니다." },
 ] as const;
 
-function hasCompletedTour() {
-  try { return localStorage.getItem(ONBOARDING_STORAGE_KEY) === "complete"; } catch { return false; }
+function hasCompletedTour(userId: string) {
+  try { return localStorage.getItem(onboardingStorageKey(userId)) === "complete"; } catch { return false; }
 }
 
-export function resetFirstRunTour() {
+export function resetFirstRunTour(userId?: unknown) {
   try { localStorage.removeItem(ONBOARDING_STORAGE_KEY); } catch { /* storage를 사용할 수 없어도 수동 재생은 가능하다. */ }
-  window.dispatchEvent(new CustomEvent("kpubdata:onboarding:replay"));
+  window.dispatchEvent(new CustomEvent("kpubdata:onboarding:replay", { detail: userId }));
 }
 
-export function FirstRunTour() {
-  const [open, setOpen] = useState(() => !hasCompletedTour());
+export function FirstRunTour({ userId }: { userId: string }) {
+  const [open, setOpen] = useState(() => !hasCompletedTour(userId));
   const [step, setStep] = useState(0);
   const [rect, setRect] = useState<DOMRect | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
-    const replay = () => { setStep(0); setOpen(true); };
+    const replay = (event: Event) => {
+      const requestedUserId = (event as CustomEvent<string | Event>).detail;
+      if (typeof requestedUserId === "string" && requestedUserId !== userId) return;
+      setStep(0); setOpen(true);
+    };
     window.addEventListener("kpubdata:onboarding:replay", replay);
     return () => window.removeEventListener("kpubdata:onboarding:replay", replay);
-  }, []);
+  }, [userId]);
 
   useEffect(() => {
     if (!open) return;
@@ -66,6 +75,7 @@ export function FirstRunTour() {
 
   function close() {
     try { localStorage.setItem(ONBOARDING_STORAGE_KEY, "complete"); } catch { /* 비필수 저장소 */ }
+    try { localStorage.setItem(onboardingStorageKey(userId), "complete"); } catch { /* storage unavailable */ }
     setOpen(false);
   }
 

--- a/src/features/onboarding/FirstRunTour.tsx
+++ b/src/features/onboarding/FirstRunTour.tsx
@@ -9,11 +9,18 @@ export function onboardingStorageKey(userId: string): string {
   return `${ONBOARDING_STORAGE_KEY_PREFIX}:${userId}`;
 }
 
-const steps = [
+const emptyWorkspaceSteps = [
   { target: "sidebar", title: "작업 공간 둘러보기", copy: "왼쪽 메뉴에서 데이터 탐색, Build·Quality 확인, Kubi와 Provider 설정으로 이동할 수 있습니다." },
   { target: "workflow", title: "데이터가 이렇게 만들어집니다", copy: "데이터를 찾고 가져오기 설정을 준비한 뒤 Preview로 실제 데이터를 확인·검증하고 Build합니다. 이후 Quality 결과를 확인하고 활용할 수 있습니다." },
   { target: "start-actions", title: "여기서 시작하세요", copy: "카탈로그에서 데이터를 찾으려면 Discover, API·파일·URL을 직접 가져오려면 Add Data를 사용하세요." },
   { target: "kubi-helper", title: "막히면 Kubi에게 물어보세요", copy: "Kubi는 현재 화면의 Dataset·Run·Stage와 Builder Evidence를 바탕으로 분석을 돕습니다." },
+] as const;
+
+const dashboardSteps = [
+  { target: "sidebar", title: "작업 공간 둘러보기", copy: "왼쪽 메뉴에서 데이터 탐색, Build·Quality 확인, Kubi와 Provider 설정으로 이동할 수 있습니다." },
+  { target: "dashboard-overview", title: "작업 현황 확인", copy: "현재 Dataset과 Build 실행 현황을 이 Dashboard에서 확인할 수 있습니다." },
+  { target: "dashboard-builds", title: "최근 Build 확인", copy: "최근 실행과 진행 상태를 확인하고 필요하면 Build 상세 화면으로 이동하세요." },
+  { target: "dashboard-quality", title: "품질 결과 확인", copy: "최근 Quality 경고를 확인하고 필요한 조치를 이어갈 수 있습니다." },
 ] as const;
 
 function hasCompletedTour(userId: string) {
@@ -25,8 +32,17 @@ export function resetFirstRunTour(userId?: unknown) {
   window.dispatchEvent(new CustomEvent("kpubdata:onboarding:replay", { detail: userId }));
 }
 
-export function FirstRunTour({ userId }: { userId: string }) {
-  const [open, setOpen] = useState(() => !hasCompletedTour(userId));
+export function FirstRunTour({
+  userId,
+  autoStart = true,
+  variant = "empty-workspace",
+}: {
+  userId: string;
+  autoStart?: boolean;
+  variant?: "empty-workspace" | "dashboard";
+}) {
+  const steps = variant === "dashboard" ? dashboardSteps : emptyWorkspaceSteps;
+  const [open, setOpen] = useState(() => autoStart && !hasCompletedTour(userId));
   const [step, setStep] = useState(0);
   const [rect, setRect] = useState<DOMRect | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -71,7 +87,7 @@ export function FirstRunTour({ userId }: { userId: string }) {
       window.removeEventListener("scroll", update, true);
       document.removeEventListener("keydown", onKeyDown);
     };
-  }, [open, step]);
+  }, [open, step, steps]);
 
   function close() {
     try { localStorage.setItem(ONBOARDING_STORAGE_KEY, "complete"); } catch { /* 비필수 저장소 */ }

--- a/src/features/onboarding/FirstRunTour.tsx
+++ b/src/features/onboarding/FirstRunTour.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Button } from "@/shared/ui/Button";
+
+export const ONBOARDING_STORAGE_KEY = "kpubdata:onboarding:v1";
+
+const steps = [
+  { target: "sidebar", title: "작업 공간 둘러보기", copy: "왼쪽 메뉴에서 데이터 탐색, Build·Quality 확인, Kubi와 Provider 설정으로 이동할 수 있습니다." },
+  { target: "workflow", title: "데이터가 이렇게 만들어집니다", copy: "데이터를 찾고 가져오기 설정을 준비한 뒤 Preview로 실제 데이터를 확인·검증하고 Build합니다. 이후 Quality 결과를 확인하고 활용할 수 있습니다." },
+  { target: "start-actions", title: "여기서 시작하세요", copy: "카탈로그에서 데이터를 찾으려면 Discover, API·파일·URL을 직접 가져오려면 Add Data를 사용하세요." },
+  { target: "kubi-helper", title: "막히면 Kubi에게 물어보세요", copy: "Kubi는 현재 화면의 Dataset·Run·Stage와 Builder Evidence를 바탕으로 분석을 돕습니다." },
+] as const;
+
+function hasCompletedTour() {
+  try { return localStorage.getItem(ONBOARDING_STORAGE_KEY) === "complete"; } catch { return false; }
+}
+
+export function resetFirstRunTour() {
+  try { localStorage.removeItem(ONBOARDING_STORAGE_KEY); } catch { /* storage를 사용할 수 없어도 수동 재생은 가능하다. */ }
+  window.dispatchEvent(new CustomEvent("kpubdata:onboarding:replay"));
+}
+
+export function FirstRunTour() {
+  const [open, setOpen] = useState(() => !hasCompletedTour());
+  const [step, setStep] = useState(0);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const replay = () => { setStep(0); setOpen(true); };
+    window.addEventListener("kpubdata:onboarding:replay", replay);
+    return () => window.removeEventListener("kpubdata:onboarding:replay", replay);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    previousFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    return () => previousFocusRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const update = () => setRect(document.querySelector<HTMLElement>(`[data-tour="${steps[step].target}"]`)?.getBoundingClientRect() ?? null);
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") close();
+      if (event.key !== "Tab") return;
+      const focusable = dialogRef.current?.querySelectorAll<HTMLElement>("button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex='-1'])");
+      if (!focusable?.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last.focus(); }
+      else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus(); }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    dialogRef.current?.focus();
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, step]);
+
+  function close() {
+    try { localStorage.setItem(ONBOARDING_STORAGE_KEY, "complete"); } catch { /* 비필수 저장소 */ }
+    setOpen(false);
+  }
+
+  if (!open || typeof document === "undefined") return null;
+  const width = Math.min(336, window.innerWidth - 24);
+  const left = rect ? Math.max(12, Math.min(rect.left, window.innerWidth - width - 12)) : 12;
+  const below = rect ? rect.bottom + 12 : 80;
+  const top = Math.max(12, Math.min(below, window.innerHeight - 230));
+
+  return createPortal(
+    <>
+      <div className="fixed inset-0 z-[80] bg-black/20" aria-hidden="true" />
+      {rect ? <div aria-hidden="true" className="pointer-events-none fixed z-[81] rounded-xl ring-4 ring-accent ring-offset-4 ring-offset-background" style={{ left: rect.left, top: rect.top, width: rect.width, height: rect.height }} /> : null}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="onboarding-title"
+        tabIndex={-1}
+        className="fixed z-[82] rounded-xl border border-border bg-card p-5 text-foreground shadow-xl outline-none"
+        style={{ left, top, width }}
+      >
+        <p className="text-xs font-semibold text-accent-subtle-foreground">{step + 1} / {steps.length}</p>
+        <h2 id="onboarding-title" className="mt-1 text-base font-semibold">{steps[step].title}</h2>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">{steps[step].copy}</p>
+        <div className="mt-5 flex items-center justify-between gap-2">
+          <Button variant="ghost" size="sm" onClick={close}>건너뛰기</Button>
+          <div className="flex gap-2">
+            {step > 0 ? <Button variant="secondary" size="sm" onClick={() => setStep((value) => value - 1)}>이전</Button> : null}
+            {step < steps.length - 1
+              ? <Button size="sm" onClick={() => setStep((value) => value + 1)}>다음</Button>
+              : <Button size="sm" onClick={close}>완료</Button>}
+          </div>
+        </div>
+      </div>
+    </>,
+    document.body,
+  );
+}

--- a/src/pages/AddDataPage.tsx
+++ b/src/pages/AddDataPage.tsx
@@ -17,12 +17,14 @@
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { fetchCatalog, testProvider, uploadSourceFile } from "@/features/add-data/api";
-import { ConfigureStep, type CatalogState, type ProviderTestState, type UploadState } from "@/features/add-data/components/ConfigureStep";
+import { fetchCatalog, fetchProviderConfigured, uploadSourceFile } from "@/features/add-data/api";
+import { CREDENTIAL_PREREQUISITE_MESSAGE, checkCredentialPrerequisite } from "@/features/add-data/credentialPrerequisite";
+import { ConfigureStep, type CatalogState, type UploadState } from "@/features/add-data/components/ConfigureStep";
 import { PreviewValidationStep, type PreviewState } from "@/features/add-data/components/PreviewValidationStep";
 import { ReviewBuildStep } from "@/features/add-data/components/ReviewBuildStep";
 import { SourceStep } from "@/features/add-data/components/SourceStep";
 import { clearAddDataDraft, hasAddDataDraft, loadAddDataDraft, saveAddDataDraft } from "@/features/add-data/draftStorage";
+import { checkRequiredParams } from "@/features/add-data/requiredParams";
 import { findDataset, identityFromCatalog, identityFromFilename, identityFromUrl } from "@/features/add-data/identity";
 import {
   INITIAL_DRAFT,
@@ -43,10 +45,10 @@ import { validateSpec } from "@/features/validation/api";
 import { Button, Card, PageHeader, Stepper, type StepItem } from "@/shared/ui";
 
 const STEPS: StepItem[] = [
-  { id: "source", label: "소스" },
-  { id: "configure", label: "설정" },
-  { id: "preview", label: "미리보기·검증" },
-  { id: "review", label: "검토·빌드" },
+  { id: "source", label: "데이터 선택" },
+  { id: "configure", label: "가져오기 설정" },
+  { id: "preview", label: "Preview · 검증" },
+  { id: "review", label: "검토 · Build" },
 ];
 
 export function AddDataPage() {
@@ -57,7 +59,10 @@ export function AddDataPage() {
   const [draft, setDraft] = useState<AddDataDraft>(INITIAL_DRAFT);
   const [step, setStep] = useState(0);
   const [catalog, setCatalog] = useState<CatalogState>({ status: "loading", providers: [] });
-  const [providerTest, setProviderTest] = useState<ProviderTestState>({ status: "idle" });
+  // provider별 effective credential 구성 여부(GET /providers 요약). null = 아직
+  // 로딩 중이거나 조회 실패 — credential prerequisite는 이때 아무것도 막지 않는다
+  // (§3: Studio가 credential 존재 여부를 추측하지 않는다).
+  const [providerConfigured, setProviderConfigured] = useState<Record<string, boolean> | null>(null);
   const [upload, setUpload] = useState<UploadState>({ status: "idle" });
   const [preview, setPreview] = useState<PreviewState>({ status: "idle" });
   const [previewView, setPreviewView] = useState<"sample" | "diff">("sample");
@@ -100,6 +105,19 @@ export function AddDataPage() {
     return () => controller.abort();
   }, []);
 
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchProviderConfigured(controller.signal)
+      .then((configured) => {
+        if (!controller.signal.aborted) setProviderConfigured(configured);
+      })
+      .catch(() => {
+        // 조회 실패는 "미설정"으로 단정하지 않는다 — null 그대로 두면 prerequisite가
+        // 막지 않는다(위 상태 선언 주석 참고).
+      });
+    return () => controller.abort();
+  }, []);
+
   // Discover preselection(#249 완료를 hard blocker로 두지 않는다 — 쿼리 파라미터만 읽는다).
   useEffect(() => {
     if (preselectApplied.current || catalog.status !== "loaded") return;
@@ -137,6 +155,11 @@ export function AddDataPage() {
       const sourceChanged = lastIdentitySourceRef.current !== null && lastIdentitySourceRef.current !== sourceKey;
       lastIdentitySourceRef.current = sourceKey;
       if (sourceChanged) {
+        // 이 effect는 자동 생성 identity(ID/제목/설명)와 touched 플래그만 담당한다.
+        // 이전 Dataset 전용 요청 파라미터(sourceParams) 초기화는 Provider/Dataset
+        // <select> onChange가 같은 updateDraft에서 atomic하게 처리한다 — 여기서
+        // 하면 setDraft updater 안에서 ref를 mutate하는 특성상 StrictMode의 updater
+        // 이중 호출에서 reset 결과가 버려질 수 있다(#S-stale-params).
         return {
           ...current,
           datasetId: identity.datasetId,
@@ -220,17 +243,14 @@ export function AddDataPage() {
     setStep((s) => Math.max(s - 1, 0));
   }
 
-  async function handleTestProvider() {
-    setProviderTest({ status: "testing" });
-    try {
-      const result = await testProvider(draft.publicApi.provider);
-      setProviderTest({ status: "tested", result });
-    } catch (cause) {
-      setProviderTest({
-        status: "tested",
-        error: cause instanceof Error ? cause.message : "연결 테스트에 실패했습니다.",
-      });
-    }
+  /**
+   * "API 연결하기" CTA — 기존 draft persistence(`saveAddDataDraft`)를 그대로 재사용해
+   * 초안을 저장한 뒤 Provider 화면으로 이동한다. URL에는 provider id와 safe return
+   * destination만 싣는다 — credential/BuildSpec 전체는 절대 담지 않는다(§4).
+   */
+  function handleConnectProvider(provider: string) {
+    saveAddDataDraft(draft);
+    navigate(`/provider?provider=${encodeURIComponent(provider)}&returnTo=${encodeURIComponent("/add")}`);
   }
 
   async function handleUploadFile(file: File) {
@@ -312,6 +332,31 @@ export function AddDataPage() {
       return;
     }
     const spec = specResult.spec;
+
+    // Preview 전 usability preflight — Dataset metadata로 필수 요청 파라미터를 아는
+    // 경우에만 동작한다. 누락이면 Preview API를 호출하지 않고 사용자 문구로 안내한다
+    // (Builder/Core validation을 대체하지 않는 사전 안내).
+    if (draft.sourceKind === "public_api") {
+      const selected = findDataset(catalog.providers, draft.publicApi.provider, draft.publicApi.dataset);
+
+      // credential prerequisite — Preview까지 가서 뒤늦게 credential 오류로 실패하지
+      // 않는다(§3). Configure 단계 배너와 같은 판정을 재사용한다.
+      const prerequisite = checkCredentialPrerequisite(selected, providerConfigured, draft.publicApi.provider);
+      if (prerequisite.blocked) {
+        const message = `${CREDENTIAL_PREREQUISITE_MESSAGE.title} — ${CREDENTIAL_PREREQUISITE_MESSAGE.body.replace("\n", " ")}`;
+        setPreview({ status: "error", error: message });
+        setValidation({ status: "validated", valid: false, errors: [message] });
+        return;
+      }
+
+      const requiredCheck = checkRequiredParams(draft.publicApi.sourceParams, selected?.request_parameters);
+      if (requiredCheck.error) {
+        setPreview({ status: "error", error: requiredCheck.error });
+        setValidation({ status: "validated", valid: false, errors: [requiredCheck.error] });
+        return;
+      }
+    }
+
     const signatureAtRequest = draftSignature(draft);
     setPreview({ status: "loading" });
     setValidation({ status: "validating", valid: false, errors: [] });
@@ -390,7 +435,7 @@ export function AddDataPage() {
       <PageHeader
         eyebrow="Add Data"
         title="데이터 추가"
-        description="Source 유형에 맞는 입력만 보여주고 Preview·Validation을 거쳐 Build를 시작합니다."
+        description="가져오기에 필요한 설정을 준비하고, Preview에서 실제 데이터를 확인·검증한 뒤 Build를 시작합니다."
       />
 
       {draftAvailable ? (
@@ -415,8 +460,8 @@ export function AddDataPage() {
             draft={draft}
             updateDraft={updateDraft}
             catalog={catalog}
-            providerTest={providerTest}
-            onTestProvider={handleTestProvider}
+            providerConfigured={providerConfigured}
+            onConnectProvider={handleConnectProvider}
             upload={upload}
             onUploadFile={handleUploadFile}
             specError={specResult.error}
@@ -440,6 +485,7 @@ export function AddDataPage() {
             onChangeSampleMode={(mode: PreviewSampleMode) => updateDraft({ previewSampleMode: mode })}
             onChangeColumns={(columns: PreviewColumnView) => updateDraft({ previewColumns: columns })}
             onRefresh={() => void runPreviewAndValidate()}
+            isStale={isStale}
             view={previewView}
             onChangeView={setPreviewView}
           />

--- a/src/pages/BuildArtifactsPage.tsx
+++ b/src/pages/BuildArtifactsPage.tsx
@@ -1,18 +1,25 @@
 /**
  * 빌드 결과물 페이지 (/builds/:buildId/artifacts).
  *
- * manifest 요약, 생성 파일 목록, manifest 원본(JSON)을 보여준다(제안 §5.7, #30).
+ * manifest 요약, 다운로드 가능한 파일 목록, manifest 원본(JSON)을 보여준다(제안 §5.7, #30).
  *
- * 실연동 모드에서는 `GET /builds/{run_id}/manifest`의 authoritative manifest 본문을
- * 그대로 렌더링한다. 일부 legacy/partial 실행은 manifest에 메타데이터 필드가 없을 수
- * 있으며, 그 경우에만 "일부 메타데이터가 없다"고 사실대로 안내한다. mock 모드에서는
- * 결정적 fixture manifest를 쓴다.
+ * manifest 요약/JSON은 `GET /builds/{run_id}/manifest`에서, **다운로드 파일 목록은
+ * `GET /artifacts/{run_id}`**에서 따로 받는다. 두 호출은 독립적이라 한쪽 실패가 다른 쪽을
+ * 막지 않는다. 다운로드는 `/artifacts/{run_id}` 목록이 준 canonical run-relative 경로만
+ * 쓴다 — `manifest.outputs`는 output_root 절대 storage 경로라 다운로드 식별자로 못 쓴다.
+ * 일부 legacy/partial 실행은 manifest에 메타데이터 필드가 없을 수 있으며, 그 경우에만
+ * "일부 메타데이터가 없다"고 사실대로 안내한다. mock 모드에서는 결정적 fixture를 쓴다.
  */
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { getBuildManifest } from "@/features/artifacts/api";
+import {
+  downloadArtifact,
+  getBuildManifest,
+  listArtifactFiles,
+  saveBlobAsFile,
+} from "@/features/artifacts/api";
 import type { BuildManifest } from "@/shared/lib/types";
-import { Card, EmptyState, ErrorState, LinkButton, PageHeader, SkeletonTable } from "@/shared/ui";
+import { Button, Card, EmptyState, ErrorState, LinkButton, PageHeader, SkeletonTable } from "@/shared/ui";
 
 interface ManifestState {
   status: "loading" | "loaded" | "error";
@@ -20,11 +27,71 @@ interface ManifestState {
   error?: string;
 }
 
+type ArtifactsState =
+  | { status: "loading" }
+  | { status: "loaded"; files: string[] }
+  | { status: "error"; error: string };
+
 /** 파일 경로에서 표시용 이름과 형식(확장자)을 뽑는다. */
 function describeFile(path: string): { name: string; format: string } {
-  const name = path.split("/").pop() ?? path;
+  const name = path.split(/[\\/]/).pop() ?? path;
   const dot = name.lastIndexOf(".");
   return { name, format: dot >= 0 ? name.slice(dot + 1) : "—" };
+}
+
+type RowDownloadState =
+  | { status: "idle" }
+  | { status: "downloading" }
+  | { status: "error"; message: string };
+
+/**
+ * artifact 파일 한 줄. `path`는 `GET /artifacts/{run_id}`가 준 canonical run-relative
+ * POSIX 경로다. 다운로드는 exact run_id + 이 경로를 그대로 써서 인증된 Builder 요청
+ * (`downloadArtifact`)으로 받아 Blob으로 저장한다. 다운로드 중에는 버튼을 비활성화해
+ * 중복 클릭을 막고, 실패는 이 row에만 표시한다 — 페이지 전체를 실패 상태로 만들지 않는다.
+ */
+function ArtifactRow({ runId, path }: { runId: string; path: string }) {
+  const { name, format } = describeFile(path);
+  const [state, setState] = useState<RowDownloadState>({ status: "idle" });
+
+  const onDownload = useCallback(() => {
+    if (state.status === "downloading") return;
+    setState({ status: "downloading" });
+    downloadArtifact(runId, path)
+      .then(({ blob, filename }) => {
+        saveBlobAsFile(blob, filename);
+        setState({ status: "idle" });
+      })
+      .catch((cause: unknown) => {
+        setState({
+          status: "error",
+          message: cause instanceof Error ? cause.message : "다운로드에 실패했습니다.",
+        });
+      });
+  }, [runId, path, state.status]);
+
+  return (
+    <li className="grid grid-cols-[1.6fr_0.6fr_0.8fr] items-center gap-4 border-b border-border px-6 py-3 text-sm last:border-0">
+      <span className="break-all font-medium">{name}</span>
+      <span className="uppercase text-muted-foreground">{format}</span>
+      <span className="flex flex-col items-start gap-1">
+        <Button
+          size="sm"
+          variant="secondary"
+          loading={state.status === "downloading"}
+          disabled={state.status === "downloading"}
+          onClick={onDownload}
+        >
+          다운로드
+        </Button>
+        {state.status === "error" ? (
+          <span role="alert" className="text-xs text-red-600 dark:text-red-400">
+            {state.message}
+          </span>
+        ) : null}
+      </span>
+    </li>
+  );
 }
 
 /**
@@ -35,10 +102,12 @@ function describeFile(path: string): { name: string; format: string } {
 export function BuildArtifactsPage() {
   const { buildId = "" } = useParams();
   const [state, setState] = useState<ManifestState>({ status: "loading" });
+  const [artifacts, setArtifacts] = useState<ArtifactsState>({ status: "loading" });
 
   const load = useCallback(() => {
     const controller = new AbortController();
     setState({ status: "loading" });
+    setArtifacts({ status: "loading" });
     getBuildManifest(buildId, controller.signal)
       .then((manifest) => {
         if (!controller.signal.aborted) setState({ status: "loaded", manifest });
@@ -48,6 +117,20 @@ export function BuildArtifactsPage() {
         setState({
           status: "error",
           error: cause instanceof Error ? cause.message : "manifest를 불러오지 못했습니다.",
+        });
+      });
+    // 다운로드 가능한 파일 목록은 canonical `GET /artifacts/{run_id}`에서 별도로 받는다
+    // (manifest.outputs는 storage 절대경로라 다운로드 식별자로 못 쓴다). manifest 로드와
+    // 독립적이라 한쪽 실패가 다른 쪽을 막지 않는다.
+    listArtifactFiles(buildId, controller.signal)
+      .then((files) => {
+        if (!controller.signal.aborted) setArtifacts({ status: "loaded", files });
+      })
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setArtifacts({
+          status: "error",
+          error: cause instanceof Error ? cause.message : "파일 목록을 불러오지 못했습니다.",
         });
       });
     return () => controller.abort();
@@ -142,23 +225,17 @@ export function BuildArtifactsPage() {
               <span>형식</span>
               <span>액션</span>
             </div>
-            {!manifest.outputs || manifest.outputs.length === 0 ? (
-              <EmptyState title={manifest.outputs === undefined ? "파일 정보 미제공" : "생성된 파일이 없습니다"} />
+            {artifacts.status === "loading" ? (
+              <SkeletonTable rows={4} />
+            ) : artifacts.status === "error" ? (
+              <EmptyState title="파일 목록을 불러오지 못했습니다" description={artifacts.error} />
+            ) : artifacts.files.length === 0 ? (
+              <EmptyState title="생성된 파일이 없습니다" />
             ) : (
               <ul>
-                {manifest.outputs.map((path) => {
-                  const { name, format } = describeFile(path);
-                  return (
-                    <li
-                      key={path}
-                      className="grid grid-cols-[1.6fr_0.6fr_0.8fr] items-center gap-4 border-b border-border px-6 py-3 text-sm last:border-0 "
-                    >
-                      <span className="break-all font-medium">{name}</span>
-                      <span className="uppercase text-muted-foreground">{format}</span>
-                      <span className="text-muted-foreground">다운로드(연동 예정)</span>
-                    </li>
-                  );
-                })}
+                {artifacts.files.map((path) => (
+                  <ArtifactRow key={path} runId={buildId} path={path} />
+                ))}
               </ul>
             )}
           </Card>

--- a/src/pages/BuildPublishPage.tsx
+++ b/src/pages/BuildPublishPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
-import { getDataset, listDatasetRuns } from "@/features/datasets/api";
+import { getBuild } from "@/features/runs/api/getBuild";
 import {
   describePublishFailure,
   getPublishReadiness,
@@ -11,6 +11,7 @@ import {
 } from "@/features/publish/api";
 import { usePublishJob } from "@/features/publish/usePublishJob";
 import { formatDateTime } from "@/features/datasets/model";
+import type { BuildRunStatus } from "@/shared/lib/types";
 import { Button, Card, PageHeader, Skeleton, StatusBadge } from "@/shared/ui";
 
 type ReadinessState =
@@ -18,10 +19,33 @@ type ReadinessState =
   | { status: "loaded"; data: PublishReadinessResponse }
   | { status: "error"; message: string };
 
-interface DatasetContext {
-  title: string;
+/**
+ * 게시 화면의 Run 문맥(Dataset identity + Build 완료 상태)은 URL의 `?dataset=` 존재
+ * 여부가 아니라 **exact run_id**로만 해석한다 — Builds/Runs·Artifacts·Dataset Detail·
+ * 딥링크 어느 경로로 들어와도 동일하게 표시되도록 한다. canonical 경로는
+ * `getBuild(runId)`(= `/builds/{run_id}/spec` snapshot + authoritative status)이며,
+ * latest run으로 대체하지 않는다.
+ */
+interface RunContext {
+  datasetTitle: string;
+  datasetId: string;
+  status: BuildRunStatus;
   finishedAt: string | null;
 }
+
+type RunContextState =
+  | { status: "loading" }
+  | { status: "loaded"; data: RunContext }
+  | { status: "error"; message: string };
+
+const BUILD_STATUS_LABEL: Record<BuildRunStatus, string> = {
+  queued: "대기 중",
+  running: "실행 중",
+  cancelling: "취소 중",
+  succeeded: "완료",
+  failed: "실패",
+  cancelled: "취소됨",
+};
 
 const inputClassName =
   "h-10 w-full rounded-lg border border-input bg-card px-3 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
@@ -29,8 +53,10 @@ const inputClassName =
 export function BuildPublishPage() {
   const { buildId: runId = "" } = useParams();
   const [searchParams] = useSearchParams();
-  const datasetId = searchParams.get("dataset") ?? "";
-  const [datasetContext, setDatasetContext] = useState<DatasetContext>();
+  // `?dataset=`은 있으면 보조 표시 힌트로만 쓴다 — 없다고 실제 존재하는 Run을
+  // "확인되지 않음"으로 만들지 않는다(canonical 해석은 runId 기반).
+  const datasetHint = searchParams.get("dataset") ?? "";
+  const [runContext, setRunContext] = useState<RunContextState>({ status: "loading" });
   const [readiness, setReadiness] = useState<ReadinessState>({ status: "loading" });
   const [readinessVersion, setReadinessVersion] = useState(0);
   const [destination, setDestination] = useState("");
@@ -39,28 +65,38 @@ export function BuildPublishPage() {
   const publish = usePublishJob();
 
   useEffect(() => {
-    if (!datasetId || !runId) {
-      setDatasetContext(undefined);
+    if (!runId) {
+      setRunContext({ status: "error", message: "게시할 Run ID가 없습니다." });
       return;
     }
-    const controller = new AbortController();
     let active = true;
-    Promise.all([
-      getDataset(datasetId, controller.signal),
-      listDatasetRuns(datasetId, 50, controller.signal),
-    ]).then(([dataset, runs]) => {
-      if (!active) return;
-      const run = runs.runs.find((item) => item.run_id === runId);
-      if (!run) return;
-      setDatasetContext({ title: dataset.title, finishedAt: run.finished_at });
-    }).catch(() => {
-      if (active && !controller.signal.aborted) setDatasetContext(undefined);
-    });
+    setRunContext({ status: "loading" });
+    // canonical: getBuild(runId) = BuildSpec snapshot(dataset identity) + authoritative status.
+    // dataset URL 파라미터도, listDatasetRuns 윈도우도 필요로 하지 않는다.
+    getBuild(runId)
+      .then((run) => {
+        if (!active) return;
+        setRunContext({
+          status: "loaded",
+          data: {
+            datasetTitle: run.spec.title || run.spec.datasetId || runId,
+            datasetId: run.spec.datasetId,
+            status: run.status,
+            finishedAt: run.finishedAt ?? null,
+          },
+        });
+      })
+      .catch((cause: unknown) => {
+        if (!active) return;
+        setRunContext({
+          status: "error",
+          message: cause instanceof Error ? cause.message : "이 Run의 정보를 확인할 수 없습니다.",
+        });
+      });
     return () => {
       active = false;
-      controller.abort();
     };
-  }, [datasetId, runId]);
+  }, [runId]);
 
   useEffect(() => {
     if (!runId) {
@@ -91,6 +127,19 @@ export function BuildPublishPage() {
     };
   }, [runId, readinessVersion, publish.reset]);
 
+  const runCtx = runContext.status === "loaded" ? runContext.data : null;
+  const datasetLabel = runCtx?.datasetTitle ?? (datasetHint || null);
+  const buildCompletionText =
+    runContext.status === "loading"
+      ? "확인 중…"
+      : runCtx
+        ? runCtx.status === "succeeded"
+          ? runCtx.finishedAt
+            ? `완료 · ${formatDateTime(runCtx.finishedAt)}`
+            : "완료"
+          : `${BUILD_STATUS_LABEL[runCtx.status]}${runCtx.finishedAt ? ` · ${formatDateTime(runCtx.finishedAt)}` : ""}`
+        : "확인되지 않음";
+
   const destinationError = validatePublishDestination(destination);
   const builderReady = readiness.status === "loaded" && readiness.data.ready && readiness.data.blockers.length === 0;
   const canReview = Boolean(runId && builderReady && !destinationError && publish.status !== "publishing");
@@ -117,19 +166,22 @@ export function BuildPublishPage() {
     <main className="flex flex-1 flex-col gap-6 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
       <PageHeader
         eyebrow="게시"
-        title={`${(datasetContext?.title ?? runId) || "Run"} 게시`}
+        title={`${datasetLabel || runId || "Run"} 게시`}
         description="Builder가 선택한 Run의 준비 상태를 확인한 뒤 Hugging Face에 게시합니다."
       />
 
       <Card>
         <p className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">선택한 Run</p>
         <dl className="mt-3 grid gap-3 text-sm sm:grid-cols-2">
-          <div><dt className="text-muted-foreground">Dataset</dt><dd>{(datasetContext?.title ?? datasetId) || "확인되지 않음"}</dd></div>
+          <div><dt className="text-muted-foreground">Dataset</dt><dd>{datasetLabel || (runContext.status === "loading" ? "확인 중…" : "확인되지 않음")}</dd></div>
           <div><dt className="text-muted-foreground">Run ID</dt><dd className="break-all font-mono">{runId || "—"}</dd></div>
-          <div><dt className="text-muted-foreground">Build 완료</dt><dd>{datasetContext?.finishedAt ? formatDateTime(datasetContext.finishedAt) : "확인되지 않음"}</dd></div>
+          <div><dt className="text-muted-foreground">Build 완료</dt><dd>{buildCompletionText}</dd></div>
           <div><dt className="text-muted-foreground">Target</dt><dd>Hugging Face</dd></div>
         </dl>
-        <p className="mt-3 text-xs text-muted-foreground">이 화면은 URL의 exact Run ID를 유지하며 latest Run으로 바꾸지 않습니다.</p>
+        <p className="mt-3 text-xs text-muted-foreground">이 화면은 URL의 exact Run ID로 Dataset과 Build 완료 상태를 확인하며, latest Run으로 바꾸지 않습니다.</p>
+        {runContext.status === "error" ? (
+          <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">이 Run의 Dataset 정보를 불러오지 못했습니다. Run ID로 게시 준비 상태는 아래에서 계속 확인할 수 있습니다.</p>
+        ) : null}
       </Card>
 
       <Card>

--- a/src/pages/BuildsPage.tsx
+++ b/src/pages/BuildsPage.tsx
@@ -64,6 +64,8 @@ import {
   SkeletonTable,
   Skeleton,
   StatusBadge,
+  StageLegend,
+  TermHelp,
   TextInput,
 } from "@/shared/ui";
 
@@ -301,7 +303,7 @@ export function BuildsPage() {
       <PageHeader
         eyebrow="Builds / Runs"
         title="빌드 실행 이력"
-        description="Run 상태, Stage Progress, Quality, Failure evidence를 한 화면에서 확인합니다."
+        description={<span><strong>Build</strong>는 데이터를 수집·처리하는 작업이고 <strong>Run</strong>은 그 Build가 실제로 한 번 실행된 기록입니다. <TermHelp term="build" /> <TermHelp term="run" /></span>}
       />
 
       <KpiRow kpi={kpi} />
@@ -687,6 +689,7 @@ function RunDetailPanel({
           <h3 className="text-sm font-semibold">Pipeline / Stage Progress</h3>
           {stagesState.status === "loaded" ? <MultiSourceOutcomeBadge outcome={outcome} /> : null}
         </div>
+        <div className="mt-3"><StageLegend /></div>
         {stagesState.status === "loading" || stagesState.status === "idle" ? (
           <Skeleton className="mt-4 h-24 w-full" />
         ) : stagesState.status === "error" ? (

--- a/src/pages/DatasetDetailPage.tsx
+++ b/src/pages/DatasetDetailPage.tsx
@@ -24,7 +24,7 @@ import type {
   RunStagesResponse,
   StageDetailResponse,
 } from "@/shared/lib/builderApi";
-import { Button, Card, EmptyState, ErrorState, LinkButton, PageHeader, Skeleton } from "@/shared/ui";
+import { Button, Card, EmptyState, ErrorState, LinkButton, PageHeader, Skeleton, StageLegend } from "@/shared/ui";
 
 type DetailTab = "overview" | "schema" | "preview" | "quality" | "builds" | "ai";
 
@@ -278,6 +278,7 @@ export function DatasetDetailPage() {
         <label className="min-w-44 flex-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Stage<select aria-label="Stage 선택" className={`mt-1 w-full ${selectClassName}`} value={selectedStage} disabled={!sourceStageEntry} onChange={(event) => updateContext({ stage: event.target.value })}>{DATASET_STAGES.map((stageName) => <option key={stageName} value={stageName}>{stageName} · {sourceStageEntry?.[stageName].status ?? "unavailable"}</option>)}</select></label>
         <div title="선택된 source/stage가 아니라 이 run 전체(모든 source)의 결과입니다" className="flex min-h-9 items-center gap-2 px-2 text-xs text-muted-foreground"><span>Run 상태</span><strong className="text-foreground">{runStatus}</strong></div>
       </Card>
+      <StageLegend />
 
       {stagesState.status === "error" ? <Card variant="error" role="alert">{stagesState.error}</Card> : invalidSource ? <Card variant="error" role="alert">URL의 source `{requestedSource}`는 선택한 run에 존재하지 않습니다.</Card> : null}
       {runFailedButSelectedStageOk ? (

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -178,7 +178,7 @@ describe("HomePage 대시보드 KPI", () => {
     renderHome();
 
     expect(await within(kpiCard("QUALITY WARN (24H)")).findByText("4")).toBeInTheDocument();
-    expect(within(kpiCard("DATASETS")).getByText("확인 불가")).toBeInTheDocument();
+    expect(await within(kpiCard("DATASETS")).findByText("확인 불가")).toBeInTheDocument();
     expect(within(kpiCard("DATASETS")).queryByText("1")).not.toBeInTheDocument();
   });
 
@@ -206,16 +206,29 @@ describe("HomePage 대시보드 KPI", () => {
     expect(await screen.findByText("r1")).toBeInTheDocument();
   });
 
-  it("빌드 목록 실패는 Recent Builds만 에러로 만들고 KPI 요청을 유발하지 않는다", async () => {
+  it("빌드가 없어도 기존 사용자의 aggregate KPI는 정상 표시한다", async () => {
+    baseHandlers({
+      builds: () => HttpResponse.json({ builds: [] }),
+      datasets: () => HttpResponse.json({ datasets: [], total: 3 }),
+    });
+    renderHome();
+
+    expect(await screen.findByText("작업 현황을 한눈에 확인하세요")).toBeInTheDocument();
+    expect(await within(kpiCard("DATASETS")).findByText("3")).toBeInTheDocument();
+    expect(await within(kpiCard("SUCCEEDED (24H)")).findByText("9")).toBeInTheDocument();
+    expect(await within(kpiCard("QUALITY WARN (24H)")).findByText("4")).toBeInTheDocument();
+  });
+
+  it("빌드 목록 실패도 Recent Builds만 에러로 만들고 healthy KPI는 유지한다", async () => {
     baseHandlers({ builds: () => HttpResponse.json({ error: "down" }, { status: 500 }) });
     renderHome();
 
     expect(
       await screen.findByText("빌드 목록을 불러올 수 없습니다", undefined, { timeout: 4000 }),
     ).toBeInTheDocument();
-    // 근거 없는 KPI는 전부 "확인 불가" — 임의 숫자 합성 없음.
-    expect(within(kpiCard("DATASETS")).getByText("확인 불가")).toBeInTheDocument();
-    expect(within(kpiCard("QUALITY WARN (24H)")).getByText("확인 불가")).toBeInTheDocument();
+    expect(await within(kpiCard("DATASETS")).findByText("12")).toBeInTheDocument();
+    expect(await within(kpiCard("SUCCEEDED (24H)")).findByText("9")).toBeInTheDocument();
+    expect(await within(kpiCard("QUALITY WARN (24H)")).findByText("4")).toBeInTheDocument();
   });
 });
 
@@ -259,7 +272,7 @@ describe("HomePage 신규 사용자 판정", () => {
     renderHome();
 
     expect(await screen.findByText(DASHBOARD_HEADING)).toBeInTheDocument();
-    expect(within(kpiCard("DATASETS")).getByText("확인 불가")).toBeInTheDocument();
+    expect(await within(kpiCard("DATASETS")).findByText("확인 불가")).toBeInTheDocument();
     expect(screen.queryByText(NEW_USER_HEADING)).not.toBeInTheDocument();
   });
 

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -9,12 +9,13 @@
  * - `total`을 안 보내는 (구버전) Builder에서는 DATASETS만 "확인 불가"
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, within } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { http, HttpResponse, delay } from "msw";
 import { mswServer } from "../../vitest.setup";
 import { API_BASE } from "@/shared/config/env";
 import { HomePage } from "./HomePage";
+import { useAuthStore } from "@/features/auth/store";
 
 const BUILDS = [
   { run_id: "r1", status: "ok", started_at: "2026-09-01T08:00:00+00:00", finished_at: "2026-09-01T08:05:00+00:00" },
@@ -102,8 +103,13 @@ function renderHome() {
   return render(
     <MemoryRouter>
       <HomePage />
+      <CurrentPath />
     </MemoryRouter>,
   );
+}
+
+function CurrentPath() {
+  return <output data-testid="current-path">{useLocation().pathname}</output>;
 }
 
 /** KPI 라벨이 들어 있는 카드(라벨 span의 부모)를 돌려준다. */
@@ -113,6 +119,23 @@ function kpiCard(label: string) {
 
 beforeEach(() => {
   vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+});
+
+describe("Existing Dashboard 사용 가이드", () => {
+  it("navigating to Discover 없이 현재 계정의 guide tour를 수동으로 연다", async () => {
+    useAuthStore.setState({ userId: "keycloak-subject-existing" });
+    baseHandlers();
+    renderHome();
+
+    const guide = await screen.findByRole("button", { name: "사용 가이드" });
+    expect(screen.queryByRole("link", { name: "사용 가이드" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    fireEvent.click(guide);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/");
+    useAuthStore.getState().clear();
+  });
 });
 
 afterEach(() => {

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -65,6 +65,7 @@ function baseHandlers(overrides: {
   monitoringBuilds?: () => Response | Promise<Response>;
   monitoringSummary?: () => Response | Promise<Response>;
   quality?: () => Response | Promise<Response>;
+  qualityDetail?: (runId: string) => Response | Promise<Response>;
 } = {}) {
   mswServer.use(
     http.get(`${API_BASE}/builds`, overrides.builds ?? (() => HttpResponse.json({ builds: BUILDS }))),
@@ -83,6 +84,16 @@ function baseHandlers(overrides: {
     http.get(
       `${API_BASE}/quality/summary`,
       overrides.quality ?? (() => HttpResponse.json(QUALITY_SUMMARY)),
+    ),
+    http.get(`${API_BASE}/builds/:runId/quality`, ({ params }) =>
+      overrides.qualityDetail?.(String(params.runId)) ??
+      HttpResponse.json({
+        run_id: String(params.runId),
+        availability: "available",
+        evaluated_checks: 0,
+        quality_results: {},
+        schema_drift: {},
+      }),
     ),
   );
 }
@@ -232,13 +243,149 @@ describe("HomePage 대시보드 KPI", () => {
   });
 });
 
+describe("HomePage 최근 품질 상태", () => {
+  const warning = {
+    source_key: "source-1",
+    category: "completeness",
+    rule: "missing_values",
+    column: "value",
+    status: "warn" as const,
+    actual: 3,
+    threshold: 0,
+    affected_rows: 3,
+    evaluated_rows: 10,
+    detail: "Missing values 3건",
+  };
+
+  it("최근 Run의 실제 WARN/FAIL만 표시하고 24H KPI와 범위를 구분한다", async () => {
+    baseHandlers({
+      qualityDetail: (runId) => HttpResponse.json({
+        run_id: runId,
+        availability: "available",
+        evaluated_checks: 1,
+        quality_results: { "source-1": [warning] },
+        schema_drift: {},
+      }),
+    });
+    renderHome();
+
+    expect(await screen.findByText("최근 품질 상태")).toBeInTheDocument();
+    expect(await screen.findByText("Missing values 3건")).toBeInTheDocument();
+    expect(screen.getByText("WARN")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Quality Center 보기" })).toHaveAttribute("href", "/quality");
+  });
+
+  it("확인 가능한 결과에 WARN/FAIL이 없으면 빈 상태를 정직하게 표시한다", async () => {
+    baseHandlers();
+    renderHome();
+
+    expect(
+      await screen.findByText("최근 확인한 Build에서 품질 경고가 없습니다"),
+    ).toBeInTheDocument();
+  });
+
+  it("detail unavailable을 0건이나 PASS로 위장하지 않는다", async () => {
+    baseHandlers({
+      qualityDetail: (runId) => HttpResponse.json({
+        run_id: runId,
+        availability: "unavailable",
+        evaluated_checks: 0,
+        quality_results: {},
+        schema_drift: {},
+      }),
+    });
+    renderHome();
+
+    expect(await screen.findByText("일부 품질 정보를 확인할 수 없습니다")).toBeInTheDocument();
+    expect(screen.queryByText("최근 확인한 Build에서 품질 경고가 없습니다")).not.toBeInTheDocument();
+  });
+
+  it("succeeded가 아닌 Run(failed/cancelled)에는 getBuildQuality를 호출하지 않는다", async () => {
+    const detailRuns: string[] = [];
+    baseHandlers({
+      builds: () => HttpResponse.json({
+        builds: [
+          { run_id: "ok-1", status: "ok", started_at: "2026-09-01T05:00:00+00:00", finished_at: "2026-09-01T05:05:00+00:00" },
+          { run_id: "failed-1", status: "failed", started_at: "2026-09-01T04:00:00+00:00", finished_at: "2026-09-01T04:05:00+00:00" },
+          { run_id: "cancelled-1", status: "cancelled", started_at: "2026-09-01T03:00:00+00:00", finished_at: "2026-09-01T03:05:00+00:00" },
+        ],
+      }),
+      qualityDetail: (runId) => {
+        detailRuns.push(runId);
+        return HttpResponse.json({
+          run_id: runId,
+          availability: "available",
+          evaluated_checks: 1,
+          quality_results: { "source-1": [warning] },
+          schema_drift: {},
+        });
+      },
+    });
+    renderHome();
+
+    expect(await screen.findByText("Missing values 3건")).toBeInTheDocument();
+    expect(detailRuns).toEqual(["ok-1"]);
+  });
+
+  it("WARN/FAIL 항목은 해당 Run의 context(/builds/:runId)로 이동하는 링크다", async () => {
+    baseHandlers({
+      builds: () => HttpResponse.json({
+        builds: [
+          { run_id: "run-warn", status: "ok", started_at: "2026-09-01T05:00:00+00:00", finished_at: "2026-09-01T05:05:00+00:00" },
+        ],
+      }),
+      qualityDetail: (runId) => HttpResponse.json({
+        run_id: runId,
+        availability: "available",
+        evaluated_checks: 1,
+        quality_results: { "source-1": [warning] },
+        schema_drift: {},
+      }),
+    });
+    renderHome();
+
+    const alert = await screen.findByText("Missing values 3건");
+    const link = alert.closest("a");
+    expect(link).toHaveAttribute("href", "/builds/run-warn");
+  });
+
+  it("최근 Build가 6개여도 detail은 최대 5개만 병렬 조회한다", async () => {
+    const detailRuns: string[] = [];
+    baseHandlers({
+      builds: () => HttpResponse.json({
+        builds: Array.from({ length: 6 }, (_, index) => ({
+          run_id: `r${index}`,
+          status: "ok",
+          started_at: `2026-09-01T0${index}:00:00+00:00`,
+          finished_at: `2026-09-01T0${index}:05:00+00:00`,
+        })),
+      }),
+      qualityDetail: (runId) => {
+        detailRuns.push(runId);
+        return HttpResponse.json({
+          run_id: runId,
+          availability: "available",
+          evaluated_checks: 0,
+          quality_results: {},
+          schema_drift: {},
+        });
+      },
+    });
+    renderHome();
+
+    await screen.findByText("최근 확인한 Build에서 품질 경고가 없습니다");
+    expect(detailRuns).toHaveLength(5);
+    expect(detailRuns).not.toContain("r0");
+  });
+});
+
 /**
  * 신규 사용자 판정: 빈 build 목록만으로는 부족하다. real 모드에서는 Builder
  * GET /datasets의 authoritative `total`이 0으로 확인돼야 신규 사용자로 확정한다.
  * total을 확인할 수 없으면(구버전 Builder / 404·5xx) 기존 대시보드를 보여준다.
  */
 describe("HomePage 신규 사용자 판정", () => {
-  const NEW_USER_HEADING = "공공데이터를 쉽게 수집하고 변환하세요";
+  const NEW_USER_HEADING = "공공데이터를 찾아 신뢰할 수 있는 데이터셋으로 만드세요";
   const DASHBOARD_HEADING = "작업 현황을 한눈에 확인하세요";
 
   it("dataset total > 0이고 빌드가 없으면 신규 사용자가 아니다(기존 대시보드)", async () => {
@@ -288,5 +435,29 @@ describe("HomePage 신규 사용자 판정", () => {
       await within(kpiCard("DATASETS")).findByText("확인 불가", undefined, { timeout: 4000 }),
     ).toBeInTheDocument();
     expect(screen.queryByText(NEW_USER_HEADING)).not.toBeInTheDocument();
+  });
+});
+
+describe("HomePage 전체 작업 흐름 (설명형, 클릭 카드 아님)", () => {
+  it("STEP 1~4를 설명형 워크플로로 보여준다", async () => {
+    baseHandlers({
+      builds: () => HttpResponse.json({ builds: [] }),
+      datasets: () => HttpResponse.json({ datasets: [], total: 0 }),
+    });
+    renderHome();
+
+    expect(await screen.findByText("전체 작업 흐름")).toBeInTheDocument();
+    expect(screen.getByText("데이터 찾기")).toBeInTheDocument();
+    expect(screen.getByText("Discover 또는 직접 데이터 추가")).toBeInTheDocument();
+    expect(screen.getByText("가져오기 준비")).toBeInTheDocument();
+    expect(screen.getByText("Public API는 인증·활용신청·요청값을 확인")).toBeInTheDocument();
+    expect(screen.getByText("Preview · Build")).toBeInTheDocument();
+    expect(screen.getByText("데이터를 미리 확인·검증한 뒤 Build")).toBeInTheDocument();
+    expect(screen.getByText("품질 확인 · 활용")).toBeInTheDocument();
+    expect(screen.getByText("Quality · Kubi · Export · Publish")).toBeInTheDocument();
+
+    // 클릭 가능한 카드가 아니다 — STEP 카드 자체가 링크/버튼이 아니어야 한다.
+    expect(screen.queryByRole("link", { name: /데이터 찾기/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /데이터 찾기/ })).not.toBeInTheDocument();
   });
 });

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -1,0 +1,279 @@
+/**
+ * Home 대시보드 KPI wiring 테스트.
+ *
+ * 검증 대상:
+ * - DATASETS → GET /datasets의 authoritative `total` (Builder 1.22.0)
+ * - QUALITY WARN (24H) → GET /quality/summary의 `warn_runs`
+ * - 각 aggregate 경계가 독립적이다 — 하나가 실패해도 나머지 KPI와 Recent Builds는 유지된다
+ * - Recent Builds는 KPI 요청 지연/실패와 무관하게 자기 상태로 렌더된다
+ * - `total`을 안 보내는 (구버전) Builder에서는 DATASETS만 "확인 불가"
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { http, HttpResponse, delay } from "msw";
+import { mswServer } from "../../vitest.setup";
+import { API_BASE } from "@/shared/config/env";
+import { HomePage } from "./HomePage";
+
+const BUILDS = [
+  { run_id: "r1", status: "ok", started_at: "2026-09-01T08:00:00+00:00", finished_at: "2026-09-01T08:05:00+00:00" },
+];
+
+const MONITORING_BUILDS = {
+  window: "24h",
+  bucket: "hour",
+  availability: "available",
+  excluded_count: 0,
+  buckets: [
+    {
+      bucket_start: "2026-09-01T08:00:00+00:00",
+      bucket_end: "2026-09-01T09:00:00+00:00",
+      total: 9,
+      success: 9,
+      failed: 0,
+      cancelled: 0,
+    },
+  ],
+  recent_runs: [],
+};
+
+const MONITORING_SUMMARY = {
+  generated_at: "2026-09-01T09:00:00+00:00",
+  status: "healthy",
+  api: { availability: "available", sample_count: 10, p95_latency_ms: 5 },
+  queue: { availability: "available", waiting: 0, running: 3, total: 3 },
+  workers: { availability: "available", active: 0, capacity: 4, utilization: 0 },
+  artifact_store: { availability: "available", last_write_at: null },
+};
+
+const QUALITY_SUMMARY = {
+  window: "24h",
+  generated_at: "2026-09-01T09:00:00+00:00",
+  availability: "available",
+  total_runs: 7,
+  evaluated_runs: 6,
+  pass_runs: 2,
+  warn_runs: 4,
+  fail_runs: 1,
+};
+
+/** 기본: 모든 boundary가 정상. 개별 테스트가 필요한 것만 override한다. */
+function baseHandlers(overrides: {
+  builds?: () => Response | Promise<Response>;
+  datasets?: () => Response | Promise<Response>;
+  monitoringBuilds?: () => Response | Promise<Response>;
+  monitoringSummary?: () => Response | Promise<Response>;
+  quality?: () => Response | Promise<Response>;
+} = {}) {
+  mswServer.use(
+    http.get(`${API_BASE}/builds`, overrides.builds ?? (() => HttpResponse.json({ builds: BUILDS }))),
+    http.get(
+      `${API_BASE}/datasets`,
+      overrides.datasets ?? (() => HttpResponse.json({ datasets: [], total: 12 })),
+    ),
+    http.get(
+      `${API_BASE}/monitoring/builds`,
+      overrides.monitoringBuilds ?? (() => HttpResponse.json(MONITORING_BUILDS)),
+    ),
+    http.get(
+      `${API_BASE}/monitoring/summary`,
+      overrides.monitoringSummary ?? (() => HttpResponse.json(MONITORING_SUMMARY)),
+    ),
+    http.get(
+      `${API_BASE}/quality/summary`,
+      overrides.quality ?? (() => HttpResponse.json(QUALITY_SUMMARY)),
+    ),
+  );
+}
+
+function renderHome() {
+  return render(
+    <MemoryRouter>
+      <HomePage />
+    </MemoryRouter>,
+  );
+}
+
+/** KPI 라벨이 들어 있는 카드(라벨 span의 부모)를 돌려준다. */
+function kpiCard(label: string) {
+  return screen.getByText(label).parentElement as HTMLElement;
+}
+
+beforeEach(() => {
+  vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("HomePage 대시보드 KPI", () => {
+  it("DATASETS는 GET /datasets의 authoritative total을, QUALITY WARN은 warn_runs를 보여준다", async () => {
+    baseHandlers();
+    renderHome();
+
+    expect(await within(kpiCard("DATASETS")).findByText("12")).toBeInTheDocument();
+    expect(await within(kpiCard("QUALITY WARN (24H)")).findByText("4")).toBeInTheDocument();
+    expect(await within(kpiCard("SUCCEEDED (24H)")).findByText("9")).toBeInTheDocument();
+    expect(await within(kpiCard("RUNNING")).findByText("3")).toBeInTheDocument();
+  });
+
+  it("dataset aggregate 실패는 DATASETS만 '확인 불가'로 만들고 나머지 KPI는 유지한다", async () => {
+    baseHandlers({ datasets: () => HttpResponse.json({ error: "boom" }, { status: 500 }) });
+    renderHome();
+
+    expect(await within(kpiCard("QUALITY WARN (24H)")).findByText("4")).toBeInTheDocument();
+    expect(await within(kpiCard("SUCCEEDED (24H)")).findByText("9")).toBeInTheDocument();
+    // 5xx는 apiFetch가 지수 백오프로 재시도하므로 catch까지 시간이 걸린다.
+    expect(
+      await within(kpiCard("DATASETS")).findByText("확인 불가", undefined, { timeout: 4000 }),
+    ).toBeInTheDocument();
+  });
+
+  it("quality aggregate 404(구버전 Builder)는 QUALITY WARN만 '확인 불가'로 만든다", async () => {
+    baseHandlers({ quality: () => HttpResponse.json({ error: "not found" }, { status: 404 }) });
+    renderHome();
+
+    expect(await within(kpiCard("DATASETS")).findByText("12")).toBeInTheDocument();
+    expect(await within(kpiCard("SUCCEEDED (24H)")).findByText("9")).toBeInTheDocument();
+    expect(within(kpiCard("QUALITY WARN (24H)")).getByText("확인 불가")).toBeInTheDocument();
+  });
+
+  it("monitoring 실패는 monitoring KPI만 degraded로 만들고 DATASETS/QUALITY WARN은 유지한다", async () => {
+    baseHandlers({
+      monitoringBuilds: () => HttpResponse.json({ error: "x" }, { status: 500 }),
+      monitoringSummary: () => HttpResponse.json({ error: "x" }, { status: 500 }),
+    });
+    renderHome();
+
+    expect(await within(kpiCard("DATASETS")).findByText("12")).toBeInTheDocument();
+    expect(await within(kpiCard("QUALITY WARN (24H)")).findByText("4")).toBeInTheDocument();
+    expect(
+      await within(kpiCard("SUCCEEDED (24H)")).findByText("확인 불가", undefined, { timeout: 4000 }),
+    ).toBeInTheDocument();
+    expect(within(kpiCard("RUNNING")).getByText("확인 불가")).toBeInTheDocument();
+  });
+
+  it("total을 안 보내는 Builder에서는 DATASETS만 '확인 불가'이고 items.length로 대체하지 않는다", async () => {
+    baseHandlers({
+      datasets: () =>
+        HttpResponse.json({
+          datasets: [
+            {
+              dataset_id: "d.a",
+              title: "A",
+              sources: [],
+              latest_run_id: "r1",
+              status: "ok",
+              updated_at: null,
+              row_counts: {},
+              total_row_count: 0,
+              stages: {},
+              quality: null,
+            },
+          ],
+        }),
+    });
+    renderHome();
+
+    expect(await within(kpiCard("QUALITY WARN (24H)")).findByText("4")).toBeInTheDocument();
+    expect(within(kpiCard("DATASETS")).getByText("확인 불가")).toBeInTheDocument();
+    expect(within(kpiCard("DATASETS")).queryByText("1")).not.toBeInTheDocument();
+  });
+
+  it("Recent Builds는 KPI 요청이 지연돼도 자기 데이터를 즉시 렌더한다", async () => {
+    baseHandlers({
+      datasets: async () => {
+        await delay("infinite");
+        return HttpResponse.json({ datasets: [], total: 12 });
+      },
+      quality: async () => {
+        await delay("infinite");
+        return HttpResponse.json(QUALITY_SUMMARY);
+      },
+      monitoringBuilds: async () => {
+        await delay("infinite");
+        return HttpResponse.json(MONITORING_BUILDS);
+      },
+      monitoringSummary: async () => {
+        await delay("infinite");
+        return HttpResponse.json(MONITORING_SUMMARY);
+      },
+    });
+    renderHome();
+
+    expect(await screen.findByText("r1")).toBeInTheDocument();
+  });
+
+  it("빌드 목록 실패는 Recent Builds만 에러로 만들고 KPI 요청을 유발하지 않는다", async () => {
+    baseHandlers({ builds: () => HttpResponse.json({ error: "down" }, { status: 500 }) });
+    renderHome();
+
+    expect(
+      await screen.findByText("빌드 목록을 불러올 수 없습니다", undefined, { timeout: 4000 }),
+    ).toBeInTheDocument();
+    // 근거 없는 KPI는 전부 "확인 불가" — 임의 숫자 합성 없음.
+    expect(within(kpiCard("DATASETS")).getByText("확인 불가")).toBeInTheDocument();
+    expect(within(kpiCard("QUALITY WARN (24H)")).getByText("확인 불가")).toBeInTheDocument();
+  });
+});
+
+/**
+ * 신규 사용자 판정: 빈 build 목록만으로는 부족하다. real 모드에서는 Builder
+ * GET /datasets의 authoritative `total`이 0으로 확인돼야 신규 사용자로 확정한다.
+ * total을 확인할 수 없으면(구버전 Builder / 404·5xx) 기존 대시보드를 보여준다.
+ */
+describe("HomePage 신규 사용자 판정", () => {
+  const NEW_USER_HEADING = "공공데이터를 쉽게 수집하고 변환하세요";
+  const DASHBOARD_HEADING = "작업 현황을 한눈에 확인하세요";
+
+  it("dataset total > 0이고 빌드가 없으면 신규 사용자가 아니다(기존 대시보드)", async () => {
+    baseHandlers({
+      builds: () => HttpResponse.json({ builds: [] }),
+      datasets: () => HttpResponse.json({ datasets: [], total: 3 }),
+    });
+    renderHome();
+
+    expect(await screen.findByText(DASHBOARD_HEADING)).toBeInTheDocument();
+    expect(await within(kpiCard("DATASETS")).findByText("3")).toBeInTheDocument();
+    expect(screen.queryByText(NEW_USER_HEADING)).not.toBeInTheDocument();
+  });
+
+  it("dataset total = 0이고 빌드가 없으면 신규 사용자 화면을 보여준다", async () => {
+    baseHandlers({
+      builds: () => HttpResponse.json({ builds: [] }),
+      datasets: () => HttpResponse.json({ datasets: [], total: 0 }),
+    });
+    renderHome();
+
+    expect(await screen.findByText(NEW_USER_HEADING)).toBeInTheDocument();
+    expect(screen.queryByText(DASHBOARD_HEADING)).not.toBeInTheDocument();
+  });
+
+  it("dataset total이 없는 구버전 Builder에서는 빈 빌드만으로 신규 사용자로 오판하지 않는다", async () => {
+    baseHandlers({
+      builds: () => HttpResponse.json({ builds: [] }),
+      datasets: () => HttpResponse.json({ datasets: [] }),
+    });
+    renderHome();
+
+    expect(await screen.findByText(DASHBOARD_HEADING)).toBeInTheDocument();
+    expect(within(kpiCard("DATASETS")).getByText("확인 불가")).toBeInTheDocument();
+    expect(screen.queryByText(NEW_USER_HEADING)).not.toBeInTheDocument();
+  });
+
+  it("dataset aggregate가 5xx로 실패해도 빈 빌드만으로 신규 사용자로 오판하지 않는다", async () => {
+    baseHandlers({
+      builds: () => HttpResponse.json({ builds: [] }),
+      datasets: () => HttpResponse.json({ error: "boom" }, { status: 500 }),
+    });
+    renderHome();
+
+    expect(await screen.findByText(DASHBOARD_HEADING)).toBeInTheDocument();
+    expect(
+      await within(kpiCard("DATASETS")).findByText("확인 불가", undefined, { timeout: 4000 }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(NEW_USER_HEADING)).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -164,6 +164,12 @@ export function HomePage() {
   useEffect(() => {
     let active = true;
 
+    // real Builder의 aggregate는 Recent Builds와 독립적인 API 경계다. /builds의
+    // 성공 여부나 빈 목록 여부와 무관하게 즉시 시작한다.
+    if (realBuilder) {
+      loadRealKpis(() => active, setStats, setKpi);
+    }
+
     // Recent Builds는 KPI 요청과 완전히 독립이다 — 받는 즉시 커밋하고, 실패하면
     // KPI와 무관하게 그 섹션만 에러 상태로 둔다.
     listBuilds()
@@ -172,21 +178,16 @@ export function HomePage() {
         setBuilds(list);
         setBuildsState("success");
 
-        // 빌드가 없다 — monitoring/quality aggregate는 여기서 부르지 않는다. 다만
-        // 신규 사용자 판정에는 authoritative dataset total이 필요하므로 real 모드에서는
-        // 그것만 독립적으로 조회한다(total 없음/실패 시 신규로 확정하지 않는다).
+        // real 모드 aggregate는 effect 시작 시 이미 독립적으로 요청했다. 빈 build는
+        // 신규 사용자 판정의 한 근거일 뿐, monitoring/quality를 unavailable로 만들지 않는다.
         if (list.length === 0) {
-          if (realBuilder) {
-            setKpi({ datasets: "loading", monitoring: "unavailable", quality: "unavailable" });
-            loadDatasetTotal(() => active, setStats, setKpi);
-          } else {
+          if (!realBuilder) {
             setKpi({ datasets: "unavailable", monitoring: "unavailable", quality: "unavailable" });
           }
           return;
         }
 
         if (realBuilder) {
-          loadRealKpis(() => active, setStats, setKpi);
           return;
         }
 
@@ -202,8 +203,11 @@ export function HomePage() {
       .catch(() => {
         if (!active) return;
         setBuildsState("error");
-        // 빌드 목록을 못 받으면 KPI 근거도 없다 — 임의값 대신 전부 "확인 불가".
-        setKpi({ datasets: "unavailable", monitoring: "unavailable", quality: "unavailable" });
+        // real aggregate는 /builds 오류와 독립적으로 계속 진행한다. mock/demo의
+        // 기존 동작만 유지해, 근거 없는 KPI를 표시하지 않는다.
+        if (!realBuilder) {
+          setKpi({ datasets: "unavailable", monitoring: "unavailable", quality: "unavailable" });
+        }
       });
 
     return () => {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -294,6 +294,7 @@ export function HomePage() {
         <EmptyWorkspaceHome userId={userId} />
       ) : (
         <ExistingUserHome
+          userId={userId}
           stats={stats}
           recentBuilds={recentBuilds}
           buildsState={buildsState}
@@ -485,12 +486,14 @@ function KubiHero() {
 }
 
 function ExistingUserHome({
+  userId,
   stats,
   recentBuilds,
   buildsState,
   kpi,
   recentQuality,
 }: {
+  userId: string | null;
   stats: DashboardStats;
   recentBuilds: BuildListItem[];
   buildsState: "loading" | "error" | "success";
@@ -503,19 +506,20 @@ function ExistingUserHome({
         eyebrow="대시보드"
         title="작업 현황을 한눈에 확인하세요"
         description="최근 데이터셋, 빌드 상태, 품질 경고를 모니터링합니다"
-        actions={<LinkButton variant="secondary" to="/discover">사용 가이드</LinkButton>}
+        actions={userId ? <Button variant="secondary" onClick={() => resetFirstRunTour(userId)}>사용 가이드</Button> : undefined}
       />
 
-      <KpiCards stats={stats} kpi={kpi} />
+      <section data-tour="dashboard-overview"><KpiCards stats={stats} kpi={kpi} /></section>
 
       <section className="grid gap-6 xl:grid-cols-2">
-        <RecentBuildsSection
+        <div data-tour="dashboard-builds"><RecentBuildsSection
           recentBuilds={recentBuilds}
           loading={buildsState === "loading"}
           apiState={buildsState}
-        />
-        <QualitySection state={recentQuality} />
+        /></div>
+        <div data-tour="dashboard-quality"><QualitySection state={recentQuality} /></div>
       </section>
+      {userId ? <FirstRunTour userId={userId} autoStart={false} variant="dashboard" /> : null}
     </>
   );
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -14,17 +14,20 @@
  */
 import {
   useEffect,
+  useMemo,
   useState,
   type Dispatch,
   type FormEvent,
   type SetStateAction,
 } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { useAssistConfig } from "@/features/assistant/config";
 import { listBuilds } from "@/features/runs/api";
-import { SUGGESTED_QUESTIONS } from "@/features/kubi/suggestedQuestions";
+import { getSuggestedQuestions } from "@/features/kubi/suggestedQuestions";
 import { useKubiStore } from "@/features/kubi/useKubiSession";
-import { useUIStore } from "@/shared/hooks/useUIStore";
+import { FirstRunTour, resetFirstRunTour } from "@/features/onboarding/FirstRunTour";
 import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
+import type { BuildQualityResponse, QualityCheckResult } from "@/shared/lib/builderApi.schema";
 import type { BuildListItem } from "@/shared/lib/types";
 import {
   Button,
@@ -33,6 +36,7 @@ import {
   LinkButton,
   PageHeader,
   Skeleton,
+  HelpTooltip,
 } from "@/shared/ui";
 
 interface DashboardStats {
@@ -160,6 +164,10 @@ export function HomePage() {
     monitoring: "loading",
     quality: "loading",
   });
+  const [recentQuality, setRecentQuality] = useState<RecentQualityState>({
+    phase: "loading",
+    alerts: [],
+  });
 
   useEffect(() => {
     let active = true;
@@ -215,13 +223,58 @@ export function HomePage() {
     };
   }, [realBuilder]);
 
-  const recentBuilds = [...builds]
-    .sort((a, b) => {
-      const aTime = a.startedAt ? new Date(a.startedAt).getTime() : 0;
-      const bTime = b.startedAt ? new Date(b.startedAt).getTime() : 0;
-      return bTime - aTime;
-    })
-    .slice(0, 5);
+  const recentBuilds = useMemo(
+    () =>
+      [...builds]
+        .sort((a, b) => {
+          const aTime = a.startedAt ? new Date(a.startedAt).getTime() : 0;
+          const bTime = b.startedAt ? new Date(b.startedAt).getTime() : 0;
+          return bTime - aTime;
+        })
+        .slice(0, 5),
+    [builds],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    if (buildsState === "loading") {
+      setRecentQuality({ phase: "loading", alerts: [] });
+      return () => controller.abort();
+    }
+    if (!realBuilder || buildsState === "error" || recentBuilds.length === 0) {
+      setRecentQuality({ phase: "unavailable", alerts: [] });
+      return () => controller.abort();
+    }
+
+    // Quality 결과는 manifest에서 조회한다(GET /builds/{run_id}/quality). manifest가 있는
+    // 것은 성공적으로 완료된 Run뿐이므로, queued/running/취소된 Run에 getBuildQuality를
+    // 호출하면 항상 404다 — canonical 대상인 succeeded Run만 조회한다.
+    const qualityRuns = recentBuilds.filter((run) => run.status === "succeeded");
+    if (qualityRuns.length === 0) {
+      setRecentQuality({ phase: "ready", alerts: [], incomplete: false });
+      return () => controller.abort();
+    }
+
+    setRecentQuality({ phase: "loading", alerts: [] });
+    void Promise.allSettled(
+      qualityRuns.map((run) => builderApi.getBuildQuality(run.id, controller.signal)),
+    ).then((results) => {
+      if (controller.signal.aborted) return;
+      const alerts: QualityAlert[] = [];
+      let incomplete = false;
+      results.forEach((result, index) => {
+        if (result.status === "rejected") {
+          incomplete = true;
+          return;
+        }
+        if (result.value.availability !== "available") incomplete = true;
+        alerts.push(...qualityAlertsForRun(qualityRuns[index], result.value));
+      });
+      setRecentQuality({ phase: "ready", alerts: alerts.slice(0, 5), incomplete });
+    });
+
+    return () => controller.abort();
+  }, [buildsState, realBuilder, recentBuilds]);
 
   // real 모드: 빌드 0개 + dataset total 조회 성공(kpi.datasets="ready") + total===0
   // 이 모두 충족될 때만 신규 사용자로 확정한다. total이 unavailable이면 빈 build만으로
@@ -243,6 +296,7 @@ export function HomePage() {
           recentBuilds={recentBuilds}
           buildsState={buildsState}
           kpi={kpi}
+          recentQuality={recentQuality}
         />
       )}
     </main>
@@ -254,17 +308,18 @@ function NewUserHome() {
     <>
       <PageHeader
         eyebrow="시작하기"
-        title="공공데이터를 쉽게 수집하고 변환하세요"
-        description="Kubi가 도와드립니다. 자연어로 물어보거나 원하는 방식으로 바로 시작하세요."
+        title="공공데이터를 찾아 신뢰할 수 있는 데이터셋으로 만드세요"
+        description="데이터를 찾거나 직접 가져온 뒤 Preview와 Quality를 확인하고 Build할 수 있습니다."
+        actions={<Button variant="ghost" size="sm" onClick={resetFirstRunTour}>둘러보기 다시 보기</Button>}
       />
 
-      <KubiHero />
+      <WorkflowStrip />
 
-      <section className="grid gap-6 lg:grid-cols-2">
+      <section data-tour="start-actions" className="grid gap-6 lg:grid-cols-2">
         <Card variant="elevated" className="flex flex-col items-center justify-center p-10 text-center">
           <h2 className="text-xl font-semibold tracking-tight">공공데이터 탐색</h2>
           <p className="mt-3 text-muted-foreground">
-            어떤 공공데이터를 다룰 수 있는지 카탈로그에서 둘러보세요
+            Builder가 제공하는 공공데이터 카탈로그에서 Provider와 Dataset을 찾아 시작합니다.
           </p>
           <LinkButton className="mt-6" variant="secondary" to="/discover">
             탐색하기
@@ -272,40 +327,112 @@ function NewUserHome() {
         </Card>
 
         <Card variant="elevated" className="flex flex-col items-center justify-center p-10 text-center">
-          <h2 className="text-xl font-semibold tracking-tight">데이터 바로 가져오기</h2>
+          <h2 className="text-xl font-semibold tracking-tight">데이터 직접 가져오기</h2>
           <p className="mt-3 text-muted-foreground">
-            Public API, 파일, URL에서 데이터를 직접 가져와 빌드하세요
+            Public API·파일·URL을 직접 추가하고 Preview와 검증을 거쳐 Build합니다.
           </p>
           <LinkButton className="mt-6" variant="secondary" to="/add">
             데이터 추가하기
           </LinkButton>
         </Card>
       </section>
+      <div data-tour="kubi-helper"><KubiHero /></div>
+      <FirstRunTour />
     </>
   );
 }
 
+interface QualityAlert {
+  runId: string;
+  runTitle: string;
+  status: "warn" | "fail";
+  detail: string;
+}
+
+type RecentQualityState =
+  | { phase: "loading"; alerts: [] }
+  | { phase: "ready"; alerts: QualityAlert[]; incomplete: boolean }
+  | { phase: "unavailable"; alerts: [] };
+
+function qualityAlertsForRun(
+  run: BuildListItem,
+  response: BuildQualityResponse,
+): QualityAlert[] {
+  const runTitle = run.title ?? run.id;
+  return Object.values(response.quality_results)
+    .flat()
+    .filter((result): result is QualityCheckResult & { status: "warn" | "fail" } =>
+      result.status === "warn" || result.status === "fail",
+    )
+    .map((result) => ({
+      runId: run.id,
+      runTitle,
+      status: result.status,
+      detail: result.detail ?? [result.rule, result.column].filter(Boolean).join(" · "),
+    }));
+}
+
+const WORKFLOW_STEPS = [
+  ["1", "데이터 찾기", "Discover 또는 직접 데이터 추가"],
+  ["2", "가져오기 준비", "Public API는 인증·활용신청·요청값을 확인"],
+  ["3", "Preview · Build", "데이터를 미리 확인·검증한 뒤 Build"],
+  ["4", "품질 확인 · 활용", "Quality · Kubi · Export · Publish"],
+] as const;
+
 /**
- * Home의 Kubi 자연어 hero (#Phase2 UI polish).
+ * Home의 전체 작업 흐름 설명. 클릭 가능한 액션 카드가 아니라 workflow 개요이므로
+ * hover/button 느낌(그림자 강조, cursor-pointer)과 카드 자체 navigation을 두지
+ * 않는다 — 각 STEP에서 실제로 할 일은 아래 "공공데이터 탐색"/"데이터 직접
+ * 가져오기" 카드와 사이드바에서 진행한다.
+ */
+function WorkflowStrip() {
+  return (
+    <section data-tour="workflow" aria-labelledby="workflow-heading" className="space-y-3">
+      <div>
+        <h2 id="workflow-heading" className="text-sm font-semibold text-foreground">전체 작업 흐름</h2>
+        <p className="text-xs text-muted-foreground">아래는 진행 순서를 보여주는 설명입니다 — 각 단계는 사이드바 메뉴와 화면 안내를 따라 진행하세요.</p>
+      </div>
+      <ol className="grid items-stretch gap-2 sm:grid-cols-2 xl:grid-cols-[1fr_auto_1fr_auto_1fr_auto_1fr]">
+        {WORKFLOW_STEPS.map(([number, title, copy], index) => (
+          <li key={number} className="contents">
+            <div className="rounded-xl border border-border bg-card p-4">
+              <span className="text-xs font-semibold text-accent-subtle-foreground">STEP {number}</span>
+              <h3 className="mt-2 text-sm font-semibold">{title}</h3>
+              <p className="mt-1 text-xs leading-5 text-muted-foreground">{copy}</p>
+            </div>
+            {index < WORKFLOW_STEPS.length - 1 ? (
+              <span aria-hidden="true" className="hidden items-center justify-center text-muted-foreground xl:flex">→</span>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+/**
+ * Home의 Kubi 자연어 hero (#Phase2 UI polish, #S-kubi-suggest).
  *
- * 새 assistant system이 아니라 topbar `KubiSearchInput`과 동일한 seed 흐름
- * (`useKubiStore().seedQuestion` + `useUIStore().openKubiDrawer`)을 재사용한다. 여기서
- * evidence 조회/LLM 호출을 직접 하지 않는다 — drawer가 열리면 `useKubiSession`이 이어받는다.
+ * 본격적인 Kubi 작업 시작점이므로 drawer가 아니라 `/kubi` 전용 페이지로 이동한다.
+ * 새 assistant system을 만들지 않고 기존 seed 메커니즘(`useKubiStore().seedQuestion`)만
+ * 재사용한다 — `/kubi`가 mount되면 `useKubiSession`이 pendingSeed를 소비해 답변을
+ * 생성한다. 질문 내용은 URL query에 싣지 않는다(seed store로만 전달).
  *
- * `ask()`(useKubiSession.ts)는 seed를 받는 즉시 실행하고, API Key 미설정 시 `no_key` 에러
- * turn을 만든다. 여기서 원치 않는 에러 turn을 일부러 만들지 않기 위해, seed는
- * `isConfigured`일 때만 남기고 아니면 drawer만 열어 기존 API Key 설정 안내를 보여준다.
+ * `ask()`(useKubiSession.ts)는 seed를 받는 즉시 실행하고 API Key 미설정 시 `no_key`
+ * 에러 turn을 만든다. 원치 않는 에러 turn을 피하려고 seed는 `isConfigured`일 때만
+ * 남기고, 아니면 seed 없이 `/kubi`로 이동해 그 화면의 API Key 설정 안내를 보여준다.
  */
 function KubiHero() {
   const [query, setQuery] = useState("");
-  const openKubiDrawer = useUIStore((state) => state.openKubiDrawer);
+  const navigate = useNavigate();
   const seedQuestion = useKubiStore((state) => state.seedQuestion);
   const { isConfigured } = useAssistConfig();
+  const startQuestions = getSuggestedQuestions({ context: { page: "home" }, turns: [] });
 
   function ask(question: string) {
     const trimmed = question.trim();
     if (trimmed && isConfigured) seedQuestion(trimmed);
-    openKubiDrawer();
+    navigate("/kubi");
   }
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -315,10 +442,10 @@ function KubiHero() {
   }
 
   return (
-    <Card variant="elevated" className="p-8">
-      <h2 className="text-xl font-semibold tracking-tight">Kubi에게 필요한 데이터를 물어보세요</h2>
+    <Card className="p-6">
+      <h2 className="text-base font-semibold tracking-tight">어디서 시작할지 모르겠다면 Kubi에게 물어보세요</h2>
       <p className="mt-2 text-sm text-muted-foreground">
-        한국어로 질문하면 Kubi가 적합한 공공데이터를 찾고 BuildSpec까지 제안합니다.
+        원하는 데이터나 분석 목적을 입력하면 Kubi에서 시작 방법을 함께 찾아볼 수 있습니다.
       </p>
       <form className="mt-4 flex flex-col gap-2 sm:flex-row" onSubmit={handleSubmit}>
         <label className="sr-only" htmlFor="home-kubi-hero">
@@ -332,10 +459,10 @@ function KubiHero() {
           type="search"
           value={query}
         />
-        <Button type="submit">Kubi에게 물어보기</Button>
+        <Button type="submit">Kubi에서 시작하기 →</Button>
       </form>
       <div className="mt-4 flex flex-wrap gap-1.5">
-        {SUGGESTED_QUESTIONS.map((question) => (
+        {startQuestions.map((question) => (
           <button
             key={question}
             type="button"
@@ -348,7 +475,7 @@ function KubiHero() {
       </div>
       {!isConfigured ? (
         <p className="mt-3 text-xs text-muted-foreground">
-          아직 API Key가 설정되지 않았습니다. Kubi를 열면 설정 방법을 안내합니다.
+          아직 API Key가 설정되지 않았습니다. Kubi 화면에서 설정 방법을 안내합니다.
         </p>
       ) : null}
     </Card>
@@ -360,11 +487,13 @@ function ExistingUserHome({
   recentBuilds,
   buildsState,
   kpi,
+  recentQuality,
 }: {
   stats: DashboardStats;
   recentBuilds: BuildListItem[];
   buildsState: "loading" | "error" | "success";
   kpi: KpiPhases;
+  recentQuality: RecentQualityState;
 }) {
   return (
     <>
@@ -382,7 +511,7 @@ function ExistingUserHome({
           loading={buildsState === "loading"}
           apiState={buildsState}
         />
-        <QualitySection />
+        <QualitySection state={recentQuality} />
       </section>
     </>
   );
@@ -396,31 +525,35 @@ function ExistingUserHome({
 function KpiCards({ stats, kpi }: { stats: DashboardStats; kpi: KpiPhases }) {
   return (
     <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-      <KpiCard label="DATASETS" value={stats.datasetCount} loading={kpi.datasets === "loading"} />
+      <KpiCard label="DATASETS" help="현재 접근할 수 있는 전체 빌드 Dataset 수입니다." value={stats.datasetCount} loading={kpi.datasets === "loading"} />
       <KpiCard
         label="SUCCEEDED (24H)"
+        help="최근 24시간 동안 성공적으로 완료된 Build Run 수입니다."
         value={stats.buildSuccess}
         loading={kpi.monitoring === "loading"}
         variant="success"
       />
       <KpiCard
         label="QUALITY WARN (24H)"
+        help="최근 24시간 Quality 검사에서 WARN이 하나 이상 확인된 Run 수입니다."
         value={stats.qualityWarn}
         loading={kpi.quality === "loading"}
         variant="error"
       />
-      <KpiCard label="RUNNING" value={stats.running} loading={kpi.monitoring === "loading"} />
+      <KpiCard label="RUNNING" help="현재 실행 중인 Build 작업 수입니다." value={stats.running} loading={kpi.monitoring === "loading"} />
     </section>
   );
 }
 
 function KpiCard({
   label,
+  help,
   value,
   loading,
   variant = "default",
 }: {
   label: string;
+  help: string;
   value: number | null;
   loading: boolean;
   variant?: "default" | "success" | "error";
@@ -428,7 +561,7 @@ function KpiCard({
   if (loading) {
     return (
       <Card>
-        <span className="text-sm text-muted-foreground">{label}</span>
+        <span className="inline-flex items-center gap-1 text-sm text-muted-foreground">{label}<HelpTooltip content={help} label={`${label} 정의`} /></span>
         <Skeleton className="mt-2 h-8 w-16" />
       </Card>
     );
@@ -440,7 +573,7 @@ function KpiCard({
 
   return (
     <Card className="flex items-center justify-between">
-      <span className="text-sm text-muted-foreground">{label}</span>
+      <span className="inline-flex items-center gap-1 text-sm text-muted-foreground">{label}<HelpTooltip content={help} label={`${label} 정의`} /></span>
       <span className={`text-2xl font-semibold tracking-tight ${colorClass}`}>
         {value === null ? "확인 불가" : value}
       </span>
@@ -510,15 +643,55 @@ function RecentBuildsSection({
   );
 }
 
-function QualitySection() {
+function QualitySection({ state }: { state: RecentQualityState }) {
   return (
     <section>
-      <PageHeader eyebrow="품질" title="품질 경고" className="mb-4" />
+      <PageHeader eyebrow="품질" title="최근 품질 상태" className="mb-4" />
       <Card className="p-0">
-        <EmptyState
-          title="개별 품질 경고 목록은 아직 제공되지 않습니다"
-          description="최근 24시간 WARN run 수는 위의 QUALITY WARN (24H) KPI에서 확인할 수 있습니다. 어떤 run이 경고인지는 각 빌드의 품질 화면에서 확인하세요."
-        />
+        {state.phase === "loading" ? (
+          <div className="space-y-3 px-6 py-5">
+            {[1, 2, 3].map((item) => <Skeleton key={item} className="h-8 w-full" />)}
+          </div>
+        ) : state.phase === "unavailable" || (state.incomplete && state.alerts.length === 0) ? (
+          <EmptyState
+            title="일부 품질 정보를 확인할 수 없습니다"
+            description="Builder에서 최근 Run의 Quality 결과를 제공하지 못했습니다. 실패한 Build를 Quality FAIL로 간주하지 않습니다."
+          />
+        ) : state.alerts.length === 0 ? (
+          <EmptyState
+            title="최근 확인한 Build에서 품질 경고가 없습니다"
+            description="현재 확인 가능한 최근 Quality 결과 중 추가 확인이 필요한 WARN/FAIL이 없습니다."
+          />
+        ) : (
+          <div>
+            <div className="px-6 py-4">
+              <h3 className="font-semibold">품질 확인 필요</h3>
+              {state.incomplete ? (
+                <p className="mt-1 text-xs text-muted-foreground">일부 Run의 Quality 결과는 확인하지 못했습니다.</p>
+              ) : null}
+            </div>
+            <ul className="border-t border-border">
+              {state.alerts.map((alert, index) => (
+                <li key={`${alert.runId}:${alert.detail}:${index}`} className="border-b border-border last:border-0">
+                  {/* WARN/FAIL 항목에서 해당 Run의 Quality context(/builds/:runId, ?run= canonical
+                      form과 동일)로 바로 이동한다 — BuildsPage와 Recent Builds가 이미 쓰는 경로다. */}
+                  <Link to={`/builds/${encodeURIComponent(alert.runId)}`} className="block px-6 py-3 hover:bg-muted focus-visible:bg-muted focus-visible:outline-none">
+                    <div className="flex items-center justify-between gap-3 text-sm">
+                      <span className="truncate font-medium">{alert.runTitle}</span>
+                      <span className={alert.status === "fail" ? "font-semibold text-red-600 dark:text-red-400" : "font-semibold text-amber-700 dark:text-amber-400"}>
+                        {alert.status.toUpperCase()}
+                      </span>
+                    </div>
+                    <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{alert.detail}</p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <div className="border-t border-border px-6 py-4">
+          <LinkButton variant="secondary" size="sm" to="/quality">Quality Center 보기</LinkButton>
+        </div>
       </Card>
     </section>
   );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -26,6 +26,7 @@ import { listBuilds } from "@/features/runs/api";
 import { getSuggestedQuestions } from "@/features/kubi/suggestedQuestions";
 import { useKubiStore } from "@/features/kubi/useKubiSession";
 import { FirstRunTour, resetFirstRunTour } from "@/features/onboarding/FirstRunTour";
+import { useAuthStore } from "@/features/auth/store";
 import { builderApi, isRealBuilderEnabled } from "@/shared/lib/builderApi";
 import type { BuildQualityResponse, QualityCheckResult } from "@/shared/lib/builderApi.schema";
 import type { BuildListItem } from "@/shared/lib/types";
@@ -151,6 +152,7 @@ function loadRealKpis(
  */
 export function HomePage() {
   const realBuilder = isRealBuilderEnabled();
+  const userId = useAuthStore((state) => state.userId);
   const [builds, setBuilds] = useState<BuildListItem[]>([]);
   const [buildsState, setBuildsState] = useState<"loading" | "error" | "success">("loading");
   const [stats, setStats] = useState<DashboardStats>({
@@ -289,7 +291,7 @@ export function HomePage() {
   return (
     <main className="flex flex-1 flex-col gap-8 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
       {isNew ? (
-        <NewUserHome />
+        <EmptyWorkspaceHome userId={userId} />
       ) : (
         <ExistingUserHome
           stats={stats}
@@ -303,7 +305,7 @@ export function HomePage() {
   );
 }
 
-function NewUserHome() {
+function EmptyWorkspaceHome({ userId }: { userId: string | null }) {
   return (
     <>
       <PageHeader
@@ -337,7 +339,7 @@ function NewUserHome() {
         </Card>
       </section>
       <div data-tour="kubi-helper"><KubiHero /></div>
-      <FirstRunTour />
+      {userId ? <FirstRunTour userId={userId} /> : null}
     </>
   );
 }
@@ -501,6 +503,7 @@ function ExistingUserHome({
         eyebrow="대시보드"
         title="작업 현황을 한눈에 확인하세요"
         description="최근 데이터셋, 빌드 상태, 품질 경고를 모니터링합니다"
+        actions={<LinkButton variant="secondary" to="/discover">사용 가이드</LinkButton>}
       />
 
       <KpiCards stats={stats} kpi={kpi} />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,7 +12,13 @@
  * 실제 예시 데이터셋이 없는 상태에서 서비스가 미완성인 인상을 줬다. 같은 CTA는 이미
  * "공공데이터 탐색 → /discover" 카드가 담당한다.
  */
-import { useEffect, useState, type FormEvent } from "react";
+import {
+  useEffect,
+  useState,
+  type Dispatch,
+  type FormEvent,
+  type SetStateAction,
+} from "react";
 import { useAssistConfig } from "@/features/assistant/config";
 import { listBuilds } from "@/features/runs/api";
 import { SUGGESTED_QUESTIONS } from "@/features/kubi/suggestedQuestions";
@@ -32,98 +38,178 @@ import {
 interface DashboardStats {
   datasetCount: number | null;
   buildSuccess: number | null;
-  validationWarn: number | null;
+  qualityWarn: number | null;
   running: number | null;
 }
 
-interface LoadingState {
-  builds: boolean;
-  stats: boolean;
+/**
+ * 각 KPI aggregate는 독립적인 API 경계다 — 하나가 실패해도 나머지 KPI 값과
+ * Recent Builds는 영향받지 않는다. "loading"은 skeleton, "unavailable"은
+ * "확인 불가"(임의 숫자 합성 없음)로 렌더된다.
+ */
+type KpiPhase = "loading" | "ready" | "unavailable";
+
+interface KpiPhases {
+  /** DATASETS — GET /datasets의 authoritative `total` (Builder 1.22.0). */
+  datasets: KpiPhase;
+  /** SUCCEEDED (24H) + RUNNING — GET /monitoring/* 공유 경계. */
+  monitoring: KpiPhase;
+  /** QUALITY WARN (24H) — GET /quality/summary (Builder 1.22.0). */
+  quality: KpiPhase;
 }
 
-interface ApiState {
-  builds: "loading" | "error" | "success";
-  stats: "loading" | "error" | "success";
+/**
+ * DATASETS KPI + 신규 사용자 판정을 위한 authoritative dataset total만 독립적으로
+ * 조회한다 — monitoring/quality 경계는 건드리지 않는다.
+ *
+ * 1.21.0 이하 Builder는 `total`을 보내지 않으므로 그때는 items.length/limit로
+ * 대체하지 않고 "확인 불가"(kpi.datasets="unavailable", datasetCount=null)로 둔다.
+ * 호출부는 이 상태를 "dataset 없음"으로 오해하지 않는다.
+ */
+function loadDatasetTotal(
+  isActive: () => boolean,
+  setStats: Dispatch<SetStateAction<DashboardStats>>,
+  setKpi: Dispatch<SetStateAction<KpiPhases>>,
+): void {
+  builderApi
+    .listDatasets(1)
+    .then((res) => {
+      if (!isActive()) return;
+      setStats((prev) => ({ ...prev, datasetCount: res.total ?? null }));
+      setKpi((prev) => ({ ...prev, datasets: res.total === undefined ? "unavailable" : "ready" }));
+    })
+    .catch(() => {
+      if (!isActive()) return;
+      setStats((prev) => ({ ...prev, datasetCount: null }));
+      setKpi((prev) => ({ ...prev, datasets: "unavailable" }));
+    });
+}
+
+/**
+ * 실연동 모드에서 Home KPI 3개 경계를 각각 독립적으로 로드한다.
+ *
+ * 세 요청은 서로를, 그리고 이미 커밋된 Recent Builds를 절대 block하지 않는다.
+ * 한 aggregate가 실패/미지원이면 해당 KPI만 "확인 불가"가 되고 값을 지어내지 않는다.
+ */
+function loadRealKpis(
+  isActive: () => boolean,
+  setStats: Dispatch<SetStateAction<DashboardStats>>,
+  setKpi: Dispatch<SetStateAction<KpiPhases>>,
+): void {
+  // (1) DATASETS — dataset total.
+  loadDatasetTotal(isActive, setStats, setKpi);
+
+  // (2) SUCCEEDED (24H) + RUNNING — monitoring. 각 endpoint 실패는 그 값만 null로.
+  void Promise.all([
+    builderApi.getMonitoringBuilds().catch(() => null),
+    builderApi.getMonitoringSummary().catch(() => null),
+  ]).then(([monitoring, summary]) => {
+    if (!isActive()) return;
+    const monitoredSuccess =
+      monitoring?.availability === "available"
+        ? monitoring.buckets.reduce((sum, bucket) => sum + bucket.success, 0)
+        : null;
+    setStats((prev) => ({
+      ...prev,
+      buildSuccess: monitoredSuccess,
+      // GET /builds의 real 계약은 terminal summary만 제공하므로 active 수로 해석하지 않는다.
+      running: summary?.queue.running ?? null,
+    }));
+    setKpi((prev) => ({ ...prev, monitoring: "ready" }));
+  });
+
+  // (3) QUALITY WARN (24H) — quality summary. 미지원(1.21.0 이하 → 404)/실패면 "확인 불가".
+  builderApi
+    .getQualitySummary()
+    .then((res) => {
+      if (!isActive()) return;
+      setStats((prev) => ({
+        ...prev,
+        qualityWarn: res.availability === "available" ? res.warn_runs : null,
+      }));
+      setKpi((prev) => ({ ...prev, quality: "ready" }));
+    })
+    .catch(() => {
+      if (!isActive()) return;
+      setStats((prev) => ({ ...prev, qualityWarn: null }));
+      setKpi((prev) => ({ ...prev, quality: "unavailable" }));
+    });
 }
 
 /**
  * 신규 사용자 여부를 판단한다.
- * dataset/build이 하나도 없으면 신규 사용자로 간주한다.
+ *
+ * 신규 사용자는 "빌드도 dataset도 없음"이 실제로 확인됐을 때만 확정한다. 빈 build
+ * 목록만으로는 부족하다 — dataset은 있는데 아직 build를 돌리지 않은 사용자를 신규로
+ * 오판할 수 있기 때문이다. real 모드에서는 Builder GET /datasets의 authoritative
+ * `total`(1.22.0)을 함께 확인하고, total이 unavailable(구버전 Builder / 404·5xx)이면
+ * 신규로 추측하지 않고 기존 대시보드를 보여준다(DATASETS만 "확인 불가").
  */
 export function HomePage() {
+  const realBuilder = isRealBuilderEnabled();
   const [builds, setBuilds] = useState<BuildListItem[]>([]);
+  const [buildsState, setBuildsState] = useState<"loading" | "error" | "success">("loading");
   const [stats, setStats] = useState<DashboardStats>({
-    datasetCount: 0,
-    buildSuccess: 0,
-    validationWarn: null,
-    running: 0,
+    datasetCount: null,
+    buildSuccess: null,
+    qualityWarn: null,
+    running: null,
   });
-  const [loading, setLoading] = useState<LoadingState>({
-    builds: true,
-    stats: true,
-  });
-  const [apiState, setApiState] = useState<ApiState>({
-    builds: "loading",
-    stats: "loading",
+  const [kpi, setKpi] = useState<KpiPhases>({
+    datasets: "loading",
+    monitoring: "loading",
+    quality: "loading",
   });
 
   useEffect(() => {
     let active = true;
 
-    const fetchData = async () => {
-      try {
-        const realBuilder = isRealBuilderEnabled();
-        const buildList = await listBuilds();
-        // Recent builds and monitoring have independent authority and latency.
-        if (active) {
-          setBuilds(buildList);
-          setApiState((prev) => ({ ...prev, builds: "success" }));
-          setLoading((prev) => ({ ...prev, builds: false }));
-        }
-        // 비어 있는 목록은 신규 사용자 분기에 충분하며, 불필요한 monitoring 호출로 막지 않는다.
-        const [monitoring, summary] = realBuilder && buildList.length > 0
-          ? await Promise.all([
-              builderApi.getMonitoringBuilds().catch(() => null),
-              builderApi.getMonitoringSummary().catch(() => null),
-            ])
-          : [null, null];
-        if (active) {
-          setBuilds(buildList);
-          setApiState((prev) => ({ ...prev, builds: "success" }));
+    // Recent Builds는 KPI 요청과 완전히 독립이다 — 받는 즉시 커밋하고, 실패하면
+    // KPI와 무관하게 그 섹션만 에러 상태로 둔다.
+    listBuilds()
+      .then((list) => {
+        if (!active) return;
+        setBuilds(list);
+        setBuildsState("success");
 
-          const succeeded = buildList.filter((b) => b.status === "succeeded").length;
-          const running = buildList.filter((b) => b.status === "running" || b.status === "queued").length;
+        // 빌드가 없다 — monitoring/quality aggregate는 여기서 부르지 않는다. 다만
+        // 신규 사용자 판정에는 authoritative dataset total이 필요하므로 real 모드에서는
+        // 그것만 독립적으로 조회한다(total 없음/실패 시 신규로 확정하지 않는다).
+        if (list.length === 0) {
+          if (realBuilder) {
+            setKpi({ datasets: "loading", monitoring: "unavailable", quality: "unavailable" });
+            loadDatasetTotal(() => active, setStats, setKpi);
+          } else {
+            setKpi({ datasets: "unavailable", monitoring: "unavailable", quality: "unavailable" });
+          }
+          return;
+        }
 
-          const monitoredSuccess = monitoring?.availability === "available"
-            ? monitoring.buckets.reduce((sum, bucket) => sum + bucket.success, 0)
-            : null;
-          setStats({
-            // /datasets has no total; a paginated response length is not a dataset count.
-            datasetCount: null,
-            buildSuccess: realBuilder ? monitoredSuccess : succeeded,
-            validationWarn: null,
-            // GET /builds의 real 계약은 terminal summary만 제공하므로 active 수로 해석하지 않는다.
-            running: realBuilder ? summary?.queue.running ?? null : running,
-          });
-          setApiState((prev) => ({ ...prev, stats: "success" }));
+        if (realBuilder) {
+          loadRealKpis(() => active, setStats, setKpi);
+          return;
         }
-      } catch {
-        if (active) {
-          setApiState((prev) => ({ ...prev, builds: "error", stats: "error" }));
-        }
-      } finally {
-        if (active) {
-          setLoading((prev) => ({ ...prev, builds: false, stats: false }));
-        }
-      }
-    };
 
-    fetchData();
+        // mock/demo: 기존 demo 의미 유지 — mock 목록에서 직접 계산한다. 여기는
+        // 애초에 mock 모드이므로 real 실패를 mock 숫자로 대체하는 경로가 아니다.
+        const succeeded = list.filter((b) => b.status === "succeeded").length;
+        const running = list.filter(
+          (b) => b.status === "running" || b.status === "queued",
+        ).length;
+        setStats({ datasetCount: null, buildSuccess: succeeded, qualityWarn: null, running });
+        setKpi({ datasets: "unavailable", monitoring: "ready", quality: "unavailable" });
+      })
+      .catch(() => {
+        if (!active) return;
+        setBuildsState("error");
+        // 빌드 목록을 못 받으면 KPI 근거도 없다 — 임의값 대신 전부 "확인 불가".
+        setKpi({ datasets: "unavailable", monitoring: "unavailable", quality: "unavailable" });
+      });
 
     return () => {
       active = false;
     };
-  }, []);
+  }, [realBuilder]);
 
   const recentBuilds = [...builds]
     .sort((a, b) => {
@@ -133,11 +219,28 @@ export function HomePage() {
     })
     .slice(0, 5);
 
-  const isNew = apiState.builds === "success" && builds.length === 0;
+  // real 모드: 빌드 0개 + dataset total 조회 성공(kpi.datasets="ready") + total===0
+  // 이 모두 충족될 때만 신규 사용자로 확정한다. total이 unavailable이면 빈 build만으로
+  // 추측하지 않는다. mock/demo 모드에는 dataset aggregate 권위가 없으므로 기존
+  // build 기반 판정을 그대로 유지한다.
+  const datasetsConfirmedEmpty = kpi.datasets === "ready" && stats.datasetCount === 0;
+  const isNew =
+    buildsState === "success" &&
+    builds.length === 0 &&
+    (realBuilder ? datasetsConfirmedEmpty : true);
 
   return (
     <main className="flex flex-1 flex-col gap-8 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
-      {isNew ? <NewUserHome /> : <ExistingUserHome stats={stats} recentBuilds={recentBuilds} loading={loading} apiState={apiState} />}
+      {isNew ? (
+        <NewUserHome />
+      ) : (
+        <ExistingUserHome
+          stats={stats}
+          recentBuilds={recentBuilds}
+          buildsState={buildsState}
+          kpi={kpi}
+        />
+      )}
     </main>
   );
 }
@@ -251,13 +354,13 @@ function KubiHero() {
 function ExistingUserHome({
   stats,
   recentBuilds,
-  loading,
-  apiState,
+  buildsState,
+  kpi,
 }: {
   stats: DashboardStats;
   recentBuilds: BuildListItem[];
-  loading: LoadingState;
-  apiState: ApiState;
+  buildsState: "loading" | "error" | "success";
+  kpi: KpiPhases;
 }) {
   return (
     <>
@@ -267,36 +370,42 @@ function ExistingUserHome({
         description="최근 데이터셋, 빌드 상태, 품질 경고를 모니터링합니다"
       />
 
-      <KpiCards stats={stats} loading={loading.stats} apiState={apiState.stats} />
+      <KpiCards stats={stats} kpi={kpi} />
 
       <section className="grid gap-6 xl:grid-cols-2">
-        <RecentBuildsSection recentBuilds={recentBuilds} loading={loading.builds} apiState={apiState.builds} />
+        <RecentBuildsSection
+          recentBuilds={recentBuilds}
+          loading={buildsState === "loading"}
+          apiState={buildsState}
+        />
         <QualitySection />
       </section>
     </>
   );
 }
 
-function KpiCards({ stats, loading, apiState }: { stats: DashboardStats; loading: boolean; apiState: ApiState["stats"] }) {
-  if (apiState === "error") {
-    return (
-      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        {["DATASETS", "SUCCEEDED (24H)", "VALIDATION WARN", "RUNNING"].map((label) => (
-          <Card key={label} variant="error" className="flex items-center justify-between">
-            <span className="text-sm text-muted-foreground">{label}</span>
-            <span className="text-xl font-semibold tracking-tight text-muted-foreground">—</span>
-          </Card>
-        ))}
-      </section>
-    );
-  }
-
+/**
+ * KPI 4칸. 각 칸은 자기 aggregate 경계의 phase만 본다 — 한 aggregate가 실패해도
+ * 다른 칸은 정상 값을 유지하고, 전체를 한꺼번에 에러로 덮지 않는다. null 값은
+ * KpiCard가 "확인 불가"로 렌더한다(임의 숫자 합성 없음).
+ */
+function KpiCards({ stats, kpi }: { stats: DashboardStats; kpi: KpiPhases }) {
   return (
     <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-      <KpiCard label="DATASETS" value={stats.datasetCount} loading={loading} />
-      <KpiCard label="SUCCEEDED (24H)" value={stats.buildSuccess} loading={loading} variant="success" />
-      <KpiCard label="VALIDATION WARN" value={stats.validationWarn} loading={loading} variant="error" />
-      <KpiCard label="RUNNING" value={stats.running} loading={loading} />
+      <KpiCard label="DATASETS" value={stats.datasetCount} loading={kpi.datasets === "loading"} />
+      <KpiCard
+        label="SUCCEEDED (24H)"
+        value={stats.buildSuccess}
+        loading={kpi.monitoring === "loading"}
+        variant="success"
+      />
+      <KpiCard
+        label="QUALITY WARN (24H)"
+        value={stats.qualityWarn}
+        loading={kpi.quality === "loading"}
+        variant="error"
+      />
+      <KpiCard label="RUNNING" value={stats.running} loading={kpi.monitoring === "loading"} />
     </section>
   );
 }
@@ -335,7 +444,15 @@ function KpiCard({
   );
 }
 
-function RecentBuildsSection({ recentBuilds, loading, apiState }: { recentBuilds: BuildListItem[]; loading: boolean; apiState: ApiState["builds"] }) {
+function RecentBuildsSection({
+  recentBuilds,
+  loading,
+  apiState,
+}: {
+  recentBuilds: BuildListItem[];
+  loading: boolean;
+  apiState: "loading" | "error" | "success";
+}) {
   return (
     <section>
       <PageHeader eyebrow="최근 빌드" title="최근 실행" className="mb-4" />
@@ -395,8 +512,8 @@ function QualitySection() {
       <PageHeader eyebrow="품질" title="품질 경고" className="mb-4" />
       <Card className="p-0">
         <EmptyState
-          title="품질 경고 집계 확인 불가"
-          description="Builder monitoring API는 validation warning 집계를 제공하지 않습니다. 각 빌드의 품질 화면에서 확인하세요."
+          title="개별 품질 경고 목록은 아직 제공되지 않습니다"
+          description="최근 24시간 WARN run 수는 위의 QUALITY WARN (24H) KPI에서 확인할 수 있습니다. 어떤 run이 경고인지는 각 빌드의 품질 화면에서 확인하세요."
         />
       </Card>
     </section>

--- a/src/pages/ProviderPage.test.tsx
+++ b/src/pages/ProviderPage.test.tsx
@@ -14,7 +14,8 @@ import { MemoryRouter } from "react-router-dom";
 import { http, HttpResponse, delay } from "msw";
 import { mswServer } from "../../vitest.setup";
 import { API_BASE } from "@/shared/config/env";
-import { ProviderPage } from "./ProviderPage";
+import { ProviderPage, isCredentialStoreUnavailable } from "./ProviderPage";
+import { ApiError } from "@/shared/lib/builderApi";
 
 const PROVIDERS = {
   providers: [
@@ -88,6 +89,61 @@ describe("ProviderPage credential 상태", () => {
     expect(screen.queryByRole("button", { name: "삭제" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "등록하기" })).not.toBeInTheDocument();
   });
+
+  it("unrelated credential GET 503은 일반 조회 실패로 표시한다", async () => {
+    mswServer.use(
+      http.get(`${API_BASE}/providers/datago/credential`, () =>
+        HttpResponse.json({ error: "upstream temporarily unavailable" }, { status: 503 }),
+      ),
+    );
+    renderProviders();
+    await selectProvider("datago");
+
+    expect(await screen.findByText("자격 증명 상태를 불러오지 못했습니다", undefined, { timeout: 4000 })).toBeInTheDocument();
+    expect(screen.queryByText("자격 증명 저장소가 아직 구성되지 않았습니다")).not.toBeInTheDocument();
+  });
+
+  it("unrelated credential PUT/DELETE 503은 master key 안내 대신 일반 실패로 표시한다", async () => {
+    let configured = false;
+    mswServer.use(
+      http.get(`${API_BASE}/providers/datago/credential`, () =>
+        HttpResponse.json({ configured, masked: configured ? "dg••••99" : null, updated_at: null }),
+      ),
+      http.put(`${API_BASE}/providers/datago/credential`, () =>
+        HttpResponse.json({ error: "upstream temporarily unavailable" }, { status: 503 }),
+      ),
+      http.delete(`${API_BASE}/providers/datago/credential`, () =>
+        HttpResponse.json({ error: "upstream temporarily unavailable" }, { status: 503 }),
+      ),
+    );
+    renderProviders();
+    await selectProvider("datago");
+
+    fireEvent.click(await screen.findByRole("button", { name: "등록하기" }));
+    fireEvent.change(screen.getByPlaceholderText("API Key를 입력하세요"), { target: { value: "secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "저장" }));
+    expect(await screen.findByText("Credential 저장에 실패했습니다", undefined, { timeout: 4000 })).toBeInTheDocument();
+    expect(screen.queryByText(/master key/)).not.toBeInTheDocument();
+
+    configured = true;
+    fireEvent.click(screen.getAllByText("datago")[0].closest("li") as HTMLElement);
+    expect(await screen.findByRole("button", { name: "삭제" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "삭제" }));
+    expect(await screen.findByText("Credential 삭제에 실패했습니다", undefined, { timeout: 4000 })).toBeInTheDocument();
+    expect(screen.queryByText(/master key/)).not.toBeInTheDocument();
+  });
+});
+
+describe("isCredentialStoreUnavailable", () => {
+  it("정확한 Builder 503 payload만 저장소 미구성으로 판별한다", () => {
+    expect(
+      isCredentialStoreUnavailable(
+        new ApiError(503, "Service Unavailable", { error: "credential store is not configured" }),
+      ),
+    ).toBe(true);
+    expect(isCredentialStoreUnavailable(new ApiError(503, "Service Unavailable", { error: "upstream down" }))).toBe(false);
+    expect(isCredentialStoreUnavailable(new ApiError(500, "boom", { error: "credential store is not configured" }))).toBe(false);
+  });
 });
 
 describe("ProviderPage provider 전환 race", () => {
@@ -159,12 +215,50 @@ describe("ProviderPage provider 전환 race", () => {
     await selectProvider("kosis");
     expect(await screen.findByRole("button", { name: "등록하기" })).toBeInTheDocument();
 
-    // 임의 sleep 대신, PUT 완료 후의 loadCredentialMeta(datago) refresh가 실제로
-    // 발생했음을 GET 횟수로 결정적으로 기다린다(초기 조회 1 + mutation 후 refresh 1).
-    // waitFor가 폴링을 act()로 감싸므로 뒤늦은 state 갱신도 act 안에서 flush된다.
-    await waitFor(() => expect(datagoCredentialGets).toBeGreaterThanOrEqual(2));
+    // B로 떠난 뒤에는 stale A metadata refresh를 새로 시작하지 않는다.
+    await waitFor(() => expect(datagoStored).toBe(true));
+    expect(datagoCredentialGets).toBe(1);
 
     expect(screen.queryByText(/DATAGO-NEWKEY/)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "등록하기" })).toBeInTheDocument();
+  });
+
+  it("A mutation 완료가 pending B credential GET을 stale 처리하지 않는다", async () => {
+    let resolveKosis: ((response: Response) => void) | undefined;
+    let resolvePut: ((response: Response) => void) | undefined;
+    let datagoCredentialGets = 0;
+    mswServer.use(
+      http.get(`${API_BASE}/providers/datago/credential`, () => {
+        datagoCredentialGets += 1;
+        return HttpResponse.json({ configured: false, masked: null, updated_at: null });
+      }),
+      http.put(`${API_BASE}/providers/datago/credential`, () =>
+        new Promise<Response>((resolve) => {
+          resolvePut = resolve;
+        }),
+      ),
+      http.get(`${API_BASE}/providers/kosis/credential`, () =>
+        new Promise<Response>((resolve) => {
+          resolveKosis = resolve;
+        }),
+      ),
+    );
+    renderProviders();
+
+    await selectProvider("datago");
+    fireEvent.click(await screen.findByRole("button", { name: "등록하기" }));
+    fireEvent.change(screen.getByPlaceholderText("API Key를 입력하세요"), { target: { value: "secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "저장" }));
+    await selectProvider("kosis");
+
+    await waitFor(() => expect(resolveKosis).toBeDefined());
+    await waitFor(() => expect(resolvePut).toBeDefined());
+    resolvePut?.(HttpResponse.json({ provider: "datago", configured: true, masked: "DG", updated_at: null }));
+    // A의 stale mutation 완료가 B request-generation을 증가시키지 않는다.
+    await waitFor(() => expect(datagoCredentialGets).toBe(1));
+    expect(datagoCredentialGets).toBe(1);
+    resolveKosis?.(HttpResponse.json({ configured: false, masked: null, updated_at: null }));
+
+    expect(await screen.findByRole("button", { name: "등록하기" })).toBeInTheDocument();
   });
 });

--- a/src/pages/ProviderPage.test.tsx
+++ b/src/pages/ProviderPage.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * ProviderPage credential 상태·race 테스트.
+ *
+ * 검증 대상:
+ * - credential configured / not-configured 상태를 각각 정확히 렌더
+ * - GET /providers/{p}/credential 503(운영자가 master key 미구성)을 "저장소 미구성"으로
+ *   구분해서 표시 — "아직 등록 안 함"이나 일반 오류와 섞지 않는다
+ * - provider A 조회가 pending인 동안 B로 전환하면 A의 늦은 응답이 B 패널을 오염하지 않는다
+ * - A의 credential mutation(저장) 완료 뒤의 늦은 metadata refresh도 B를 덮지 않는다
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { http, HttpResponse, delay } from "msw";
+import { mswServer } from "../../vitest.setup";
+import { API_BASE } from "@/shared/config/env";
+import { ProviderPage } from "./ProviderPage";
+
+const PROVIDERS = {
+  providers: [
+    { provider: "datago", requires_credential: true, configured: false },
+    { provider: "kosis", requires_credential: true, configured: false },
+  ],
+};
+
+function renderProviders() {
+  return render(
+    <MemoryRouter>
+      <ProviderPage />
+    </MemoryRouter>,
+  );
+}
+
+async function selectProvider(name: string) {
+  fireEvent.click(await screen.findByText(name));
+}
+
+beforeEach(() => {
+  vi.stubEnv("VITE_USE_REAL_BUILDER", "true");
+  mswServer.use(http.get(`${API_BASE}/providers`, () => HttpResponse.json(PROVIDERS)));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("ProviderPage credential 상태", () => {
+  it("configured=true면 마스킹 값과 삭제 버튼을 보여준다", async () => {
+    mswServer.use(
+      http.get(`${API_BASE}/providers/datago/credential`, () =>
+        HttpResponse.json({ configured: true, masked: "dg••••99", updated_at: "2026-08-15T09:25:00+00:00" }),
+      ),
+    );
+    renderProviders();
+    await selectProvider("datago");
+
+    expect(await screen.findByText(/dg••••99/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
+  });
+
+  it("configured=false면 등록 CTA를 보여주고 마스킹 값/삭제 버튼은 없다", async () => {
+    mswServer.use(
+      http.get(`${API_BASE}/providers/datago/credential`, () =>
+        HttpResponse.json({ configured: false, masked: null, updated_at: null }),
+      ),
+    );
+    renderProviders();
+    await selectProvider("datago");
+
+    expect(await screen.findByRole("button", { name: "등록하기" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "삭제" })).not.toBeInTheDocument();
+  });
+
+  it("credential GET 503은 '저장소 미구성'으로 구분해서 표시한다", async () => {
+    mswServer.use(
+      http.get(`${API_BASE}/providers/datago/credential`, () =>
+        HttpResponse.json({ error: "credential store is not configured" }, { status: 503 }),
+      ),
+    );
+    renderProviders();
+    await selectProvider("datago");
+
+    expect(
+      await screen.findByText("자격 증명 저장소가 아직 구성되지 않았습니다", undefined, { timeout: 4000 }),
+    ).toBeInTheDocument();
+    // 일반 오류 문구나 등록/삭제 컨트롤로 오인되지 않는다.
+    expect(screen.queryByText("자격 증명 상태를 불러오지 못했습니다")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "삭제" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "등록하기" })).not.toBeInTheDocument();
+  });
+});
+
+describe("ProviderPage provider 전환 race", () => {
+  it("A 조회가 pending인 동안 B로 전환하면 A의 늦은 응답이 B 패널을 덮지 않는다", async () => {
+    mswServer.use(
+      http.get(`${API_BASE}/providers/datago/credential`, async () => {
+        await delay(250);
+        return HttpResponse.json({
+          configured: true,
+          masked: "DATAGO-STALE",
+          updated_at: "2026-08-15T09:25:00+00:00",
+        });
+      }),
+      http.get(`${API_BASE}/providers/kosis/credential`, () =>
+        HttpResponse.json({ configured: false, masked: null, updated_at: null }),
+      ),
+    );
+    renderProviders();
+
+    await selectProvider("datago");
+    await selectProvider("kosis");
+
+    // kosis는 자기 상태(미등록)를 보여준다.
+    expect(await screen.findByRole("button", { name: "등록하기" })).toBeInTheDocument();
+
+    // datago의 늦은 응답이 도착할 시간을 준다.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    expect(screen.queryByText(/DATAGO-STALE/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "등록하기" })).toBeInTheDocument();
+  });
+
+  it("A credential 저장 완료 후의 늦은 metadata refresh도 B 패널을 덮지 않는다", async () => {
+    let datagoStored = false;
+    let datagoCredentialGets = 0;
+    mswServer.use(
+      http.get(`${API_BASE}/providers/datago/credential`, () => {
+        datagoCredentialGets += 1;
+        return HttpResponse.json(
+          datagoStored
+            ? { configured: true, masked: "DATAGO-NEWKEY", updated_at: "2026-09-01T00:00:00+00:00" }
+            : { configured: false, masked: null, updated_at: null },
+        );
+      }),
+      http.put(`${API_BASE}/providers/datago/credential`, async () => {
+        await delay(250);
+        datagoStored = true;
+        return HttpResponse.json({
+          provider: "datago",
+          configured: true,
+          masked: "DATAGO-NEWKEY",
+          updated_at: "2026-09-01T00:00:00+00:00",
+        });
+      }),
+      http.get(`${API_BASE}/providers/kosis/credential`, () =>
+        HttpResponse.json({ configured: false, masked: null, updated_at: null }),
+      ),
+    );
+    renderProviders();
+
+    await selectProvider("datago");
+    fireEvent.click(await screen.findByRole("button", { name: "등록하기" }));
+    fireEvent.change(screen.getByPlaceholderText("API Key를 입력하세요"), {
+      target: { value: "typed-secret" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    // 저장이 진행 중인 동안 B로 전환.
+    await selectProvider("kosis");
+    expect(await screen.findByRole("button", { name: "등록하기" })).toBeInTheDocument();
+
+    // 임의 sleep 대신, PUT 완료 후의 loadCredentialMeta(datago) refresh가 실제로
+    // 발생했음을 GET 횟수로 결정적으로 기다린다(초기 조회 1 + mutation 후 refresh 1).
+    // waitFor가 폴링을 act()로 감싸므로 뒤늦은 state 갱신도 act 안에서 flush된다.
+    await waitFor(() => expect(datagoCredentialGets).toBeGreaterThanOrEqual(2));
+
+    expect(screen.queryByText(/DATAGO-NEWKEY/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "등록하기" })).toBeInTheDocument();
+  });
+});

--- a/src/pages/ProviderPage.test.tsx
+++ b/src/pages/ProviderPage.test.tsx
@@ -14,7 +14,7 @@ import { MemoryRouter } from "react-router-dom";
 import { http, HttpResponse, delay } from "msw";
 import { mswServer } from "../../vitest.setup";
 import { API_BASE } from "@/shared/config/env";
-import { ProviderPage, isCredentialStoreUnavailable } from "./ProviderPage";
+import { ProviderPage, isCredentialStoreUnavailable, isSafeReturnTo } from "./ProviderPage";
 import { ApiError } from "@/shared/lib/builderApi";
 
 const PROVIDERS = {
@@ -24,9 +24,9 @@ const PROVIDERS = {
   ],
 };
 
-function renderProviders() {
+function renderProviders(initialEntry = "/provider") {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <ProviderPage />
     </MemoryRouter>,
   );
@@ -131,6 +131,52 @@ describe("ProviderPage credential 상태", () => {
     fireEvent.click(screen.getByRole("button", { name: "삭제" }));
     expect(await screen.findByText("Credential 삭제에 실패했습니다", undefined, { timeout: 4000 })).toBeInTheDocument();
     expect(screen.queryByText(/master key/)).not.toBeInTheDocument();
+  });
+});
+
+describe("ProviderPage 연결 상태 표현 (credential readiness)", () => {
+  it("generic live probe(연결 테스트) 대신 credential readiness만 노출한다", async () => {
+    mswServer.use(
+      http.get(`${API_BASE}/providers`, () => HttpResponse.json({
+        providers: [{ provider: "datago", requires_credential: true, configured: true }],
+      })),
+      http.get(`${API_BASE}/providers/datago/credential`, () => HttpResponse.json({
+        configured: true,
+        masked: "dg••••99",
+        updated_at: "2026-09-01T00:00:00+00:00",
+      })),
+    );
+    renderProviders();
+    await selectProvider("datago");
+
+    expect(await screen.findByText(/dg••••99/)).toBeInTheDocument();
+    expect(screen.getByText("자격 증명 (Credential) 상태")).toBeInTheDocument();
+    expect(screen.getByText("연결 상태")).toBeInTheDocument();
+    // 사용자 저장 credential이 있으면 "API Key 등록됨" + Preview 안내.
+    expect(screen.getAllByText("API Key 등록됨").length).toBeGreaterThan(0);
+    expect(screen.getByText(/실제 Dataset API 사용 가능 여부는 Add Data의 Preview/)).toBeInTheDocument();
+    // generic probe UI는 없다.
+    expect(screen.queryByRole("button", { name: "연결 테스트" })).not.toBeInTheDocument();
+    expect(screen.queryByText("연결 / 실제 API 확인")).not.toBeInTheDocument();
+  });
+
+  it("credential 미설정이면 목록·상세 모두 'API Key 미설정'으로 표시한다", async () => {
+    mswServer.use(
+      http.get(`${API_BASE}/providers`, () => HttpResponse.json({
+        providers: [{ provider: "datago", requires_credential: true, configured: false }],
+      })),
+      http.get(`${API_BASE}/providers/datago/credential`, () => HttpResponse.json({
+        configured: false,
+        masked: null,
+        updated_at: null,
+      })),
+    );
+    renderProviders();
+    // 목록 배지 — provider 선택 전에도 요약 기준으로 표시된다.
+    expect(await screen.findAllByText("API Key 미설정")).not.toHaveLength(0);
+    await selectProvider("datago");
+    expect(await screen.findByRole("button", { name: "등록하기" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "연결 테스트" })).not.toBeInTheDocument();
   });
 });
 
@@ -260,5 +306,81 @@ describe("ProviderPage provider 전환 race", () => {
     resolveKosis?.(HttpResponse.json({ configured: false, masked: null, updated_at: null }));
 
     expect(await screen.findByRole("button", { name: "등록하기" })).toBeInTheDocument();
+  });
+});
+
+describe("ProviderPage Add Data 왕복 (#S-add-data §4)", () => {
+  it("?provider=로 넘어오면 목록 로딩 후 해당 provider를 자동 선택한다", async () => {
+    mswServer.use(
+      http.get(`${API_BASE}/providers/datago/credential`, () =>
+        HttpResponse.json({ configured: false, masked: null, updated_at: null }),
+      ),
+    );
+    renderProviders("/provider?provider=datago&returnTo=%2Fadd");
+
+    expect(await screen.findByRole("button", { name: "등록하기" })).toBeInTheDocument();
+  });
+
+  it("returnTo가 있으면 Add Data 복귀 안내 배너를 보여준다", async () => {
+    renderProviders("/provider?provider=datago&returnTo=%2Fadd");
+    expect(
+      await screen.findByText("데이터 추가를 계속하려면 API 연결을 완료하세요."),
+    ).toBeInTheDocument();
+  });
+
+  it("returnTo가 없으면 복귀 안내 배너를 보여주지 않는다", async () => {
+    renderProviders();
+    await selectProvider("datago");
+    expect(
+      screen.queryByText("데이터 추가를 계속하려면 API 연결을 완료하세요."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("credential을 저장하면 returnTo로 돌아가는 CTA를 보여준다", async () => {
+    let configured = false;
+    mswServer.use(
+      http.get(`${API_BASE}/providers/datago/credential`, () =>
+        HttpResponse.json(
+          configured
+            ? { configured: true, masked: "dg••••99", updated_at: "2026-09-02T00:00:00+00:00" }
+            : { configured: false, masked: null, updated_at: null },
+        ),
+      ),
+      http.put(`${API_BASE}/providers/datago/credential`, () => {
+        configured = true;
+        return HttpResponse.json({ provider: "datago", configured: true, masked: "dg••••99", updated_at: null });
+      }),
+    );
+    renderProviders("/provider?provider=datago&returnTo=%2Fadd");
+
+    fireEvent.click(await screen.findByRole("button", { name: "등록하기" }));
+    fireEvent.change(screen.getByPlaceholderText("API Key를 입력하세요"), { target: { value: "secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    const cta = await screen.findByRole("link", { name: "데이터 설정으로 돌아가기" });
+    expect(cta).toHaveAttribute("href", "/add");
+  });
+
+  it("저장 전에는 돌아가기 CTA를 보여주지 않는다", async () => {
+    mswServer.use(
+      http.get(`${API_BASE}/providers/datago/credential`, () =>
+        HttpResponse.json({ configured: true, masked: "dg••••99", updated_at: null }),
+      ),
+    );
+    renderProviders("/provider?provider=datago&returnTo=%2Fadd");
+    await screen.findByText(/dg••••99/);
+    expect(screen.queryByRole("link", { name: "데이터 설정으로 돌아가기" })).not.toBeInTheDocument();
+  });
+});
+
+describe("isSafeReturnTo — open redirect 방지", () => {
+  it("내부 절대 경로만 안전으로 판정한다", () => {
+    expect(isSafeReturnTo("/add")).toBe(true);
+    expect(isSafeReturnTo(null)).toBe(false);
+    expect(isSafeReturnTo("")).toBe(false);
+    expect(isSafeReturnTo("add")).toBe(false);
+    expect(isSafeReturnTo("//evil.com")).toBe(false);
+    expect(isSafeReturnTo("https://evil.com")).toBe(false);
+    expect(isSafeReturnTo("/\\evil.com")).toBe(false);
   });
 });

--- a/src/pages/ProviderPage.tsx
+++ b/src/pages/ProviderPage.tsx
@@ -15,6 +15,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  ApiError,
   builderApi,
   isRealBuilderEnabled,
   type ProviderSummary,
@@ -58,6 +59,13 @@ interface CredentialForm {
 type CredentialMetaState =
   | { status: "idle" | "loading" }
   | { status: "not_applicable" }
+  /**
+   * 운영자가 encrypted credential store(master key)를 구성하지 않았다 —
+   * Builder가 `GET /providers/{provider}/credential`에 503
+   * `credential store is not configured`로 답한 경우. "사용자가 아직 credential을
+   * 등록하지 않음"(200 `configured:false`)이나 일반 조회 실패와 구분한다.
+   */
+  | { status: "store_unavailable" }
   | { status: "error"; message: string }
   | {
       status: "loaded";
@@ -87,7 +95,14 @@ export function ProviderPage() {
   const [showCredentialForm, setShowCredentialForm] = useState(false);
   const [credentialForm, setCredentialForm] = useState<CredentialForm>({ credential: "" });
   const [credentialMeta, setCredentialMeta] = useState<CredentialMetaState>({ status: "idle" });
+  // credential 메타 조회/갱신 race guard는 두 축을 함께 본다:
+  // (1) request-generation — 더 나중에 시작한 조회가 항상 이긴다.
+  // (2) selectedProviderIdRef — 그 조회의 대상 provider가 "지금 화면에 선택된"
+  //     provider와 같아야 한다. mutation(save/delete) 완료 후의 늦은
+  //     loadCredentialMeta(A)가 generation을 최신으로 올려도, 그 사이 사용자가
+  //     B로 옮겼다면 A의 결과/loading/error가 B 패널을 절대 덮지 못한다(#324, #322).
   const credentialRequestGeneration = useRef(0);
+  const selectedProviderIdRef = useRef<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -130,6 +145,13 @@ export function ProviderPage() {
     void loadProviders();
   }, [loadProviders]);
 
+  // selectedProvider가 바뀔 때(특히 loadProviders 새로고침으로 선택 provider가
+  // 목록에서 사라져 null이 될 때) ref를 정렬 상태로 유지한다. 네트워크 응답은
+  // 항상 이 커밋/effect 이후에 도착하므로, 진행 중이던 조회의 stale 판정 기준이 된다.
+  useEffect(() => {
+    selectedProviderIdRef.current = selectedProvider?.id ?? null;
+  }, [selectedProvider]);
+
   /**
    * 선택된 provider의 "사용자 저장 credential" 메타데이터를 authoritative하게 다시 읽는다.
    * requires_credential=false면 조회 자체를 하지 않는다(등록/삭제할 credential이 없음).
@@ -137,15 +159,20 @@ export function ProviderPage() {
   const loadCredentialMeta = useCallback(
     async (provider: ProviderConfig) => {
       const generation = ++credentialRequestGeneration.current;
+      // 이 조회 결과를 화면에 반영해도 되는지: 가장 최신 조회이면서, 그 대상이
+      // 여전히 선택된 provider일 때만. loading/error/loaded 커밋 전에 항상 확인한다.
+      const stillCurrent = () =>
+        generation === credentialRequestGeneration.current &&
+        provider.id === selectedProviderIdRef.current;
       if (!provider.requiresCredential) {
-        if (generation === credentialRequestGeneration.current) setCredentialMeta({ status: "not_applicable" });
+        if (stillCurrent()) setCredentialMeta({ status: "not_applicable" });
         return;
       }
-      setCredentialMeta({ status: "loading" });
+      if (stillCurrent()) setCredentialMeta({ status: "loading" });
       try {
         if (isRealBuilderEnabled()) {
           const meta = await builderApi.getProviderCredential(provider.id);
-          if (generation !== credentialRequestGeneration.current) return;
+          if (!stillCurrent()) return;
           setCredentialMeta({
             status: "loaded",
             configured: meta.configured,
@@ -153,11 +180,15 @@ export function ProviderPage() {
             updatedAt: meta.updated_at,
           });
         } else {
-          if (generation !== credentialRequestGeneration.current) return;
+          if (!stillCurrent()) return;
           setCredentialMeta(mockCredentialMeta(provider));
         }
-      } catch {
-        if (generation !== credentialRequestGeneration.current) return;
+      } catch (cause) {
+        if (!stillCurrent()) return;
+        if (cause instanceof ApiError && cause.status === 503) {
+          setCredentialMeta({ status: "store_unavailable" });
+          return;
+        }
         setCredentialMeta({ status: "error", message: "자격 증명 상태를 불러오지 못했습니다" });
       }
     },
@@ -165,6 +196,10 @@ export function ProviderPage() {
   );
 
   const handleProviderSelect = (provider: ProviderConfig) => {
+    // 선택 전환은 동기적으로 ref에 반영한다 — 직후의 loadCredentialMeta가
+    // 즉시 이 값을 기준으로 삼아야 하고, 진행 중이던 다른 provider의 조회는
+    // 여기서부터 stale로 판정된다.
+    selectedProviderIdRef.current = provider.id;
     ++credentialRequestGeneration.current;
     setSelectedProvider(provider);
     setShowCredentialForm(false);
@@ -223,12 +258,22 @@ export function ProviderPage() {
         // response로 기대하지 않고, 선택된 provider의 canonical id를 URL에 쓴다(#S02).
         await builderApi.putProviderCredential(provider.id, credentialForm.credential);
       }
-      setCredentialForm({ credential: "" });
-      setShowCredentialForm(false);
-      // 저장 후 metadata와 provider 요약을 다시 authoritative하게 갱신한다.
+      // 저장이 진행되는 동안 사용자가 다른 provider로 옮겼다면, 이 mutation의 후속
+      // form 리셋/에러가 현재 화면(B)을 오염시키면 안 된다(#322/#324와 같은 축).
+      if (selectedProviderIdRef.current === provider.id) {
+        setCredentialForm({ credential: "" });
+        setShowCredentialForm(false);
+      }
+      // metadata/provider 요약은 provider 전환 여부와 무관하게 authoritative하게
+      // 갱신한다 — loadCredentialMeta는 내부 guard로 stale 결과를 반영하지 않는다.
       await Promise.all([loadProviders(), loadCredentialMeta(provider)]);
-    } catch {
-      setError("Credential 저장에 실패했습니다");
+    } catch (cause) {
+      if (selectedProviderIdRef.current !== provider.id) return;
+      setError(
+        cause instanceof ApiError && cause.status === 503
+          ? "Builder에 자격 증명 저장소(master key)가 구성되어 있지 않아 저장할 수 없습니다."
+          : "Credential 저장에 실패했습니다",
+      );
     }
   };
 
@@ -242,8 +287,14 @@ export function ProviderPage() {
       }
       // 삭제 후 metadata와 provider 요약을 다시 authoritative하게 갱신한다.
       await Promise.all([loadProviders(), loadCredentialMeta(provider)]);
-    } catch {
-      setError("Credential 삭제에 실패했습니다");
+    } catch (cause) {
+      // 삭제 도중 다른 provider로 옮겼다면 이 실패를 현재 화면 에러로 노출하지 않는다.
+      if (selectedProviderIdRef.current !== provider.id) return;
+      setError(
+        cause instanceof ApiError && cause.status === 503
+          ? "Builder에 자격 증명 저장소(master key)가 구성되어 있지 않아 삭제할 수 없습니다."
+          : "Credential 삭제에 실패했습니다",
+      );
     }
   };
 
@@ -430,6 +481,19 @@ export function ProviderPage() {
                   <p className="mt-4 text-sm text-muted-foreground">
                     자격 증명 상태를 불러오는 중…
                   </p>
+                ) : credentialMeta.status === "store_unavailable" ? (
+                  <div className="mt-4 rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+                    <p className="font-medium text-foreground">
+                      자격 증명 저장소가 아직 구성되지 않았습니다
+                    </p>
+                    <p className="mt-2">
+                      Builder에 암호화된 자격 증명 저장소(master key)가 설정되어 있지 않아 사용자
+                      자격 증명을 등록·조회할 수 없습니다. 이는 &ldquo;아직 자격 증명을 등록하지
+                      않음&rdquo;과는 다른 상태입니다. 운영자가 Builder에
+                      <code className="mx-1">KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY</code>를 설정한
+                      뒤 다시 시도하세요.
+                    </p>
+                  </div>
                 ) : credentialMeta.status === "error" ? (
                   <p className="mt-4 text-sm text-red-600 dark:text-red-400">
                     {credentialMeta.message}

--- a/src/pages/ProviderPage.tsx
+++ b/src/pages/ProviderPage.tsx
@@ -74,6 +74,13 @@ type CredentialMetaState =
       updatedAt: string | null;
     };
 
+/** Builder가 명시한 credential store 미구성 응답만 operator remediation으로 분류한다. */
+export function isCredentialStoreUnavailable(cause: unknown): boolean {
+  if (!(cause instanceof ApiError) || cause.status !== 503) return false;
+  if (!cause.details || typeof cause.details !== "object" || Array.isArray(cause.details)) return false;
+  return (cause.details as { error?: unknown }).error === "credential store is not configured";
+}
+
 /** Builder GET /providers 요약을 화면 모델로 변환한다(연결 상태는 별도 status 점검으로 채운다). */
 function mapProviderSummary(summary: ProviderSummary): ProviderConfig {
   return {
@@ -116,19 +123,28 @@ export function ProviderPage() {
         const response = await builderApi.listProviders();
         const mapped = response.providers.map(mapProviderSummary);
         setProviders(mapped);
-        setSelectedProvider((current) => {
-          if (!current) return null;
-          const next = mapped.find((p) => p.id === current.id);
-          if (!next) return null;
-          // 연결 테스트 결과는 목록 새로고침으로 잃지 않도록 보존한다.
-          return {
-            ...next,
-            status: current.status,
-            latency: current.latency,
-            checkedAt: current.checkedAt,
-            errorCategory: current.errorCategory,
-          };
-        });
+        // ref는 사용자 선택의 동기적 source of truth다. state updater/effect가 늦게
+        // 실행되며 이미 B로 바뀐 ref를 A로 되돌리면 stale mutation refresh가 시작될 수
+        // 있으므로, 목록 응답으로 선택을 재결정하지 않는다. 실제 목록에서 사라진 경우만
+        // 명시적으로 선택을 해제한다.
+        const selectedId = selectedProviderIdRef.current;
+        const next = selectedId ? mapped.find((provider) => provider.id === selectedId) : undefined;
+        if (!next) {
+          if (selectedId) selectedProviderIdRef.current = null;
+          setSelectedProvider(null);
+        } else {
+          setSelectedProvider((current) =>
+            current?.id === next.id
+              ? {
+                  ...next,
+                  status: current.status,
+                  latency: current.latency,
+                  checkedAt: current.checkedAt,
+                  errorCategory: current.errorCategory,
+                }
+              : next,
+          );
+        }
       } else {
         // 명시적 mock/demo mode에서만 mock 목록을 쓴다.
         setProviders(getMockProviders());
@@ -144,13 +160,6 @@ export function ProviderPage() {
   useEffect(() => {
     void loadProviders();
   }, [loadProviders]);
-
-  // selectedProvider가 바뀔 때(특히 loadProviders 새로고침으로 선택 provider가
-  // 목록에서 사라져 null이 될 때) ref를 정렬 상태로 유지한다. 네트워크 응답은
-  // 항상 이 커밋/effect 이후에 도착하므로, 진행 중이던 조회의 stale 판정 기준이 된다.
-  useEffect(() => {
-    selectedProviderIdRef.current = selectedProvider?.id ?? null;
-  }, [selectedProvider]);
 
   /**
    * 선택된 provider의 "사용자 저장 credential" 메타데이터를 authoritative하게 다시 읽는다.
@@ -185,7 +194,7 @@ export function ProviderPage() {
         }
       } catch (cause) {
         if (!stillCurrent()) return;
-        if (cause instanceof ApiError && cause.status === 503) {
+        if (isCredentialStoreUnavailable(cause)) {
           setCredentialMeta({ status: "store_unavailable" });
           return;
         }
@@ -264,13 +273,17 @@ export function ProviderPage() {
         setCredentialForm({ credential: "" });
         setShowCredentialForm(false);
       }
-      // metadata/provider 요약은 provider 전환 여부와 무관하게 authoritative하게
-      // 갱신한다 — loadCredentialMeta는 내부 guard로 stale 결과를 반영하지 않는다.
-      await Promise.all([loadProviders(), loadCredentialMeta(provider)]);
+      // 목록은 authoritative하게 갱신하되, 다른 provider를 보고 있으면 A의
+      // provider-specific refresh를 시작하지 않는다. 시작 자체가 global generation을
+      // 올려 B의 pending GET을 stale로 만들 수 있기 때문이다.
+      await loadProviders();
+      if (selectedProviderIdRef.current === provider.id) {
+        await loadCredentialMeta(provider);
+      }
     } catch (cause) {
       if (selectedProviderIdRef.current !== provider.id) return;
       setError(
-        cause instanceof ApiError && cause.status === 503
+        isCredentialStoreUnavailable(cause)
           ? "Builder에 자격 증명 저장소(master key)가 구성되어 있지 않아 저장할 수 없습니다."
           : "Credential 저장에 실패했습니다",
       );
@@ -285,13 +298,16 @@ export function ProviderPage() {
       if (isRealBuilderEnabled()) {
         await builderApi.deleteProviderCredential(provider.id);
       }
-      // 삭제 후 metadata와 provider 요약을 다시 authoritative하게 갱신한다.
-      await Promise.all([loadProviders(), loadCredentialMeta(provider)]);
+      // 저장과 동일하게, 선택을 떠난 provider의 metadata refresh는 시작하지 않는다.
+      await loadProviders();
+      if (selectedProviderIdRef.current === provider.id) {
+        await loadCredentialMeta(provider);
+      }
     } catch (cause) {
       // 삭제 도중 다른 provider로 옮겼다면 이 실패를 현재 화면 에러로 노출하지 않는다.
       if (selectedProviderIdRef.current !== provider.id) return;
       setError(
-        cause instanceof ApiError && cause.status === 503
+        isCredentialStoreUnavailable(cause)
           ? "Builder에 자격 증명 저장소(master key)가 구성되어 있지 않아 삭제할 수 없습니다."
           : "Credential 삭제에 실패했습니다",
       );

--- a/src/pages/ProviderPage.tsx
+++ b/src/pages/ProviderPage.tsx
@@ -10,16 +10,20 @@
  * - "이 사용자가 저장한 credential"의 유무/마스킹 값은 GET /providers/{provider}/credential
  *   메타데이터(`{ configured, masked, updated_at }`, raw secret 없음)로만 판정한다.
  * - requires_credential=false여도 요약 configured=true일 수 있다(무인증 provider).
- * - 세 축을 화면에서 분리한다: (1) provider 사용 가능 여부, (2) 사용자 저장 credential
- *   존재 여부, (3) 연결 테스트 결과.
+ * - 두 축을 화면에서 분리한다: (1) effective credential readiness(요약 configured),
+ *   (2) 사용자 저장 credential 존재 여부(마스킹 값·삭제의 근거).
+ * - generic Provider probe(`POST /providers/{provider}/test` · `GET .../status`)는
+ *   임의의 첫 Dataset을 필수 파라미터 없이 호출하므로 신뢰할 수 없다. 이 화면은
+ *   probe 결과를 "연결 성공 여부"로 노출하지 않는다 — 실제 사용 가능 여부는 선택한
+ *   Dataset의 Preview가 확인한다(#S-provider-probe).
  */
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import {
   ApiError,
   builderApi,
   isRealBuilderEnabled,
   type ProviderSummary,
-  type ProviderTestResponse,
 } from "@/shared/lib/builderApi";
 import {
   Card,
@@ -29,6 +33,19 @@ import {
   EmptyState,
   Skeleton,
 } from "@/shared/ui";
+import { describeCredentialReadiness } from "@/shared/lib/providerStatus";
+
+/**
+ * `returnTo` query param을 안전한 내부 경로일 때만 신뢰한다(#S-add-data, §4).
+ * 절대 URL/프로토콜-상대(`//evil.com`) 경로로의 open redirect를 막는다 — 이 값은
+ * Add Data 같은 내부 화면이 이어서 편집을 재개할 안전한 복귀 지점으로만 쓴다.
+ */
+export function isSafeReturnTo(value: string | null): value is string {
+  if (!value) return false;
+  if (!value.startsWith("/") || value.startsWith("//")) return false;
+  if (value.startsWith("/\\")) return false;
+  return true;
+}
 
 interface ProviderConfig {
   id: string;
@@ -41,11 +58,6 @@ interface ProviderConfig {
    * (user credential > server default > 없음). 사용자 저장 credential 유무가 아니다.
    */
   summaryConfigured: boolean;
-  /** 연결 테스트 결과. `unknown` = 아직 점검하지 않음. */
-  status: "connected" | "failed" | "not_configured" | "unknown";
-  latency?: number;
-  checkedAt?: string;
-  errorCategory?: string;
 }
 
 interface CredentialForm {
@@ -91,17 +103,27 @@ function mapProviderSummary(summary: ProviderSummary): ProviderConfig {
     description: summary.requires_credential
       ? "자격 증명이 필요한 제공 기관입니다."
       : "자격 증명 없이 사용할 수 있는 제공 기관입니다.",
-    status: "unknown",
   };
 }
 
 export function ProviderPage() {
+  const [searchParams] = useSearchParams();
+  // Add Data 등에서 `?provider=datago&returnTo=/add`로 넘어온 경우(#S-add-data, §4).
+  // URL에는 provider id와 safe return destination만 싣는다 — credential/BuildSpec은
+  // 절대 담지 않는다. providerParam은 목록이 로딩된 뒤 딱 한 번만 자동 선택에 쓴다.
+  const providerParam = searchParams.get("provider");
+  const returnToParam = searchParams.get("returnTo");
+  const safeReturnTo = isSafeReturnTo(returnToParam) ? returnToParam : null;
+  const providerParamAppliedRef = useRef(false);
+
   const [providers, setProviders] = useState<ProviderConfig[]>([]);
   const [selectedProvider, setSelectedProvider] = useState<ProviderConfig | null>(null);
-  const [isTesting, setIsTesting] = useState(false);
   const [showCredentialForm, setShowCredentialForm] = useState(false);
   const [credentialForm, setCredentialForm] = useState<CredentialForm>({ credential: "" });
   const [credentialMeta, setCredentialMeta] = useState<CredentialMetaState>({ status: "idle" });
+  // credential을 이번 화면 방문에서 방금 저장했는지 — returnTo CTA는 저장 성공
+  // 이후에만 보여준다(§4). provider 전환 시 reset한다.
+  const [justSavedCredential, setJustSavedCredential] = useState(false);
   // credential 메타 조회/갱신 race guard는 두 축을 함께 본다:
   // (1) request-generation — 더 나중에 시작한 조회가 항상 이긴다.
   // (2) selectedProviderIdRef — 그 조회의 대상 provider가 "지금 화면에 선택된"
@@ -133,17 +155,7 @@ export function ProviderPage() {
           if (selectedId) selectedProviderIdRef.current = null;
           setSelectedProvider(null);
         } else {
-          setSelectedProvider((current) =>
-            current?.id === next.id
-              ? {
-                  ...next,
-                  status: current.status,
-                  latency: current.latency,
-                  checkedAt: current.checkedAt,
-                  errorCategory: current.errorCategory,
-                }
-              : next,
-          );
+          setSelectedProvider(next);
         }
       } else {
         // 명시적 mock/demo mode에서만 mock 목록을 쓴다.
@@ -213,48 +225,19 @@ export function ProviderPage() {
     setSelectedProvider(provider);
     setShowCredentialForm(false);
     setCredentialForm({ credential: "" });
+    setJustSavedCredential(false);
     void loadCredentialMeta(provider);
   };
 
-  /** status 점검/테스트 응답을 목록과 선택 상태에 반영한다. */
-  const applyStatus = useCallback((res: ProviderTestResponse) => {
-    const patch: Partial<ProviderConfig> = {
-      status: res.status,
-      latency: res.latency_ms,
-      checkedAt: res.checked_at,
-      errorCategory: res.error_category,
-    };
-    setProviders((list) => list.map((p) => (p.id === res.provider ? { ...p, ...patch } : p)));
-    setSelectedProvider((current) =>
-      current && current.id === res.provider ? { ...current, ...patch } : current,
-    );
-  }, []);
-
-  const handleConnectionTest = async () => {
-    if (!selectedProvider) return;
-    const provider = selectedProvider.id;
-
-    setIsTesting(true);
-    setError(null);
-    try {
-      if (isRealBuilderEnabled()) {
-        // 연결 테스트는 GET /providers/{provider}/status를 쓴다 — 임의 POST /test가 아니다(#S02).
-        applyStatus(await builderApi.getProviderStatus(provider));
-      } else {
-        applyStatus({
-          provider,
-          status: "connected",
-          configured: true,
-          latency_ms: 42,
-          checked_at: new Date().toISOString(),
-        });
-      }
-    } catch {
-      setError("연결 테스트에 실패했습니다");
-    } finally {
-      setIsTesting(false);
-    }
-  };
+  // `?provider=`로 넘어온 경우 목록이 로딩된 뒤 해당 provider를 한 번만 자동
+  // 선택한다(#S-add-data, §4) — Discover의 catalog preselection과 같은 패턴
+  // (한 번만 적용, 목록에 없으면 조용히 넘어간다).
+  useEffect(() => {
+    if (providerParamAppliedRef.current || loading || !providerParam) return;
+    providerParamAppliedRef.current = true;
+    const match = providers.find((p) => p.id === providerParam);
+    if (match) handleProviderSelect(match);
+  }, [providers, loading, providerParam]);
 
   const handleCredentialSubmit = async () => {
     if (!selectedProvider || !credentialForm.credential) return;
@@ -272,6 +255,7 @@ export function ProviderPage() {
       if (selectedProviderIdRef.current === provider.id) {
         setCredentialForm({ credential: "" });
         setShowCredentialForm(false);
+        setJustSavedCredential(true);
       }
       // 목록은 authoritative하게 갱신하되, 다른 provider를 보고 있으면 A의
       // provider-specific refresh를 시작하지 않는다. 시작 자체가 global generation을
@@ -314,25 +298,30 @@ export function ProviderPage() {
     }
   };
 
-  const getStatusBadge = (status: ProviderConfig["status"]) => {
-    const styles = {
-      connected: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300",
-      failed: "bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300",
-      not_configured: "bg-muted text-muted-foreground",
-      unknown: "bg-muted text-muted-foreground",
-    };
-    const labels = {
-      connected: "연결됨",
-      failed: "연결 실패",
-      not_configured: "미설정",
-      unknown: "연결 확인 필요",
-    };
-    return { className: styles[status], label: labels[status] };
-  };
-
   // 사용자 본인이 저장한 credential이 있는지(삭제 버튼/마스킹 값 표시의 유일한 근거).
   const userCredentialConfigured =
     credentialMeta.status === "loaded" && credentialMeta.configured;
+
+  // Provider 상태 배지는 generic live probe가 아니라 credential readiness로 표현한다
+  // (#S-provider-probe). 실제 Dataset API 사용 가능 여부는 Preview가 확인한다.
+  // `userCredentialConfigured`는 지금 선택된 provider에서만 알 수 있으므로 목록
+  // 배지에는 전달하지 않는다(요약 `configured`만 사용).
+  const readinessToneClass: Record<"success" | "warning" | "neutral", string> = {
+    success: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300",
+    warning: "bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300",
+    neutral: "bg-muted text-muted-foreground",
+  };
+  const getReadinessPresentation = (
+    provider: ProviderConfig,
+    userConfigured?: boolean,
+  ) => {
+    const readiness = describeCredentialReadiness({
+      requiresCredential: provider.requiresCredential,
+      summaryConfigured: provider.summaryConfigured,
+      userCredentialConfigured: userConfigured,
+    });
+    return { className: readinessToneClass[readiness.tone], label: readiness.label, detail: readiness.detail };
+  };
   const canRegisterCredential =
     !!selectedProvider &&
     selectedProvider.requiresCredential &&
@@ -346,6 +335,15 @@ export function ProviderPage() {
         description="공공데이터 제공 기관과 연결하고 자격 증명(credential)을 관리합니다."
         actions={<LinkButton to="/settings">설정으로 이동</LinkButton>}
       />
+      <p className="-mt-6 text-xs text-muted-foreground">
+        공공데이터 API Key와 Provider 자격 증명은 이곳에서 연결합니다. Kubi AI 요청에 사용하는 API Key와는 별개입니다.
+      </p>
+
+      {safeReturnTo ? (
+        <Card variant="dashed" className="text-sm">
+          데이터 추가를 계속하려면 API 연결을 완료하세요.
+        </Card>
+      ) : null}
 
       {error && (
         <Card variant="error">
@@ -392,10 +390,10 @@ export function ProviderPage() {
                       <div className="flex items-center gap-2 mt-1">
                         <span
                           className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                            getStatusBadge(provider.status).className
+                            getReadinessPresentation(provider).className
                           }`}
                         >
-                          {getStatusBadge(provider.status).label}
+                          {getReadinessPresentation(provider).label}
                         </span>
                       </div>
                     </div>
@@ -417,66 +415,31 @@ export function ProviderPage() {
           ) : (
             <div className="space-y-6">
               <Card>
-                <div className="flex items-start justify-between">
+                <div className="flex items-start justify-between gap-3">
                   <div>
-                    <h3 className="text-lg font-semibold">{selectedProvider.name}</h3>
+                    <h3 className="text-lg font-semibold">연결 상태</h3>
                     <p className="mt-1 text-sm text-muted-foreground">
-                      {selectedProvider.description}
+                      {getReadinessPresentation(selectedProvider, userCredentialConfigured).detail}
                     </p>
                   </div>
                   <span
-                    className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                      getStatusBadge(selectedProvider.status).className
+                    className={`shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                      getReadinessPresentation(selectedProvider, userCredentialConfigured).className
                     }`}
                   >
-                    {getStatusBadge(selectedProvider.status).label}
+                    {getReadinessPresentation(selectedProvider, userCredentialConfigured).label}
                   </span>
                 </div>
-
-                {selectedProvider.status === "connected" && (
-                  <div className="mt-4 grid grid-cols-2 gap-4 text-sm">
-                    <div>
-                      <span className="text-muted-foreground">확인 시각</span>
-                      <p className="font-medium">
-                        {selectedProvider.checkedAt
-                          ? new Date(selectedProvider.checkedAt).toLocaleString("ko-KR")
-                          : "—"}
-                      </p>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">지연 시간</span>
-                      <p className="font-medium">
-                        {selectedProvider.latency
-                          ? `${selectedProvider.latency}ms`
-                          : "—"}
-                      </p>
-                    </div>
-                  </div>
-                )}
-
-                {selectedProvider.status === "failed" && (
-                  <div className="mt-4">
-                    <span className="text-sm text-muted-foreground">에러 분류:</span>
-                    <p className="mt-1 text-sm font-medium text-red-600 dark:text-red-400">
-                      {selectedProvider.errorCategory || "알 수 없음"}
-                    </p>
-                  </div>
-                )}
-
-                <div className="mt-6">
-                  <Button
-                    variant="secondary"
-                    onClick={handleConnectionTest}
-                    disabled={isTesting}
-                  >
-                    {isTesting ? "테스트 중..." : "연결 테스트"}
-                  </Button>
-                </div>
+                <p className="mt-4 text-xs text-muted-foreground">
+                  선택한 Dataset에서 API Key가 실제 유효한지, 활용신청·필수 요청
+                  파라미터가 맞는지는 Add Data의 Preview 단계에서 확인합니다. 이
+                  화면은 Provider 인증 정보 등록 상태만 관리합니다.
+                </p>
               </Card>
 
               <Card>
                 <div className="flex items-center justify-between">
-                  <h4 className="font-semibold">자격 증명 (Credential)</h4>
+                  <h4 className="font-semibold">자격 증명 (Credential) 상태</h4>
                   {userCredentialConfigured ? (
                     <Button size="sm" variant="danger" onClick={handleCredentialDelete}>
                       삭제
@@ -563,6 +526,11 @@ export function ProviderPage() {
                     <p className="mt-2 text-xs text-muted-foreground">
                       Builder가 마스킹한 값이며 원문은 표시되지 않습니다.
                     </p>
+                    {justSavedCredential && safeReturnTo ? (
+                      <div className="mt-4">
+                        <LinkButton to={safeReturnTo}>데이터 설정으로 돌아가기</LinkButton>
+                      </div>
+                    ) : null}
                   </div>
                 ) : selectedProvider.summaryConfigured ? (
                   <p className="mt-4 text-sm text-muted-foreground">
@@ -586,7 +554,7 @@ export function ProviderPage() {
 /** mock/demo 모드에서 선택된 provider의 사용자 credential 상태를 시뮬레이션한다. */
 function mockCredentialMeta(provider: ProviderConfig): CredentialMetaState {
   if (!provider.requiresCredential) return { status: "not_applicable" };
-  const configured = provider.status === "connected";
+  const configured = provider.summaryConfigured;
   return {
     status: "loaded",
     configured,
@@ -603,7 +571,6 @@ function getMockProviders(): ProviderConfig[] {
       description: "대한민국 대표 공공데이터 포털",
       requiresCredential: true,
       summaryConfigured: false,
-      status: "not_configured",
     },
     {
       id: "kosis",
@@ -611,9 +578,6 @@ function getMockProviders(): ProviderConfig[] {
       description: "한국 통계청 통계포털",
       requiresCredential: true,
       summaryConfigured: true,
-      status: "connected",
-      latency: 150,
-      checkedAt: new Date(Date.now() - 3600000).toISOString(),
     },
     {
       id: "g2b",
@@ -621,9 +585,6 @@ function getMockProviders(): ProviderConfig[] {
       description: "국가과학기술정보원",
       requiresCredential: true,
       summaryConfigured: false,
-      status: "failed",
-      errorCategory: "AUTH_ERROR",
-      checkedAt: new Date(Date.now() - 86400000).toISOString(),
     },
   ];
 }

--- a/src/pages/QualityPage.tsx
+++ b/src/pages/QualityPage.tsx
@@ -43,7 +43,7 @@ import type {
   RunStagesResponse,
   SchemaDriftFinding,
 } from "@/shared/lib/builderApi";
-import { Button, Card, EmptyState, ErrorState, PageHeader, Skeleton } from "@/shared/ui";
+import { Button, Card, EmptyState, ErrorState, PageHeader, QualityLegend, Skeleton, TermHelp } from "@/shared/ui";
 
 interface AsyncState<T> {
   status: "idle" | "loading" | "loaded" | "error";
@@ -339,6 +339,8 @@ export function QualityPage() {
         }
       />
 
+      <QualityLegend />
+
       <Card className="flex flex-wrap items-end gap-3 p-3">
         <label className="min-w-52 flex-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
           Dataset
@@ -371,6 +373,7 @@ export function QualityPage() {
           <span>·</span><span>Availability</span><strong className="text-foreground">{qualityState.data?.availability ?? "—"}</strong>
           <QualityStateBadge state={overallState} />
         </div>
+        <p className="basis-full text-xs text-muted-foreground">현재 선택한 Dataset · Run · Source · Stage 범위의 Builder 평가 결과입니다. <TermHelp term="quality" /></p>
         {datasetDetailHref && selectedSource ? <Link className="ml-auto text-xs font-medium text-accent-subtle-foreground underline" to={datasetDetailHref}>Dataset Detail에서 보기</Link> : null}
       </Card>
 

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,31 +1,31 @@
-/**
- * 계정 발급 안내 화면 (/signup, #263 → #Phase2 UI polish).
- *
- * kpubdata-builder ADR 0015(Accepted) §5는 public signup을 기본 OFF로 하고 관리자
- * 초대/이메일 도메인 제한을 기본 정책으로 둔다. 이전에는 이 라우트가 완전히 동작하는
- * 자체 회원가입 폼(mockAuthProvider.signUp)을 열어 두고 있었는데, 이는 실제 정책(공개
- * 자율 가입 없음)과 어긋난다. 실제 Keycloak 연동도 아직 없으므로(LoginPage 주석 참고)
- * 여기서는 정책만 정직하게 안내하고, 구체적인 계정 발급 방식(관리자 초대 UI, 이메일
- * 도메인 검증 등)은 아직 구현되지 않았으므로 확정된 사실처럼 서술하지 않는다.
- */
-import { Link } from "react-router-dom";
-import { Card } from "@/shared/ui";
+/** 공개 회원가입은 Studio가 아닌 Keycloak hosted UI에서 처리한다. */
+import { Link, useLocation } from "react-router-dom";
+import { keycloakLogin } from "@/features/auth/keycloak";
+import { getSafeReturnTo } from "@/features/auth/returnTo";
+import { getOidcConfig } from "@/shared/config/env";
+import { Button, Card } from "@/shared/ui";
 
 export function SignupPage() {
+  const location = useLocation();
+  const oidc = getOidcConfig();
+  const returnTo = getSafeReturnTo(new URLSearchParams(location.search).get("returnTo"));
+
   return (
     <main className="flex min-h-screen items-center justify-center bg-background px-5 py-12">
       <Card className="w-full max-w-md text-center">
-        <h1 className="text-2xl font-semibold tracking-tight">계정 발급 안내</h1>
+        <h1 className="text-2xl font-semibold tracking-tight">KPubData 계정 만들기</h1>
         <p className="mt-3 text-sm text-muted-foreground">
-          KPubData Studio는 공개 회원가입을 제공하지 않습니다. 계정 발급 방식은 조직 정책에 따라
-          관리자가 안내합니다.
+          회원가입, 이메일 인증, 비밀번호 정책은 안전한 Keycloak 화면에서 처리합니다.
         </p>
-        <p className="mt-2 text-sm text-muted-foreground">
-          비밀번호, 이메일 인증, 비밀번호 재설정은 KPubData 계정(Keycloak)에서 관리됩니다 —
-          Studio는 비밀번호를 입력받거나 저장하지 않습니다.
-        </p>
+        {oidc.status === "ok" ? (
+          <Button className="mt-6" onClick={() => void keycloakLogin(returnTo)}>
+            Keycloak에서 회원가입 또는 로그인
+          </Button>
+        ) : (
+          <p className="mt-6 text-sm text-muted-foreground">인증 설정이 준비되면 여기서 계정을 만들 수 있습니다.</p>
+        )}
         <Link to="/login" className="mt-6 inline-block font-medium text-accent-subtle-foreground underline">
-          로그인하러 가기
+          로그인으로 돌아가기
         </Link>
       </Card>
     </main>

--- a/src/shared/content/glossary.ts
+++ b/src/shared/content/glossary.ts
@@ -1,0 +1,22 @@
+export const glossary = {
+  dataset: "KPubData에서 하나의 단위로 관리하는 빌드 결과 데이터입니다.",
+  build: "선택한 source와 설정에 따라 데이터를 수집·처리하는 작업입니다.",
+  run: "Build가 실제로 한 번 실행된 기록입니다. 같은 Dataset에도 여러 Run이 생길 수 있습니다.",
+  buildSpec: "어떤 source를 가져오고 어떻게 처리할지 Builder에 전달하는 이식 가능한 실행 명세입니다.",
+  provider: "Builder가 연결할 수 있는 외부 데이터 공급처 또는 API입니다.",
+  credential: "Provider에서 데이터를 가져올 때 필요한 API Key 등의 인증 정보입니다.",
+  preview: "Build 전에 가져올 데이터의 일부와 검증 결과를 미리 확인하는 기능입니다.",
+  bronze: "수집한 원본 데이터를 가능한 그대로 보존하는 단계입니다.",
+  silver: "Bronze 데이터를 정제·표준화해 분석과 품질 확인에 사용할 수 있게 만든 단계입니다.",
+  gold: "특정 사용 목적에 맞게 가공한 최종 데이터 단계입니다.",
+  quality: "Builder가 실제로 평가한 데이터 품질 규칙의 결과입니다.",
+  schemaDrift: "이전과 비교해 컬럼 추가·삭제·타입 변경 등 데이터 구조가 달라진 상태입니다.",
+  evidence: "Kubi 또는 Report가 참고한 Builder의 Dataset·Run·Quality 등의 근거입니다.",
+  context: "Kubi가 현재 질문을 해석할 때 사용하는 Dataset·Run·Source·Stage 범위입니다.",
+  generatedSql: "Kubi가 선택한 Silver 또는 Gold schema를 바탕으로 생성한 조회 SQL입니다.",
+  artifact: "Build 실행으로 생성된 데이터 파일 또는 결과물입니다.",
+  manifest: "Run과 생성된 산출물에 대한 메타데이터 기록입니다.",
+  readiness: "Publish 전에 필요한 조건을 Builder가 확인한 결과입니다.",
+} as const;
+
+export type GlossaryKey = keyof typeof glossary;

--- a/src/shared/lib/builderApi.schema.ts
+++ b/src/shared/lib/builderApi.schema.ts
@@ -375,6 +375,11 @@ export const datasetDetailResponseSchema = datasetSummarySchema.extend({
 
 export const datasetsResponseSchema = z.object({
   datasets: z.array(datasetSummarySchema),
+  // `total`은 Builder 1.22.0에서 추가된 additive 필드다(canonical grouping +
+  // ownership 이후, pagination 이전의 distinct dataset 수). 1.21.0 이하 Builder는
+  // 이 필드를 보내지 않으므로 optional로 둔다 — 없으면 Studio는 "확인 불가"로
+  // 표시하고, items.length/limit을 total로 대신 쓰지 않는다.
+  total: z.number().int().nonnegative().optional(),
 });
 
 export const datasetRunSummarySchema = z.object({
@@ -572,6 +577,22 @@ export const datasetQualityHistoryResponseSchema = z.object({
 });
 
 /**
+ * GET /quality/summary — 최근 24h cross-run quality aggregate (Builder 1.22.0, #486 후속).
+ * Home의 "QUALITY WARN (24H)" KPI가 임의 숫자 합성 없이 authoritative 값을 읽는다.
+ * per-run quality_results/dataset/owner는 포함하지 않는다.
+ */
+export const qualitySummaryResponseSchema = z.object({
+  window: z.literal("24h"),
+  generated_at: z.string(),
+  availability: z.enum(["available", "unavailable"]),
+  total_runs: z.number().int().nonnegative(),
+  evaluated_runs: z.number().int().nonnegative(),
+  pass_runs: z.number().int().nonnegative(),
+  warn_runs: z.number().int().nonnegative(),
+  fail_runs: z.number().int().nonnegative(),
+});
+
+/**
  * ============================================
  * Build Publish API (1.17.0, builder #491 / PR #547)
  * ============================================
@@ -696,6 +717,7 @@ export type QualityAvailability = z.infer<typeof qualityAvailabilitySchema>;
 export type BuildQualityResponse = z.infer<typeof buildQualityResponseSchema>;
 export type DatasetQualityHistoryEntry = z.infer<typeof datasetQualityHistoryEntrySchema>;
 export type DatasetQualityHistoryResponse = z.infer<typeof datasetQualityHistoryResponseSchema>;
+export type QualitySummaryResponse = z.infer<typeof qualitySummaryResponseSchema>;
 
 /**
  * Monitoring (#516) — Builder 실제 wire 계약(GET /monitoring/summary,

--- a/src/shared/lib/builderApi.schema.ts
+++ b/src/shared/lib/builderApi.schema.ts
@@ -250,6 +250,29 @@ export const catalogQuerySupportSchema = z.object({
 /**
  * GET /catalog 응답 스키마 (#416, BL2; #490으로 탐색용 metadata 확장)
  */
+/**
+ * GET /catalog 탐색 metadata의 안전한(secret-free) 요청 파라미터 설명 (#S-add-data).
+ * Builder가 raw_metadata에서 allowlist로 추려 직렬화한다 — serviceKey 등 시크릿
+ * 파라미터는 포함되지 않는다. 없는 dataset은 빈 배열.
+ */
+export const catalogRequestParameterSchema = z.object({
+  name: z.string(),
+  required: z.boolean(),
+  description: z.string().nullable(),
+  example: z.string().nullable(),
+});
+
+/**
+ * 공공데이터포털처럼 API Key 발급과 Dataset별 활용신청이 별개일 수 있는 경우의
+ * 안내 (#S-add-data). Builder가 raw_metadata.application을 그대로 전달한 것으로,
+ * 없으면 null(활용신청이 필요 없다는 뜻이 아니라 알려진 바 없음). Studio는 신청
+ * 완료/승인 여부를 이 필드로 추측하지 않는다 — Preview 성공이 최종 확인이다.
+ */
+export const catalogApplicationSchema = z.object({
+  required: z.boolean(),
+  url: z.string(),
+});
+
 export const catalogDatasetSchema = z.object({
   name: z.string(),
   title: z.string(),
@@ -260,6 +283,12 @@ export const catalogDatasetSchema = z.object({
   operations: z.array(z.enum(["list", "get", "schema", "raw", "download"])),
   query_support: catalogQuerySupportSchema.nullable(),
   requires_service_key: z.boolean(),
+  // 하위 호환: 이 필드를 아직 내려주지 않는 Builder(구버전)에서도 파싱이 깨지지
+  // 않도록 optional로 둔다(소비 측은 `?? []`). 최신 Builder는 항상 배열을 준다.
+  request_parameters: z.array(catalogRequestParameterSchema).optional(),
+  // 하위 호환: 이 필드를 아직 내려주지 않는 Builder(구버전)에서는 undefined다
+  // (소비 측은 `?? null`). 최신 Builder는 항상 값(객체 또는 null)을 준다.
+  application: catalogApplicationSchema.nullable().optional(),
 });
 
 export const catalogProviderSchema = z.object({
@@ -272,6 +301,8 @@ export const catalogResponseSchema = z.object({
 });
 
 export type CatalogQuerySupport = z.infer<typeof catalogQuerySupportSchema>;
+export type CatalogRequestParameter = z.infer<typeof catalogRequestParameterSchema>;
+export type CatalogApplication = z.infer<typeof catalogApplicationSchema>;
 export type CatalogDataset = z.infer<typeof catalogDatasetSchema>;
 export type CatalogProvider = z.infer<typeof catalogProviderSchema>;
 export type CatalogResponse = z.infer<typeof catalogResponseSchema>;

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -406,6 +406,8 @@ export type PreviewColumn = schemas.PreviewColumn;
 export type PreviewSource = schemas.PreviewSource;
 export type PreviewResponse = schemas.PreviewResponse;
 export type CatalogQuerySupport = schemas.CatalogQuerySupport;
+export type CatalogRequestParameter = schemas.CatalogRequestParameter;
+export type CatalogApplication = schemas.CatalogApplication;
 export type CatalogDataset = schemas.CatalogDataset;
 export type CatalogProvider = schemas.CatalogProvider;
 export type CatalogResponse = schemas.CatalogResponse;
@@ -791,6 +793,8 @@ export const builderApi = {
   // uploadFile은 JSON이 아닌 raw body를 보내야 해서 apiFetch를 쓰지 않는 별도 함수로
   // 아래에 정의한다(함수 선언은 호이스팅되므로 여기서 참조할 수 있다).
   uploadFile,
+  // downloadArtifactFile도 응답이 바이너리라 apiFetch를 쓰지 않는 별도 함수다.
+  downloadArtifactFile,
 };
 
 /**
@@ -844,4 +848,81 @@ export async function uploadFile(
     throw new ApiError(500, "Builder 업로드 응답이 예상된 형식과 일치하지 않습니다.", parsed);
   }
   return result.data;
+}
+
+/** Content-Disposition 헤더에서 filename을 안전하게 뽑는다(없으면 null). 경로 구분자는 제거한다. */
+function filenameFromContentDisposition(header: string | null): string | null {
+  if (!header) return null;
+  const star = /filename\*=(?:UTF-8'')?([^;]+)/i.exec(header);
+  const plain = /filename="?([^";]+)"?/i.exec(header);
+  const raw = star?.[1] ?? plain?.[1];
+  if (!raw) return null;
+  let value = raw.trim();
+  try {
+    value = decodeURIComponent(value);
+  } catch {
+    /* 인코딩되지 않은 값은 그대로 쓴다 */
+  }
+  // 디렉터리 성분은 버리고 파일명만 남긴다.
+  return value.split(/[\\/]/).pop() || null;
+}
+
+/**
+ * GET /artifacts/{run_id}/{file_path} — 실행 산출물 개별 파일을 인증된 요청으로 받는다.
+ *
+ * 응답이 JSON이 아니라 바이너리 파일이라 `apiFetch`의 JSON 경로를 쓸 수 없다. Bearer
+ * 헤더는 `uploadFile`과 동일하게 `authTokenProvider`를 재사용하고, 401이면 동일한
+ * `authErrorCallback`을 호출한다.
+ *
+ * `filePath`는 반드시 Builder `GET /artifacts/{run_id}` 목록이 준 canonical
+ * run-relative POSIX 경로여야 한다(예: "silver/datago.air_quality/table.parquet").
+ * manifest.outputs는 output_root 절대경로 + OS 구분자라 여기 넘기면 안 된다.
+ * "/" 구분자는 그대로 두고 각 세그먼트만 URL 인코딩한다 — "/"를 "%2F"/"%5C"로 넣거나
+ * 경로 의미를 바꾸지 않는다(traversal은 Builder가 decode 후 재검증해 거부한다).
+ */
+export async function downloadArtifactFile(
+  runId: string,
+  filePath: string,
+  signal?: AbortSignal,
+): Promise<{ blob: Blob; filename: string }> {
+  const encodedPath = filePath
+    .split("/")
+    .filter((segment) => segment.length > 0)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+  const headers: Record<string, string> = {};
+  const token = (await authTokenProvider?.()) ?? null;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE}/artifacts/${encodeURIComponent(runId)}/${encodedPath}`, {
+      method: "GET",
+      headers,
+      signal,
+    });
+  } catch (cause) {
+    if (signal?.aborted) throw cause;
+    throw new ApiError(0, "Builder API에 연결하지 못했습니다.", cause);
+  }
+
+  if (!response.ok) {
+    if (response.status === 401 && authErrorCallback) authErrorCallback();
+    let parsed: unknown;
+    try {
+      const text = await response.text();
+      parsed = text ? JSON.parse(text) : undefined;
+    } catch {
+      parsed = undefined;
+    }
+    throw new ApiError(response.status, formatApiErrorMessage(response.status, parsed), parsed);
+  }
+
+  const blob = await response.blob();
+  const filename =
+    filenameFromContentDisposition(response.headers.get("Content-Disposition")) ??
+    filePath.split("/").pop() ??
+    "artifact";
+  return { blob, filename };
 }

--- a/src/shared/lib/builderApi.ts
+++ b/src/shared/lib/builderApi.ts
@@ -432,6 +432,7 @@ export type SchemaDriftFinding = schemas.SchemaDriftFinding;
 export type BuildQualityResponse = schemas.BuildQualityResponse;
 export type DatasetQualityHistoryEntry = schemas.DatasetQualityHistoryEntry;
 export type DatasetQualityHistoryResponse = schemas.DatasetQualityHistoryResponse;
+export type QualitySummaryResponse = schemas.QualitySummaryResponse;
 export type QueryStage = schemas.QueryStage;
 export type QueryRequest = schemas.QueryRequest;
 export type QueryResponse = schemas.QueryResponse;
@@ -670,6 +671,19 @@ export const builderApi = {
       "/monitoring/builds?window=24h&bucket=hour",
       { signal },
       schemas.monitoringBuildsResponseSchema,
+    ),
+
+  /**
+   * GET /quality/summary — 최근 24h cross-run quality aggregate (Builder 1.22.0, #486 후속).
+   * Home "QUALITY WARN (24H)" KPI가 이 값을 authoritative하게 읽는다. 1.21.0 이하
+   * Builder에서는 404이므로 호출부가 이 KPI만 독립적으로 "확인 불가" 처리한다 —
+   * 다른 KPI/Recent Builds는 영향받지 않는다.
+   */
+  getQualitySummary: (signal?: AbortSignal) =>
+    apiFetch(
+      "/quality/summary?window=24h",
+      { signal },
+      schemas.qualitySummaryResponseSchema,
     ),
 
   /**

--- a/src/shared/lib/providerStatus.test.ts
+++ b/src/shared/lib/providerStatus.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { describeCredentialReadiness, describeProviderProbe } from "./providerStatus";
+
+describe("describeProviderProbe", () => {
+  it("connected는 success/연결됨", () => {
+    expect(describeProviderProbe({ status: "connected" })).toMatchObject({
+      tone: "success",
+      label: "연결됨",
+      detail: null,
+    });
+  });
+
+  it("저장된 credential + 403은 '연결 실패'가 아니라 '확인 필요'로 승격한다", () => {
+    const p = describeProviderProbe({
+      status: "failed",
+      errorCategory: "auth",
+      responseCode: 403,
+      credentialConfigured: true,
+    });
+    expect(p.tone).toBe("warning");
+    expect(p.label).toBe("확인 필요");
+    expect(p.title).toBe("인증 또는 API 활용신청 확인 필요");
+    expect(p.detail).toMatch(/Dataset\/API별 사용 권한/);
+  });
+
+  it("credential이 없으면 403이라도 일반 인증 오류로 매핑한다", () => {
+    const p = describeProviderProbe({ status: "failed", errorCategory: "auth", responseCode: 403 });
+    expect(p.tone).toBe("error");
+    expect(p.label).toBe("연결 오류");
+  });
+
+  it("내부 enum(network 등)을 그대로 노출하지 않는다", () => {
+    const p = describeProviderProbe({ status: "failed", errorCategory: "network" });
+    expect(p.title).toBe("네트워크 연결 오류");
+    expect(JSON.stringify(p)).not.toMatch(/"network"/);
+  });
+
+  it("알 수 없는 error_category는 unknown 문구로 떨어진다", () => {
+    expect(describeProviderProbe({ status: "failed", errorCategory: "weird" }).title).toBe(
+      "연결 상태를 확인할 수 없습니다",
+    );
+  });
+});
+
+describe("describeCredentialReadiness", () => {
+  it("requires_credential=false → 인증 불필요(neutral)", () => {
+    const r = describeCredentialReadiness({ requiresCredential: false, summaryConfigured: true });
+    expect(r).toMatchObject({ tone: "neutral", label: "인증 불필요" });
+  });
+
+  it("사용자 저장 credential이 있으면 'API Key 등록됨' + Preview 안내", () => {
+    const r = describeCredentialReadiness({
+      requiresCredential: true,
+      summaryConfigured: true,
+      userCredentialConfigured: true,
+    });
+    expect(r.tone).toBe("success");
+    expect(r.label).toBe("API Key 등록됨");
+    expect(r.detail).toMatch(/Preview에서 확인/);
+  });
+
+  it("요약 configured=true지만 사용자 credential 없음(server default)은 별도 문구", () => {
+    const r = describeCredentialReadiness({ requiresCredential: true, summaryConfigured: true });
+    expect(r.tone).toBe("success");
+    expect(r.label).toBe("연결 준비됨");
+    expect(r.detail).toMatch(/Builder 기본 자격 증명/);
+    // 사용자 등록 API Key와 동일하게 표현하지 않는다.
+    expect(r.label).not.toBe("API Key 등록됨");
+  });
+
+  it("credential이 필요한데 미설정이면 'API Key 미설정'(warning)", () => {
+    const r = describeCredentialReadiness({ requiresCredential: true, summaryConfigured: false });
+    expect(r).toMatchObject({ tone: "warning", label: "API Key 미설정" });
+  });
+});

--- a/src/shared/lib/providerStatus.ts
+++ b/src/shared/lib/providerStatus.ts
@@ -1,0 +1,152 @@
+/**
+ * Provider 상태 → 사용자 문구 변환의 단일 지점.
+ *
+ * - `describeCredentialReadiness` (현재 user-facing): ProviderPage / Add Data가
+ *   generic live probe 대신 쓰는 credential readiness 표현. Provider 수준에서
+ *   신뢰성 있게 확인 가능한 축(요구 여부 / effective configured / 사용자 저장
+ *   credential 유무)만 다룬다.
+ * - `describeProviderProbe` (retained): Builder `ProviderTestResponse` 매핑.
+ *   generic probe는 임의의 첫 Dataset을 필수 파라미터 없이 호출하므로 "연결 성공
+ *   여부"로 신뢰할 수 없어 user flow에서는 제거됐다(#S-provider-probe). Builder
+ *   API contract는 유지되므로 매핑/테스트는 남겨 둔다(직접 진단용).
+ * - 어느 경우든 선택한 Dataset의 실제 사용 가능 여부는 Preview가 SSOT다.
+ */
+
+export type ProviderProbeStatus = "connected" | "failed" | "not_configured" | "unknown";
+export type ProviderProbeTone = "success" | "warning" | "error" | "neutral";
+
+export interface ProviderProbeInput {
+  /** `ProviderTestResponse.status` (`unknown` = 아직 점검 안 함). */
+  status: ProviderProbeStatus;
+  /** `ProviderTestResponse.error_category`. */
+  errorCategory?: string;
+  /** `ProviderTestResponse.response_code` — Provider가 실제로 돌려준 HTTP 코드. */
+  responseCode?: number;
+  /**
+   * 이 principal에 대해 credential이 (effective하게) 구성돼 있는지.
+   * 저장된 credential이 있는데도 403이면 단순 인증 실패가 아니라 Dataset/API별
+   * 사용 권한 문제일 수 있으므로 "확인 필요"로 승격한다.
+   */
+  credentialConfigured?: boolean;
+}
+
+export interface ProviderProbePresentation {
+  tone: ProviderProbeTone;
+  /** 짧은 배지 문구. */
+  label: string;
+  /** 자세히 보기 제목(연결 오류/확인 필요일 때만, 그 외 null). */
+  title: string | null;
+  /** 사용자 행동 안내 1–2문장(없으면 null). */
+  detail: string | null;
+}
+
+const PERMISSION_CHECK = {
+  title: "인증 또는 API 활용신청 확인 필요",
+  detail:
+    "저장된 자격 증명으로 실제 API를 확인했지만 접근이 거부되었습니다. Provider는 Dataset/API별 사용 권한이 다를 수 있으므로 선택한 Dataset의 Preview에서 실제 사용 가능 여부를 확인하세요.",
+} as const;
+
+const FAILURES: Record<string, { title: string; detail: string }> = {
+  auth: { title: "인증 정보 확인 필요", detail: "저장된 자격 증명이 유효한지 확인한 뒤 다시 테스트하세요." },
+  network: { title: "네트워크 연결 오류", detail: "Builder가 Provider에 연결하지 못했습니다. 네트워크 상태를 확인하세요." },
+  timeout: { title: "연결 시간 초과", detail: "Provider 응답이 제한 시간 안에 도착하지 않았습니다. 잠시 후 다시 시도하세요." },
+  provider: { title: "Provider 응답 오류", detail: "Provider가 실제 API 확인 요청을 처리하지 못했습니다." },
+  unknown: { title: "연결 상태를 확인할 수 없습니다", detail: "Builder가 실제 API 확인 중 분류되지 않은 오류를 받았습니다." },
+};
+
+/** Provider 수준 검사 결과임을 항상 함께 안내한다(Dataset 사용 가능 여부와 구분). */
+export const PROVIDER_PROBE_SCOPE_NOTE =
+  "이 검사는 Provider 수준의 기본 연결 확인입니다. 선택한 Dataset의 실제 사용 가능 여부는 다음 단계 Preview에서 확인합니다.";
+
+/**
+ * Provider 상태를 **credential readiness** 로 표현한다(#S-provider-probe). Provider
+ * 수준에서 신뢰성 있게 확인 가능한 축은 이것뿐이다:
+ *   - provider가 credential을 요구하는지(`requires_credential`)
+ *   - effective credential이 구성돼 있는지(`configured`: user credential > server
+ *     default > 없음, ADR 0012)
+ *   - 이 사용자가 직접 저장한 credential이 있는지(GET /providers/{provider}/credential)
+ *
+ * "이 API Key가 해당 Dataset에서 실제 유효한가 / 활용신청이 됐는가 / 필수 파라미터가
+ * 맞는가 / 실제 응답이 성공하는가" 는 Provider 수준에서 판정하지 않는다 — 선택한
+ * Dataset의 Preview가 SSOT다. generic probe(`ProviderTestResponse`)를 사용자-facing
+ * "연결 성공 여부" 로 쓰지 않는다.
+ */
+export interface CredentialReadinessInput {
+  /** GET /providers 요약의 `requires_credential`. */
+  requiresCredential: boolean;
+  /** GET /providers 요약의 effective `configured`(user credential > server default > 없음). */
+  summaryConfigured: boolean;
+  /**
+   * 이 사용자가 직접 저장한 credential 유무(GET /providers/{provider}/credential
+   * 메타데이터). server default와 구분한다 — 목록처럼 이 값을 모를 때는 생략한다.
+   */
+  userCredentialConfigured?: boolean;
+}
+
+export interface CredentialReadinessPresentation {
+  tone: Exclude<ProviderProbeTone, "error">;
+  /** 짧은 배지/헤드라인 문구. */
+  label: string;
+  /** 안내 1–2문장. */
+  detail: string;
+}
+
+/** Preview가 실제 사용 가능 여부의 최종 확인임을 항상 함께 안내한다. */
+const READINESS_PREVIEW_NOTE =
+  "실제 Dataset API 사용 가능 여부는 Add Data의 Preview에서 확인합니다.";
+
+export function describeCredentialReadiness(
+  input: CredentialReadinessInput,
+): CredentialReadinessPresentation {
+  if (!input.requiresCredential) {
+    return {
+      tone: "neutral",
+      label: "인증 불필요",
+      detail: "이 제공 기관은 자격 증명 없이 사용할 수 있습니다.",
+    };
+  }
+  if (input.userCredentialConfigured) {
+    return {
+      tone: "success",
+      label: "API Key 등록됨",
+      detail: `이 Provider의 인증 정보가 준비되어 있습니다. ${READINESS_PREVIEW_NOTE}`,
+    };
+  }
+  if (input.summaryConfigured) {
+    // server default 로 사용 중 — 사용자 등록 API Key와 동일하게 표현하지 않는다.
+    return {
+      tone: "success",
+      label: "연결 준비됨",
+      detail: `이 제공 기관은 현재 Builder 기본 자격 증명으로 사용 중입니다. ${READINESS_PREVIEW_NOTE}`,
+    };
+  }
+  return {
+    tone: "warning",
+    label: "API Key 미설정",
+    detail: "이 Provider를 사용하는 Dataset은 API Key가 필요할 수 있습니다.",
+  };
+}
+
+export function describeProviderProbe(input: ProviderProbeInput): ProviderProbePresentation {
+  if (input.status === "connected") {
+    return { tone: "success", label: "연결됨", title: null, detail: null };
+  }
+  if (input.status === "not_configured") {
+    return {
+      tone: "neutral",
+      label: "미설정",
+      title: "자격 증명 필요",
+      detail: "이 Provider는 자격 증명이 필요합니다. Provider 설정에서 연결하세요.",
+    };
+  }
+  if (input.status === "unknown") {
+    return { tone: "neutral", label: "연결 확인 필요", title: null, detail: null };
+  }
+  // status === "failed"
+  const needsPermissionCheck = Boolean(input.credentialConfigured) && input.responseCode === 403;
+  if (needsPermissionCheck) {
+    return { tone: "warning", label: "확인 필요", ...PERMISSION_CHECK };
+  }
+  const failure = FAILURES[input.errorCategory ?? "unknown"] ?? FAILURES.unknown;
+  return { tone: "error", label: "연결 오류", ...failure };
+}

--- a/src/shared/ui/HelpTooltip.test.tsx
+++ b/src/shared/ui/HelpTooltip.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { HelpTooltip } from "./HelpTooltip";
+
+describe("HelpTooltip", () => {
+  it("hover, focus, click으로 열고 Escape로 닫으며 ARIA로 설명을 연결한다", () => {
+    render(<HelpTooltip content="Run 설명" />);
+    const trigger = screen.getByRole("button", { name: "도움말" });
+
+    fireEvent.mouseEnter(trigger);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Run 설명");
+    expect(trigger).toHaveAttribute("aria-describedby", screen.getByRole("tooltip").id);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    fireEvent.focus(trigger);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    fireEvent.blur(trigger);
+    fireEvent.click(trigger);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+  });
+});

--- a/src/shared/ui/HelpTooltip.tsx
+++ b/src/shared/ui/HelpTooltip.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "./cn";
+
+export interface HelpTooltipProps {
+  content: ReactNode;
+  label?: string;
+  className?: string;
+}
+
+export function HelpTooltip({ content, label = "도움말", className }: HelpTooltipProps) {
+  const id = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState({ left: 8, top: 8, width: 288 });
+
+  useEffect(() => {
+    if (!open) return;
+    const update = () => {
+      const rect = triggerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const width = Math.min(288, window.innerWidth - 16);
+      const left = Math.max(8, Math.min(rect.left + rect.width / 2 - width / 2, window.innerWidth - width - 8));
+      const top = Math.min(rect.bottom + 8, window.innerHeight - 120);
+      setPosition({ left, top: Math.max(8, top), width });
+    };
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    const onKeyDown = (event: KeyboardEvent) => event.key === "Escape" && setOpen(false);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <span className={cn("inline-flex align-middle", className)} onMouseLeave={() => setOpen(false)}>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={label}
+        aria-describedby={open ? id : undefined}
+        aria-expanded={open}
+        className="inline-flex size-5 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onClick={() => setOpen(true)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        onMouseEnter={() => setOpen(true)}
+      >
+        <svg aria-hidden="true" viewBox="0 0 20 20" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.7">
+          <circle cx="10" cy="10" r="7.5" />
+          <path d="M10 9.1v4.2M10 6.5h.01" strokeLinecap="round" />
+        </svg>
+      </button>
+      {open && typeof document !== "undefined"
+        ? createPortal(
+            <span
+              id={id}
+              role="tooltip"
+              style={position}
+              // tooltip surface는 완전 불투명해야 한다 — `bg-card`/`text-card-foreground`는
+              // globals.css에 정의된 불투명 토큰이다(이전의 `bg-popover`는 이 테마에
+              // 없어서 배경이 비쳤다). z-index는 drawer/modal backdrop(최대 z-[82])보다
+              // 확실히 위에 오도록 z-[120]으로 둔다. 위치는 트리거 기준으로 계산하되
+              // 항상 viewport 안으로 clamp된다(가장자리 트리거에서도 화면 밖으로
+              // 튀어나오지 않는다).
+              className="fixed z-[120] rounded-lg border border-border bg-card px-3 py-2 text-left text-xs font-normal leading-5 text-card-foreground shadow-lg"
+            >
+              {content}
+            </span>,
+            document.body,
+          )
+        : null}
+    </span>
+  );
+}

--- a/src/shared/ui/StatusLegend.tsx
+++ b/src/shared/ui/StatusLegend.tsx
@@ -1,0 +1,27 @@
+import { glossary } from "@/shared/content/glossary";
+import { QualityBadge } from "@/features/quality/QualityBadge";
+
+export function StageLegend() {
+  return (
+    <div aria-label="데이터 단계 설명" className="flex flex-wrap gap-x-4 gap-y-2 text-xs text-muted-foreground">
+      {(["bronze", "silver", "gold"] as const).map((stage) => (
+        <span key={stage}><strong className="capitalize text-foreground">{stage}</strong> · {glossary[stage]}</span>
+      ))}
+    </div>
+  );
+}
+
+export function QualityLegend() {
+  const items = [
+    ["PASS", "평가한 규칙에서 문제가 발견되지 않음"],
+    ["WARN", "결과는 존재하지만 확인이 필요한 품질 문제가 있음"],
+    ["FAIL", "품질 규칙을 충족하지 못한 문제가 있음"],
+    ["N/A", "평가값이 없거나 적용되지 않음. PASS가 아님"],
+  ] as const;
+  return (
+    <div aria-label="Quality 상태 설명" className="flex flex-wrap gap-x-4 gap-y-2 text-xs text-muted-foreground">
+      {items.map(([status, copy]) => <span key={status} className="inline-flex items-center gap-1.5"><QualityBadge status={status} />{copy}</span>)}
+      <span><strong className="text-foreground">UNAVAILABLE</strong> · Builder가 결과를 제공할 수 없는 상태. FAIL과 다름</span>
+    </div>
+  );
+}

--- a/src/shared/ui/TermHelp.test.tsx
+++ b/src/shared/ui/TermHelp.test.tsx
@@ -1,0 +1,13 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { glossary, type GlossaryKey } from "@/shared/content/glossary";
+import { TermHelp } from "./TermHelp";
+
+describe("TermHelp", () => {
+  it("typed glossary key의 정본 설명을 표시한다", () => {
+    const term: GlossaryKey = "run";
+    render(<TermHelp term={term} />);
+    fireEvent.focus(screen.getByRole("button", { name: "run 용어 도움말" }));
+    expect(screen.getByRole("tooltip")).toHaveTextContent(glossary.run);
+  });
+});

--- a/src/shared/ui/TermHelp.tsx
+++ b/src/shared/ui/TermHelp.tsx
@@ -1,0 +1,6 @@
+import { glossary, type GlossaryKey } from "@/shared/content/glossary";
+import { HelpTooltip } from "./HelpTooltip";
+
+export function TermHelp({ term }: { term: GlossaryKey }) {
+  return <HelpTooltip label={`${term} 용어 도움말`} content={glossary[term]} />;
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -21,4 +21,7 @@ export { ErrorMessage, type ErrorMessageProps } from "./ErrorMessage";
 export { ErrorState, type ErrorStateProps } from "./ErrorState";
 export { Skeleton, SkeletonTable, type SkeletonProps, type SkeletonTableProps } from "./Skeleton";
 export { Disclosure, type DisclosureProps } from "./Disclosure";
+export { HelpTooltip, type HelpTooltipProps } from "./HelpTooltip";
+export { TermHelp } from "./TermHelp";
+export { StageLegend, QualityLegend } from "./StatusLegend";
 export { cn, type ClassValue } from "./cn";


### PR DESCRIPTION
## 개요

클라우드 배포 전 KPubData Studio의 주요 사용자 흐름을 실제 Builder 계약에 맞춰
최종 점검하고, 통합 과정에서 확인된 기능·UX·상태 처리·테스트 안정성 문제를 정리합니다.

Dashboard / Provider / Add Data / Kubi / Build / Publish / Artifact / Auth /
Onboarding 흐름을 실제 사용 시나리오 기준으로 보완했습니다.

> Depends on Builder PR #572
>
> - `GET /datasets.total`
> - `GET /quality/summary`
> - Provider catalogue metadata
> - Artifact serving
> - OIDC 사용자 admission 보완

Builder/Studio의 기존 책임 경계는 유지합니다.
OIDC 인증은 Keycloak이 담당하고, Studio는 public SPA + Authorization Code + PKCE(S256)
구조를 그대로 사용합니다.

---

## 주요 변경사항

### 1. Home Dashboard 실제 aggregate 연동

Dashboard KPI를 실제 Builder aggregate에 연결했습니다.

- DATASETS → `GET /datasets.total`
- SUCCEEDED (24H) → monitoring aggregate
- QUALITY WARN (24H) → `GET /quality/summary`
- RUNNING → monitoring queue
- Recent Builds와 KPI 조회 상태를 독립적으로 처리
- 일부 endpoint 실패 시 정상 KPI까지 함께 실패 처리하지 않음
- unavailable 값을 임의로 `0` 또는 `PASS`로 합성하지 않음

최근 Quality 상세은 확인 가능한 succeeded Run 기준으로 조회하며,
Quality WARN/FAIL에서 해당 Run 문맥을 유지합니다.

### 2. Provider credential 상태 안정화

Provider 전환·credential 조회 과정의 비동기 race와 상태 혼선을 수정했습니다.

- request generation / selected provider guard
- stale loading / success / error 차단
- 이전 Provider 응답이 새 Provider 상태를 덮는 문제 수정
- credential store 미구성 `503` 별도 처리
- user credential / server default / unconfigured 상태 구분
- 일반적인 임의 API probe 제거

실제 Dataset 사용 가능 여부는 Add Data의 Preview에서 확인합니다.

### 3. Add Data Public API workflow 보완

Public API 흐름을 다음 4단계로 정리했습니다.

1. `데이터 선택`
2. `가져오기 설정`
3. `Preview · 검증`
4. `검토 · Build`

Provider credential이 필요한 경우:

- 현재 Add Data draft 보존
- `/provider?provider=...&returnTo=/add`로 이동
- Provider 저장 후 작업 복귀
- credential 미설정 상태에서는 Preview 전에 명확히 차단
- configured 상태에서는 실제 Preview로 진행

Catalogue metadata를 활용해:

- Dataset별 required request parameter 표시
- example 값 명시적 적용 지원
- 활용신청 필요 여부/application URL 표시
- secret 성격 parameter 비노출
- Dataset 변경 시 이전 Dataset 전용 parameter 제거

Configure 변경 후 기존 Preview가 남아 있으면 stale 결과임을 표시하고,
stale 상태에서 Build되지 않도록 기존 guard를 유지합니다.

### 4. Home onboarding 및 계정별 first-run 처리

First-run onboarding을 브라우저 전체가 아닌 **OIDC 계정 단위**로 분리했습니다.

- Keycloak `sub`를 사용자 identity로 유지
- onboarding localStorage key를 계정별 namespace로 분리
- 같은 브라우저에서 계정 A/B의 onboarding 상태가 서로 영향 주지 않음
- Empty Workspace와 신규 계정 여부를 구분
- Dataset/Build가 존재하는 기존 사용자는 자동 tour가 실행되지 않음

신규/Empty Workspace에서는 기존 first-run onboarding 흐름을 유지합니다.

### 5. 기존 사용자 `사용 가이드` 재실행

기존 Dashboard의 `사용 가이드`가 `/discover`로 이동하던 잘못된 동작을 수정했습니다.

- `사용 가이드`를 실제 tour 실행 버튼으로 변경
- 기존 사용자 Dashboard에도 `FirstRunTour` mount
- `autoStart={false}`로 기존 사용자의 자동 실행 방지
- Dashboard 전용 tour target 사용
- 완료된 onboarding도 사용자가 원하면 수동 재실행 가능
- 사용 가이드 클릭 시 현재 Dashboard URL 유지

### 6. Kubi 진입 및 추천 질문 개선

Kubi Page를 메인 AI workspace로 유지하고,
Home의 질문 입력은 Drawer가 아니라 Kubi Page로 전달합니다.

- seed question 1회 소비
- context / 기존 turns / stale 상태 기반 추천 질문
- context가 없을 때 부적절한 Dataset/Run/SQL 질문 억제
- 기존 Evidence / Context / Generated SQL pipeline 재사용
- 별도 불필요 LLM 호출 추가 없음

Header의 Kubi는 기존 contextual quick-assist Drawer 역할을 유지합니다.

### 7. Publish exact Run context 수정

Publish 화면의 canonical context를 Dataset query가 아닌 exact `runId`로 정리했습니다.

- `getBuild(runId)` 기반 authoritative context
- direct deep link / Builds / Artifacts / Dataset Detail에서 동일 Run 유지
- latest Run fallback 없음
- 다른 Run과의 context 혼선 방지
- Builder readiness blocker 의미 유지

`license_missing`, `credential_unavailable` 등의 blocker를 임의로 우회하지 않습니다.

### 8. Artifact 실제 다운로드 연동

기존 `다운로드(연동 예정)` 상태를 실제 Builder 다운로드 흐름으로 연결했습니다.

- 파일 목록 source of truth = `GET /artifacts/{run_id}`
- filesystem output path를 다운로드 식별자로 사용하지 않음
- exact runId + canonical run-relative path 사용
- 기존 Builder Bearer 인증 재사용
- Blob / filename 처리
- object URL revoke
- 파일별 loading / error 상태
- 단일 파일 실패가 전체 Artifact 화면을 깨뜨리지 않음

실제 Windows 환경에서 nested JSONL/Parquet Artifact 다운로드까지 확인했습니다.

### 9. Keycloak 로그인/가입 UX 정리

실연동 인증은 계속 Keycloak에 위임합니다.

- `Google로 계속하기`
  - Keycloak Google Identity Broker
- `KPubData 계정으로 로그인`
  - Keycloak hosted login
- Studio 자체 비밀번호 저장/검증 없음
- Google token을 Studio가 Builder에 직접 전달하지 않음
- Authorization Code + PKCE(S256) 유지
- silent SSO / login callback redirect 설정 문서 보완

신규 사용자 가입 여부와 이메일 인증/비밀번호 정책은 Keycloak realm 설정에서 관리합니다.

### 10. 테스트 및 CI 안정화

현재 Studio 계약과 달라진 stale test expectation을 정리했습니다.

- Add Data 단계명/Provider navigation expectation 갱신
- `downloadArtifactFile` API operation contract 반영
- Quality unavailable fixture 결정화
- Add Data credential prerequisite 테스트 race 제거
  - timeout 증가 대신 Provider/Dataset option이 실제 DOM에 나타난 뒤 조작
- Node 20 CI 지원을 유지하기 위해
  `@testing-library/jest-dom`을 Node 20 호환 `6.9.1`로 pin
- Node 20/22 CI matrix는 그대로 유지

production UI/API를 테스트 통과를 위해 과거 상태로 되돌리는 변경은 하지 않았습니다.

---

## 검증

최종 로컬 검증 기준:

- Vitest: **142 test files passed / 142**
- Tests: **1326 passed / 1326**
- TypeScript typecheck: **PASS**
- ESLint: **0 errors**
  - 기존 `e2e/helpers.ts` unused-variable warning 1건만 존재
- Vite production build: **PASS**
- `git diff --check`: **PASS**
- Add Data credential prerequisite 반복 실행: **PASS**
- 실제 Public API Preview / Build workflow 확인
- 실제 nested Artifact 다운로드 확인

CI는 Node 20 / Node 22 matrix를 유지하며 동일 흐름을 검증합니다.

---

## 의존성

이 PR의 Dashboard aggregate / Provider catalogue / Artifact 등의 실제 연동은
Builder PR #572의 계약을 전제로 합니다.

따라서 merge 순서는 다음을 권장합니다.

1. Builder #572
2. Studio #326