### PR TITLE
chore(ci): dependabot에서 typescript major 업그레이드 무시 (#327)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # main은 의도적으로 typescript를 ^6에 고정한다 (commit f9ffd26).
+      # typescript-eslint peer 요구와 충돌하므로 major 업그레이드를 무시한다 (#327).
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
## 배경

main은 의도적으로 `typescript`를 `^6`에 고정하고 있다 (commit f9ffd26 "hold typescript on ^6 and jsdom on ^29"). TypeScript 7은 네이티브(Go) 프리뷰이며, 현재 `typescript-eslint@8.x`의 peer 요구와 충돌한다.

그 결과 dev-dependencies 그룹 dependabot PR(#327)이 `typescript ^6 → ^7`을 함께 올리면서 `npm ci`가 **ERESOLVE**로 실패한다. 그룹 내 나머지 7개 업데이트는 정상이다.

## 변경

`.github/dependabot.yml`의 npm 업데이트 항목에 `typescript` major 업그레이드 무시 규칙을 추가한다. 이렇게 하면 dependabot이 TS7 bump 없이 dev-dependencies 그룹을 재생성하고, 나머지 dev-deps 업데이트는 계속 받을 수 있다.

- TS6 고정 의도를 보존한다.
- major가 아닌 patch/minor는 계속 업데이트된다.

## 관련

- Closes #327 (아래 코멘트 참고)