### PR TITLE
fix(reports): use valid stage detail limit for schema evidence

### DIFF
--- a/src/features/reports/evidence.test.ts
+++ b/src/features/reports/evidence.test.ts
@@ -1,8 +1,10 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as datasetsApi from "@/features/datasets/api";
 import { buildEvidenceRefs, fetchReportEvidence } from "./evidence";
 
 afterEach(() => {
   localStorage.clear();
+  vi.restoreAllMocks();
 });
 
 describe("fetchReportEvidence (#258)", () => {
@@ -25,6 +27,52 @@ describe("fetchReportEvidence (#258)", () => {
     // kma__weather는 mock에서 silver failed, gold not_run이라 schema를 얻을 수 없다.
     expect(evidence.schemas["kma__weather"]?.origin).toBe("unavailable");
     expect(evidence.schemas["kma__weather"]?.reason).toBeTruthy();
+  });
+
+  it("Silver schema를 사용하고 Silver stage detail을 limit=1로 조회한다", async () => {
+    const spy = vi.spyOn(datasetsApi, "getBuildStageDetail");
+
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+
+    expect(evidence.schemas["datago__air"]?.origin).toBe("silver");
+    expect(spy).toHaveBeenCalledWith("air-2026-08-14", "silver", "datago__air", 1, undefined);
+  });
+
+  it("Silver 실패 시 Gold column names로 fallback하고 Gold stage detail을 limit=1로 조회한다", async () => {
+    const spy = vi.spyOn(datasetsApi, "getBuildStageDetail").mockImplementation(async (runId, stage, sourceKey) => {
+      if (stage === "silver") throw new Error("silver unavailable");
+      return {
+        run_id: runId,
+        stage: "gold",
+        source_key: sourceKey,
+        status: "completed",
+        available: true,
+        row_count: 1,
+        columns: ["fallback_column"],
+        splits: null,
+        exports: [],
+        sample: null,
+        sample_available: false,
+      };
+    });
+
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+
+    expect(evidence.schemas["datago__air"]).toMatchObject({
+      origin: "gold_names_only",
+      columns: [],
+      columnNamesOnly: ["fallback_column"],
+    });
+    expect(spy).toHaveBeenCalledWith("air-2026-08-14", "gold", "datago__air", 1, undefined);
+  });
+
+  it("Silver와 Gold 모두 실패하면 기존 unavailable semantics를 유지한다", async () => {
+    vi.spyOn(datasetsApi, "getBuildStageDetail").mockRejectedValue(new Error("stage unavailable"));
+
+    const evidence = await fetchReportEvidence("air-quality", "air-2026-08-14");
+
+    expect(evidence.schemas["datago__air"]?.origin).toBe("unavailable");
+    expect(evidence.schemas["datago__air"]?.reason).toBeTruthy();
   });
 
   it("run이 dataset의 run 목록에 없으면 run을 실패로 표시하되 dataset/stages/quality는 그대로 시도한다(부분 실패 허용)", async () => {

--- a/src/features/reports/evidence.ts
+++ b/src/features/reports/evidence.ts
@@ -70,12 +70,12 @@ export interface ReportEvidenceBundle {
 }
 
 async function fetchSourceSchema(runId: string, sourceKey: string, signal?: AbortSignal): Promise<ReportSourceSchema> {
-  const silver = await settle(getBuildStageDetail(runId, "silver", sourceKey, 0, signal));
+  const silver = await settle(getBuildStageDetail(runId, "silver", sourceKey, 1, signal));
   if (silver.ok && silver.value.stage === "silver" && silver.value.available && silver.value.schema.length > 0) {
     return { sourceKey, origin: "silver", columns: silver.value.schema };
   }
 
-  const gold = await settle(getBuildStageDetail(runId, "gold", sourceKey, 0, signal));
+  const gold = await settle(getBuildStageDetail(runId, "gold", sourceKey, 1, signal));
   if (gold.ok && gold.value.stage === "gold" && gold.value.available && gold.value.columns.length > 0) {
     return { sourceKey, origin: "gold_names_only", columns: [], columnNamesOnly: gold.value.columns };
   }


### PR DESCRIPTION
## 요약

Report evidence의 Silver/Gold stage detail 조회가 `limit=0`을 사용해 Real Builder에서 400이 발생할 수 있던 문제를 수정했습니다.

## 변경 사항

- Report Silver stage detail 조회의 `limit`을 `0`에서 `1`로 변경
- Silver schema를 사용할 수 없을 때 Gold column names fallback 조회도 `limit=1`로 변경
- Silver 정상, Gold fallback, 양쪽 실패 및 API 호출 인자 회귀 테스트 추가

## 동작 유지

- Silver schema가 있으면 Silver schema 사용
- Silver를 사용할 수 없고 Gold가 정상이면 Gold column names fallback
- 둘 다 사용할 수 없으면 기존 unavailable 처리 유지

## 검증

- `npm.cmd test -- src/features/reports/evidence.test.ts`
- `npm.cmd test -- src/features/reports`
- `npm.cmd run typecheck`